### PR TITLE
chore: bootstrap Cloudlands Rust backend monorepo; bump intentd submodule to 8e13a25

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Local dev stack data dir created by `make dev` (intentd socket + SQLite DB)
+.dev/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,8 @@ submodules:
 - `packages/intentd` → [cloudlands-ai/intentd](https://github.com/cloudlands-ai/intentd) — Rust backend daemon
 
 Code lives in the submodule repos. The monorepo tracks specific commits of each submodule.
-The engineering spec lives in `docs/00_initial_porting/IMPLEMENTATION_SPEC.md`.
+The engineering spec lives in `docs/00_initial_porting/IMPLEMENTATION_SPEC.md`; see
+`docs/README.md` for how the porting documents relate.
 
 ## Commit & PR Workflow
 
@@ -43,6 +44,27 @@ When changes span a submodule and the monorepo, follow this sequence: Phase 1 �
 - **Rust**: keep `cargo fmt --check`, `cargo clippy -- -D warnings`, and `cargo build`
   green in `packages/intentd` before opening a PR. The `Makefile` exposes `make check` and
   `make test` for this.
+
+## Breadcrumbs (initial porting)
+
+For the duration of the **`00_initial_porting`** effort — the initial port of Intent's
+backend to the Rust daemon (`intentd`) — keep the breadcrumb trail at
+`docs/00_initial_porting/BREADCRUMBS.md` current.
+
+- **When**: whenever you complete a meaningful unit of porting work (a crate, a method or
+  group of methods, a transport/persistence change, a submodule bump).
+- **What**: append a dated entry to the changelog, newest first. Keep it concise — what
+  changed, which crates/methods were touched, and the resulting `packages/intentd` HEAD.
+  Also update the "Current submodule HEAD" and "Implemented surface" sections when they
+  change, and move items out of "Deferred / planned" as they ship.
+- **Accuracy**: never overstate. Only list surface that is actually implemented; everything
+  else stays under deferred/planned.
+- **Scope**: this policy applies only until the initial Rust-BE port is complete; it does
+  not extend to later efforts.
+
+Breadcrumb edits are docs-only and follow the same conventional-commit / PR conventions
+above (use a `docs:` commit). They typically ship in the monorepo PR that bumps the
+submodule, so the recorded HEAD matches the gitlink.
 
 ## Local Setup
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,13 @@ Breadcrumb edits are docs-only and follow the same conventional-commit / PR conv
 above (use a `docs:` commit). They typically ship in the monorepo PR that bumps the
 submodule, so the recorded HEAD matches the gitlink.
 
+## Terminology
+
+Do **not** use "wave" / "Wave N" terminology in committed documentation. It is
+coordinator-internal vocabulary specific to a single agent's delegation flow and must not
+leak into the repo. Describe progress as capabilities/milestones instead (e.g. "Repo & CI
+bootstrap", "Crate skeleton", "Core + SQLite store", "UDS JSON-RPC slice").
+
 ## Local Setup
 
 ```bash

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,12 @@ INTENTD_DIR = packages/intentd
 
 SUBMODULES = $(INTENTD_DIR)
 
-.PHONY: all ensure-submodules build build-intentd test test-intentd fmt clippy check clean
+# Local dev stack configuration (overridable from the env/CLI, e.g. `make dev DEV_PORT=6000`).
+# DEV_DATA_DIR is a dedicated, gitignored data dir so dev never touches the real one.
+DEV_DATA_DIR ?= $(PWD)/.dev/intentd
+DEV_PORT ?= 5180
+
+.PHONY: all ensure-submodules build build-intentd test test-intentd fmt clippy check clean dev
 
 all: build
 
@@ -38,3 +43,15 @@ test-intentd: ensure-submodules
 
 clean:
 	rm -rf $(INTENTD_DIR)/target
+
+dev: ensure-submodules ## Run the local dev stack against a dedicated dev data dir
+	@mkdir -p $(DEV_DATA_DIR)
+	@echo "[dev] intentd dev data dir: $(DEV_DATA_DIR) (UDS socket: $(DEV_DATA_DIR)/intentd.sock)"
+	# intentd is UDS-only today (TCP/port deferred per §5.2): the dev socket + SQLite DB
+	# live under $(DEV_DATA_DIR). DEV_PORT is reserved/forward-looking for the planned TCP
+	# listener (§5.2) and the future Tauri/Svelte FE dev server; it is exported as
+	# INTENTD_DEV_PORT now so downstream startup can pick it up without a Makefile change.
+	# TODO: when TCP (§5.2) and the Tauri/Svelte FE dev server land, start them here
+	# (alongside intentd) so `make dev` ultimately runs the whole stack.
+	INTENTD_DATA_DIR=$(DEV_DATA_DIR) INTENTD_DEV_PORT=$(DEV_PORT) \
+		cargo run -p intentd --manifest-path $(INTENTD_DIR)/Cargo.toml -- serve --listen uds

--- a/README.md
+++ b/README.md
@@ -1,66 +1,118 @@
 # Cloudlands Monorepo
 
-Internal engineering monorepo for the Cloudlands backend. This repo ties together the
-Cloudlands components via git submodules and provides unified CI/CD and tooling.
+Internal engineering monorepo for **Cloudlands**, an agentic coding platform. This repo ties
+the Cloudlands components together via git submodules and provides unified docs, tooling, and
+CI/CD. The **Rust backend (`intentd`) comes first**; the desktop frontend lands later.
 
-> ⚠️ Private Repository — This repo is internal to the Cloudlands engineering team.
+> ⚠️ Private Repository — This repo is internal to the Cloudlands engineering team. The
+> component repositories it references are also private. See Related Repositories for links.
 
 ## Architecture Overview
 
-`intentd` is a local-first Rust daemon that owns the Intent domain model — workspaces,
-notes, tasks, comments, agents, git, pull requests, scripts, terminals, files, and events —
-and exposes it over a JSON-RPC API. Clients (a desktop UI, a CLI, or an agent acting as an
-MCP client) are thin; all business logic lives in the daemon. See the engineering spec in
-`docs/00_initial_porting/IMPLEMENTATION_SPEC.md` for the full design.
+`intentd` is a local-first Rust daemon that owns the Intent domain model — workspaces, notes,
+tasks, comments, agents, git, pull requests, scripts, terminals, files, and events — and
+exposes it over a JSON-RPC 2.0 API. Clients are thin; all business logic lives in the daemon.
+A Tauri/Svelte desktop frontend is **planned** and will live in this monorepo as a second
+submodule once it exists.
 
-> Status: **bootstrap skeleton.** `intentd` currently compiles as a minimal cargo workspace
-> with a single binary crate that prints its version and usage. No daemon behavior,
-> transport, or persistence is implemented yet.
+```
+┌──────────────────────────────────────────────────────────────┐
+│                     cloudlands-ai/monorepo                    │
+│                                                              │
+│  ┌────────────────────────────────────────────────────────┐  │
+│  │ packages/                                              │  │
+│  │   ├── intentd/        ⇒ submodule → cloudlands-ai/intentd │
+│  │   │     Rust backend daemon (JSON-RPC over UDS)        │  │
+│  │   └── (frontend/)     ⇒ Tauri + Svelte desktop UI      │  │
+│  │                          ── PLANNED, not yet present ── │  │
+│  ├────────────────────────────────────────────────────────┤  │
+│  │ docs/00_initial_porting/   IMPLEMENTATION_SPEC + PROTOCOL │
+│  │ AGENTS.md   Makefile   cliff.toml   .github/workflows/ │  │
+│  └────────────────────────────────────────────────────────┘  │
+└──────────────────────────────────────────────────────────────┘
+```
 
-## Repository Map
+Code lives in the submodule repos; the monorepo tracks specific commits of each submodule and
+carries the cross-cutting docs and tooling. See `docs/00_initial_porting/IMPLEMENTATION_SPEC.md`
+for the full design.
+
+## Status
+
+| Component | Status |
+| --- | --- |
+| `packages/intentd` | **Thin UDS vertical slice.** JSON-RPC `workspace.list` + `note.list` over SQLite, served on a Unix-domain socket, with a `serve`/`call`/`status`/`doctor` CLI. The rest of the protocol surface (TCP/TLS, ACP, git, context, search, events, ~104 more methods) is planned. |
+| Desktop frontend | **Planned.** Tauri + Svelte; not yet a submodule. |
+
+## Repository Layout
 
 ```
 monorepo/
 ├── .github/
 │   └── workflows/
-│       └── ci.yml                 # PR title check (conventional commits)
+│       └── ci.yml                 # fmt/clippy/test + build matrix + PR-title check
 ├── .gitmodules                    # Submodule definitions (intentd)
 ├── cliff.toml                     # git-cliff changelog config (conventional commits)
-├── docs/                          # Architecture + porting specs
+├── docs/
+│   └── 00_initial_porting/        # IMPLEMENTATION_SPEC.md + PROTOCOL.md
 ├── packages/
-│   └── intentd/                   # Rust backend daemon (submodule)
-├── AGENTS.md                      # AI agent workflow guide
+│   └── intentd/                   # ⇒ submodule → cloudlands-ai/intentd (Rust backend)
+├── AGENTS.md                      # AI agent workflow guide (commit/PR conventions)
 ├── Makefile                       # Cross-package task orchestration
-└── README.md
+└── README.md                      # ← you are here
 ```
 
 ## Submodules
 
-| Path               | Repository                                            |
-| ------------------ | ----------------------------------------------------- |
-| `packages/intentd` | [cloudlands-ai/intentd](https://github.com/cloudlands-ai/intentd) |
-
-Code lives in the submodule repos. The monorepo tracks specific commits of each submodule.
+| Path               | Repository                                                        | Visibility |
+| ------------------ | ---------------------------------------------------------------- | ---------- |
+| `packages/intentd` | [cloudlands-ai/intentd](https://github.com/cloudlands-ai/intentd) | Private    |
 
 ## Getting Started
 
 ```bash
-git clone --recurse-submodules https://github.com/cloudlands-ai/monorepo
+# Clone with submodules
+git clone --recursive git@github.com:cloudlands-ai/monorepo.git
 cd monorepo
 
-# Or, if already cloned without submodules:
+# Or, if already cloned without --recursive:
 git submodule update --init --recursive
-```
 
-## Common Tasks
-
-```bash
-make build      # build intentd (cargo build --workspace)
+# Verify and test (delegates into packages/intentd)
 make check      # cargo fmt --check + cargo clippy -- -D warnings
 make test       # cargo test --workspace
+make build      # cargo build --workspace
 make clean      # remove build artifacts
 ```
 
+## Contributing & Workflow
+
+Changes that span a submodule and the monorepo follow a two-phase flow (see `AGENTS.md` for
+the full guide):
+
+**Phase 1 — Submodule PR.** Make scoped, conventional commits on a feature branch in the
+submodule (e.g. `cloudlands-ai/intentd`), push, open a PR, and merge (squash preferred).
+
+**Phase 2 — Monorepo update.** Pull the submodule's latest `main`, stage the updated gitlink
+(`git add packages/intentd`), commit (`chore: update intentd submodule to latest main`), push,
+and open a monorepo PR referencing the submodule PR.
+
+Conventions:
+
+- **Conventional commits** are required and PR titles are validated in CI against `feat`,
+  `fix`, `chore`, `docs`, `refactor`, `test`, `ci`, `perf`.
+- **Changelogs** are generated with `git-cliff` (see `cliff.toml`).
+- For Rust changes, keep `cargo fmt --check`, `cargo clippy -- -D warnings`, and
+  `cargo build` green in `packages/intentd` before opening a PR.
+
+## Documentation
+
+- [`docs/00_initial_porting/IMPLEMENTATION_SPEC.md`](docs/00_initial_porting/IMPLEMENTATION_SPEC.md)
+  — architecture, crate layout, persistence, and the phased roadmap.
+- [`docs/00_initial_porting/PROTOCOL.md`](docs/00_initial_porting/PROTOCOL.md) — the wire
+  contract: transport, JSON-RPC envelope, full method catalog, events, and error codes.
+
 ## Related Repositories
 
-- [cloudlands-ai/intentd](https://github.com/cloudlands-ai/intentd) — Rust backend daemon
+| Repository | Description |
+| --- | --- |
+| [cloudlands-ai/intentd](https://github.com/cloudlands-ai/intentd) | Rust backend daemon (private) — JSON-RPC over UDS, mounted at `packages/intentd`. |

--- a/docs/00_initial_porting/BREADCRUMBS.md
+++ b/docs/00_initial_porting/BREADCRUMBS.md
@@ -1,12 +1,12 @@
 # Initial Porting — Breadcrumbs
 
-A living progress log for the **initial port of Intent's backend to a headless Rustdaemon** (`intentd`). This is the durable trail future agents read first to understandwhere the port stands, and append to as work lands.
+A living progress log for the **initial port of Intent's backend to a headless Rust daemon** (`intentd`). This is the durable trail future agents read first to understand where the port stands, and append to as work lands.
 
-See also: [IMPLEMENTATION_SPEC.md](./IMPLEMENTATION_SPEC.md) (target architecture),[PROTOCOL.md](./PROTOCOL.md) (wire contract), and the root[AGENTS.md](../../AGENTS.md) (workflow + breadcrumb-update policy).
+See also: [IMPLEMENTATION_SPEC.md](./IMPLEMENTATION_SPEC.md) (target architecture), [PROTOCOL.md](./PROTOCOL.md) (wire contract), and the root [AGENTS.md](../../AGENTS.md) (workflow + breadcrumb-update policy).
 
 ## Goal
 
-Port Intent's backend to a standalone, headless Rust daemon (`intentd`) speaking**JSON-RPC 2.0 over a Unix-domain socket**, local-first. Scope of **this** effort is the**Rust backend only** — no frontend (Tauri/Svelte) yet. The Electron app in`augmentcode/intent` is the behavioral ancestor; the wire contract is defined inPROTOCOL.md.
+Port Intent's backend to a standalone, headless Rust daemon (`intentd`) speaking **JSON-RPC 2.0 over a Unix-domain socket**, local-first. Scope of **this** effort is the **Rust backend only** — no frontend (Tauri/Svelte) yet. The Electron app in `augmentcode/intent` is the behavioral ancestor; the wire contract is defined in PROTOCOL.md.
 
 ## Current submodule HEAD
 
@@ -16,34 +16,34 @@ Port Intent's backend to a standalone, headless Rust daemon (`intentd`) speaking
 
 - **JSON-RPC methods:** `workspace.list`, `note.list` (read-only, backed by SQLite).
 - **CLI:** `intentd serve`, `intentd call`, `intentd status`, `intentd doctor`.
-- **Transport:** JSON-RPC 2.0 router over UDS (newline-delimited, mode `0600`, stale-socketcleanup, SIGINT/SIGTERM handling), error codes `-32700`/`-32600`/`-32601`/`-32602`/`-32603`.
-- **Persistence:** SQLite via `sqlx` with embedded migrations (WAL, `foreign_keys`,`busy_timeout`).
+- **Transport:** JSON-RPC 2.0 router over UDS (newline-delimited, mode `0600`, stale-socket cleanup, SIGINT/SIGTERM handling), error codes `-32700`/`-32600`/`-32601`/`-32602`/`-32603`.
+- **Persistence:** SQLite via `sqlx` with embedded migrations (WAL, `foreign_keys`, `busy_timeout`).
 
 ## Deferred / planned (NOT yet built)
 
 - The remaining ~104 PROTOCOL methods (106 total in the contract; 2 implemented).
 - TCP / TLS / WSS transports, mDNS discovery, bearer-token auth.
 - ACP / provider spawning, GitHub (octocrab), context engine, PTY, search, event bus.
-- Transport panic-safety via `catch_unwind` → `-32603` (currently relies on per-connection`tokio::spawn` isolation).
+- Transport panic-safety via `catch_unwind` → `-32603` (currently relies on per-connection `tokio::spawn` isolation).
 - The entire frontend (Tauri/Svelte).
 
 ## Milestone history
 
 ### Repo & CI bootstrap
 
-Created two **private** GitHub repos (`cloudlands-ai/monorepo`, `cloudlands-ai/intentd`),a minimal intentd, the monorepo scaffold with `packages/intentd` as a submodule, CIworkflows (fmt/clippy/test + 3-target build matrix + semantic-PR-title), and `cliff.toml`.
+Created two **private** GitHub repos (`cloudlands-ai/monorepo`, `cloudlands-ai/intentd`), a minimal intentd, the monorepo scaffold with `packages/intentd` as a submodule, CI workflows (fmt/clippy/test + 3-target build matrix + semantic-PR-title), and `cliff.toml`.
 
 ### Crate skeleton
 
-Scaffolded all 12 crates (per IMPLEMENTATION_SPEC §3) as compiling stubs with §3.2dependency direction enforced. Verified (`fmt`/`clippy`/`build`).
+Scaffolded all 12 crates (per IMPLEMENTATION_SPEC §3) as compiling stubs with §3.2 dependency direction enforced. Verified (`fmt`/`clippy`/`build`).
 
 ### Core + SQLite store
 
-`intent-core` (ids, `Error` → JSON-RPC code mapping, `Config`/paths, `Workspace`/`Note`camelCase model, `WorkspaceApi` trait) and `intent-store` (SQLite via `sqlx`, embeddedmigrations, WAL/`foreign_keys`/`busy_timeout`, repositories). Verified @ submodule `41fd4a6`.
+`intent-core` (ids, `Error` → JSON-RPC code mapping, `Config`/paths, `Workspace`/`Note` camelCase model, `WorkspaceApi` trait) and `intent-store` (SQLite via `sqlx`, embedded migrations, WAL/`foreign_keys`/`busy_timeout`, repositories). Verified @ submodule `41fd4a6`.
 
 ### UDS JSON-RPC slice
 
-`intent-services` (concrete `WorkspaceApi` impl), `intent-transport` (JSON-RPC 2.0 routerwith the five standard error codes + UDS listener, mode `0600`, newline-delimited,stale-socket cleanup, SIGINT/SIGTERM) and the `intentd` CLI (`serve`/`call`/`status`/`doctor`). Integration test over a temp UDS. Verified @ submodule `2756eb4`.
+`intent-services` (concrete `WorkspaceApi` impl), `intent-transport` (JSON-RPC 2.0 router with the five standard error codes + UDS listener, mode `0600`, newline-delimited, stale-socket cleanup, SIGINT/SIGTERM) and the `intentd` CLI (`serve`/`call`/`status`/`doctor`). Integration test over a temp UDS. Verified @ submodule `2756eb4`.
 
 ### READMEs
 
@@ -51,20 +51,20 @@ README.md written for both repos (intentd + monorepo). intentd HEAD `8e13a25`.
 
 ### Breadcrumbs, docs index, `make dev`
 
-This milestone: added `docs/00_initial_porting/BREADCRUMBS.md`, `docs/README.md`, the AGENTS.mdbreadcrumb-update policy, and a `make dev` local dev-stack target.
+This milestone: added `docs/00_initial_porting/BREADCRUMBS.md`, `docs/README.md`, the AGENTS.md breadcrumb-update policy, and a `make dev` local dev-stack target.
 
 ## Next steps / open questions
 
-- Begin expanding the JSON-RPC method catalog beyond the read-only slice (write paths forworkspaces/notes), driven by PROTOCOL.md.
-- Decide when to introduce the event bus + `events.subscribe`/`events.event` (needed bymost live-update methods).
+- Begin expanding the JSON-RPC method catalog beyond the read-only slice (write paths for workspaces/notes), driven by PROTOCOL.md.
+- Decide when to introduce the event bus + `events.subscribe`/`events.event` (needed by most live-update methods).
 - Harden transport panic-safety (`catch_unwind` → `-32603`) before the full method catalog.
 - Revisit transports (TCP/TLS/WSS) + auth + mDNS once UDS reads/writes are solid.
 
 ## Changelog
 
-Append a dated entry (newest first) whenever a meaningful unit of porting work lands. Keepeach entry concise: what changed, which crates/methods, and the resulting submodule HEAD.
+Append a dated entry (newest first) whenever a meaningful unit of porting work lands. Keep each entry concise: what changed, which crates/methods, and the resulting submodule HEAD.
 
-- **2026-06-17** — Breadcrumbs, docs index & `make dev`: added breadcrumbs trail, `docs/README.md` index, and AGENTS.mdbreadcrumb-update policy. Docs-only (monorepo); submodule HEAD unchanged @ `8e13a25`.
+- **2026-06-17** — Breadcrumbs, docs index & `make dev`: added breadcrumbs trail, `docs/README.md` index, and AGENTS.md breadcrumb-update policy. Docs-only (monorepo); submodule HEAD unchanged @ `8e13a25`.
 - **2026-06-17** — READMEs: wrote README.md for both repos. Submodule HEAD `8e13a25`.
 - **UDS JSON-RPC slice** — services + transport + CLI + integration test. Submodule HEAD `2756eb4`.
 - **Core + SQLite store** — `intent-core` + `intent-store` (domain model + SQLite). Submodule HEAD `41fd4a6`.

--- a/docs/00_initial_porting/BREADCRUMBS.md
+++ b/docs/00_initial_porting/BREADCRUMBS.md
@@ -1,0 +1,72 @@
+# Initial Porting — Breadcrumbs
+
+A living progress log for the **initial port of Intent's backend to a headless Rustdaemon** (`intentd`). This is the durable trail future agents read first to understandwhere the port stands, and append to as work lands.
+
+See also: [IMPLEMENTATION_SPEC.md](./IMPLEMENTATION_SPEC.md) (target architecture),[PROTOCOL.md](./PROTOCOL.md) (wire contract), and the root[AGENTS.md](../../AGENTS.md) (workflow + breadcrumb-update policy).
+
+## Goal
+
+Port Intent's backend to a standalone, headless Rust daemon (`intentd`) speaking**JSON-RPC 2.0 over a Unix-domain socket**, local-first. Scope of **this** effort is the**Rust backend only** — no frontend (Tauri/Svelte) yet. The Electron app in`augmentcode/intent` is the behavioral ancestor; the wire contract is defined inPROTOCOL.md.
+
+## Current submodule HEAD
+
+- `packages/intentd` @ `8e13a25` (after Wave 4 READMEs)
+
+## Implemented surface so far
+
+- **JSON-RPC methods:** `workspace.list`, `note.list` (read-only, backed by SQLite).
+- **CLI:** `intentd serve`, `intentd call`, `intentd status`, `intentd doctor`.
+- **Transport:** JSON-RPC 2.0 router over UDS (newline-delimited, mode `0600`, stale-socketcleanup, SIGINT/SIGTERM handling), error codes `-32700`/`-32600`/`-32601`/`-32602`/`-32603`.
+- **Persistence:** SQLite via `sqlx` with embedded migrations (WAL, `foreign_keys`,`busy_timeout`).
+
+## Deferred / planned (NOT yet built)
+
+- The remaining ~104 PROTOCOL methods (106 total in the contract; 2 implemented).
+- TCP / TLS / WSS transports, mDNS discovery, bearer-token auth.
+- ACP / provider spawning, GitHub (octocrab), context engine, PTY, search, event bus.
+- Transport panic-safety via `catch_unwind` → `-32603` (currently relies on per-connection`tokio::spawn` isolation).
+- The entire frontend (Tauri/Svelte).
+
+## Wave history
+
+### Wave 1 — Bootstrap structure + remotes
+
+Created two **private** GitHub repos (`cloudlands-ai/monorepo`, `cloudlands-ai/intentd`),a minimal intentd, the monorepo scaffold with `packages/intentd` as a submodule, CIworkflows (fmt/clippy/test + 3-target build matrix + semantic-PR-title), and `cliff.toml`.
+
+### Wave 2 — Full crate skeleton
+
+Scaffolded all 12 crates (per IMPLEMENTATION_SPEC §3) as compiling stubs with §3.2dependency direction enforced. Verified (`fmt`/`clippy`/`build`).
+
+### Wave 3a — core + store
+
+`intent-core` (ids, `Error` → JSON-RPC code mapping, `Config`/paths, `Workspace`/`Note`camelCase model, `WorkspaceApi` trait) and `intent-store` (SQLite via `sqlx`, embeddedmigrations, WAL/`foreign_keys`/`busy_timeout`, repositories). Verified @ submodule `41fd4a6`.
+
+### Wave 3b — UDS JSON-RPC slice
+
+`intent-services` (concrete `WorkspaceApi` impl), `intent-transport` (JSON-RPC 2.0 routerwith the five standard error codes + UDS listener, mode `0600`, newline-delimited,stale-socket cleanup, SIGINT/SIGTERM) and the `intentd` CLI (`serve`/`call`/`status`/`doctor`). Integration test over a temp UDS. Verified @ submodule `2756eb4`.
+
+### Wave 4 — READMEs
+
+README.md written for both repos (intentd + monorepo). intentd HEAD `8e13a25`.
+
+### Wave 5 — Breadcrumbs, docs index, `make dev`
+
+This wave: added `docs/00_initial_porting/BREADCRUMBS.md`, `docs/README.md`, the AGENTS.mdbreadcrumb-update policy, and a `make dev` local dev-stack target.
+
+## Next steps / open questions
+
+- Begin expanding the JSON-RPC method catalog beyond the read-only slice (write paths forworkspaces/notes), driven by PROTOCOL.md.
+- Decide when to introduce the event bus + `events.subscribe`/`events.event` (needed bymost live-update methods).
+- Harden transport panic-safety (`catch_unwind` → `-32603`) before the full method catalog.
+- Revisit transports (TCP/TLS/WSS) + auth + mDNS once UDS reads/writes are solid.
+
+## Changelog
+
+Append a dated entry (newest first) whenever a meaningful unit of porting work lands. Keepeach entry concise: what changed, which crates/methods, and the resulting submodule HEAD.
+
+- **2026-06-17** — Wave 5: added breadcrumbs trail, `docs/README.md` index, and AGENTS.mdbreadcrumb-update policy. Docs-only (monorepo); submodule HEAD unchanged @ `8e13a25`.
+- **2026-06-17** — Wave 4: wrote README.md for both repos. Submodule HEAD `8e13a25`.
+- **Wave 3b** — UDS JSON-RPC slice (services + transport + CLI + integration test).Submodule HEAD `2756eb4`.
+- **Wave 3a** — `intent-core` + `intent-store` (domain model + SQLite). Submodule HEAD`41fd4a6`.
+- **Wave 2** — Full 12-crate skeleton with stubs; dependency direction enforced.
+- **Wave 1** — Bootstrap: repos, scaffold, submodule, CI, cliff.toml.

--- a/docs/00_initial_porting/BREADCRUMBS.md
+++ b/docs/00_initial_porting/BREADCRUMBS.md
@@ -10,7 +10,7 @@ Port Intent's backend to a standalone, headless Rust daemon (`intentd`) speaking
 
 ## Current submodule HEAD
 
-- `packages/intentd` @ `8e13a25` (after Wave 4 READMEs)
+- `packages/intentd` @ `8e13a25` (after the READMEs milestone)
 
 ## Implemented surface so far
 
@@ -27,31 +27,31 @@ Port Intent's backend to a standalone, headless Rust daemon (`intentd`) speaking
 - Transport panic-safety via `catch_unwind` → `-32603` (currently relies on per-connection`tokio::spawn` isolation).
 - The entire frontend (Tauri/Svelte).
 
-## Wave history
+## Milestone history
 
-### Wave 1 — Bootstrap structure + remotes
+### Repo & CI bootstrap
 
 Created two **private** GitHub repos (`cloudlands-ai/monorepo`, `cloudlands-ai/intentd`),a minimal intentd, the monorepo scaffold with `packages/intentd` as a submodule, CIworkflows (fmt/clippy/test + 3-target build matrix + semantic-PR-title), and `cliff.toml`.
 
-### Wave 2 — Full crate skeleton
+### Crate skeleton
 
 Scaffolded all 12 crates (per IMPLEMENTATION_SPEC §3) as compiling stubs with §3.2dependency direction enforced. Verified (`fmt`/`clippy`/`build`).
 
-### Wave 3a — core + store
+### Core + SQLite store
 
 `intent-core` (ids, `Error` → JSON-RPC code mapping, `Config`/paths, `Workspace`/`Note`camelCase model, `WorkspaceApi` trait) and `intent-store` (SQLite via `sqlx`, embeddedmigrations, WAL/`foreign_keys`/`busy_timeout`, repositories). Verified @ submodule `41fd4a6`.
 
-### Wave 3b — UDS JSON-RPC slice
+### UDS JSON-RPC slice
 
 `intent-services` (concrete `WorkspaceApi` impl), `intent-transport` (JSON-RPC 2.0 routerwith the five standard error codes + UDS listener, mode `0600`, newline-delimited,stale-socket cleanup, SIGINT/SIGTERM) and the `intentd` CLI (`serve`/`call`/`status`/`doctor`). Integration test over a temp UDS. Verified @ submodule `2756eb4`.
 
-### Wave 4 — READMEs
+### READMEs
 
 README.md written for both repos (intentd + monorepo). intentd HEAD `8e13a25`.
 
-### Wave 5 — Breadcrumbs, docs index, `make dev`
+### Breadcrumbs, docs index, `make dev`
 
-This wave: added `docs/00_initial_porting/BREADCRUMBS.md`, `docs/README.md`, the AGENTS.mdbreadcrumb-update policy, and a `make dev` local dev-stack target.
+This milestone: added `docs/00_initial_porting/BREADCRUMBS.md`, `docs/README.md`, the AGENTS.mdbreadcrumb-update policy, and a `make dev` local dev-stack target.
 
 ## Next steps / open questions
 
@@ -64,9 +64,9 @@ This wave: added `docs/00_initial_porting/BREADCRUMBS.md`, `docs/README.md`, the
 
 Append a dated entry (newest first) whenever a meaningful unit of porting work lands. Keepeach entry concise: what changed, which crates/methods, and the resulting submodule HEAD.
 
-- **2026-06-17** — Wave 5: added breadcrumbs trail, `docs/README.md` index, and AGENTS.mdbreadcrumb-update policy. Docs-only (monorepo); submodule HEAD unchanged @ `8e13a25`.
-- **2026-06-17** — Wave 4: wrote README.md for both repos. Submodule HEAD `8e13a25`.
-- **Wave 3b** — UDS JSON-RPC slice (services + transport + CLI + integration test).Submodule HEAD `2756eb4`.
-- **Wave 3a** — `intent-core` + `intent-store` (domain model + SQLite). Submodule HEAD`41fd4a6`.
-- **Wave 2** — Full 12-crate skeleton with stubs; dependency direction enforced.
-- **Wave 1** — Bootstrap: repos, scaffold, submodule, CI, cliff.toml.
+- **2026-06-17** — Breadcrumbs, docs index & `make dev`: added breadcrumbs trail, `docs/README.md` index, and AGENTS.mdbreadcrumb-update policy. Docs-only (monorepo); submodule HEAD unchanged @ `8e13a25`.
+- **2026-06-17** — READMEs: wrote README.md for both repos. Submodule HEAD `8e13a25`.
+- **UDS JSON-RPC slice** — services + transport + CLI + integration test. Submodule HEAD `2756eb4`.
+- **Core + SQLite store** — `intent-core` + `intent-store` (domain model + SQLite). Submodule HEAD `41fd4a6`.
+- **Crate skeleton** — Full 12-crate skeleton with stubs; dependency direction enforced.
+- **Repo & CI bootstrap** — repos, scaffold, submodule, CI, cliff.toml.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,26 @@
+# Documentation
+
+Index of the `docs/` tree for the Cloudlands monorepo.
+
+## `00_initial_porting/`
+
+Documents for the **initial port of Intent's backend to a headless Rust daemon**
+(`intentd`). Three documents work together:
+
+- **[IMPLEMENTATION_SPEC.md](./00_initial_porting/IMPLEMENTATION_SPEC.md)** — the
+  **target architecture**: crates/modules, persistence, ACP/GitHub/context integration,
+  deployment, testing, and the phased plan.
+- **[PROTOCOL.md](./00_initial_porting/PROTOCOL.md)** — the **wire contract**: transport,
+  the JSON-RPC 2.0 envelope, the full method catalog, events, the permission flow, and
+  error codes the backend must reproduce.
+- **[BREADCRUMBS.md](./00_initial_porting/BREADCRUMBS.md)** — the **living progress log**:
+  what has actually been built so far, what is deferred/planned, the current submodule
+  HEAD, and a dated changelog that agents append to as work lands.
+
+In short: the **spec** is where we're going, the **protocol** is the contract we must
+honor, and the **breadcrumbs** are where we are right now.
+
+## Workflow
+
+For the agent commit/PR workflow — and the policy requiring breadcrumbs to be kept
+current — see the root [AGENTS.md](../AGENTS.md).


### PR DESCRIPTION
## Summary

Bootstraps the Cloudlands Rust backend monorepo scaffolding and bumps the
`packages/intentd` submodule to the latest `main`.

This monorepo PR pairs with the merged submodule changes in
[cloudlands-ai/intentd](https://github.com/cloudlands-ai/intentd) — the gitlink
now points at `8e13a25` on `intentd` `main`.

## Changes

- **chore:** update `packages/intentd` submodule gitlink to `8e13a25` (latest `main`)
- **docs:** expand root `README.md` with architecture, status, workflow, and protocol docs
- **chore:** add `.gitignore` for local dev stack artifacts (`.dev/`)
- **docs:** add porting breadcrumbs trail (`docs/00_initial_porting/BREADCRUMBS.md`),
  docs index (`docs/README.md`), and breadcrumb-update policy

## Notes

- The `intentd` submodule was already pushed/merged separately; this PR only
  advances the monorepo gitlink and adds scaffolding/docs.
- `.dev/` is gitignored and not tracked.
