### PR TITLE
chore: bump intentd to M1 core CRUD

### DIFF
--- a/docs/00_initial_porting/BREADCRUMBS.md
+++ b/docs/00_initial_porting/BREADCRUMBS.md
@@ -10,18 +10,23 @@ Port Intent's backend to a standalone, headless Rust daemon (`intentd`) speaking
 
 ## Current submodule HEAD
 
-- `packages/intentd` @ `8e13a25` (after the READMEs milestone)
+- `packages/intentd` @ `c989aeb` (after the Milestone 1 — core domain CRUD milestone)
 
 ## Implemented surface so far
 
-- **JSON-RPC methods:** `workspace.list`, `note.list` (read-only, backed by SQLite).
-- **CLI:** `intentd serve`, `intentd call`, `intentd status`, `intentd doctor`.
-- **Transport:** JSON-RPC 2.0 router over UDS (newline-delimited, mode `0600`, stale-socket cleanup, SIGINT/SIGTERM handling), error codes `-32700`/`-32600`/`-32601`/`-32602`/`-32603`.
-- **Persistence:** SQLite via `sqlx` with embedded migrations (WAL, `foreign_keys`, `busy_timeout`).
+- **JSON-RPC methods (34):** full CRUD across four domains over UDS, backed by SQLite —
+  - `workspace.*` (9): `list`, `get`, `create`, `update`, `archive`, `unarchive`, `delete`, `markSeen`, `dismissAttention`.
+  - `note.*` (12): `list`, `get`, `create`, `update`, `setContent`, `add`, `edit`, `editLines`, `updateMetadata`, `listTasks`, `readAsset`, `delete`.
+  - `task.*` (8): `markAsTask`, `update`, `updateStatus`, `updateNoteStatus`, `getMyTask`, `createPrerequisite`, `assignAgent`, `convertBlocks`.
+  - `comment.*` (5): `add`, `list`, `getThread`, `respond`, `delete`.
+- **CLI:** `intentd serve`, `intentd call`, `intentd status`, `intentd doctor` (doctor now verifies migrations are applied).
+- **Transport:** JSON-RPC 2.0 router over UDS (newline-delimited, mode `0600`, stale-socket cleanup, SIGINT/SIGTERM handling), error codes `-32700`/`-32600`/`-32601`/`-32602`/`-32603`. UDS listener + control client are `cfg`-gated so non-Unix targets (Windows) build cleanly.
+- **Persistence:** SQLite via `sqlx` with embedded migrations (WAL, `foreign_keys`, `busy_timeout`), incl. the `0002_comments` migration for the comment/thread model.
+- **Tests:** end-to-end UDS lifecycle integration test plus camelCase wire-parity fixtures.
 
 ## Deferred / planned (NOT yet built)
 
-- The remaining ~104 PROTOCOL methods (106 total in the contract; 2 implemented).
+- The remaining ~72 PROTOCOL methods (106 total in the contract; 34 implemented).
 - TCP / TLS / WSS transports, mDNS discovery, bearer-token auth.
 - ACP / provider spawning, GitHub (octocrab), context engine, PTY, search, event bus.
 - Transport panic-safety via `catch_unwind` → `-32603` (currently relies on per-connection `tokio::spawn` isolation).
@@ -53,6 +58,10 @@ README.md written for both repos (intentd + monorepo). intentd HEAD `8e13a25`.
 
 This milestone: added `docs/00_initial_porting/BREADCRUMBS.md`, `docs/README.md`, the AGENTS.md breadcrumb-update policy, and a `make dev` local dev-stack target.
 
+### Milestone 1 — core domain CRUD
+
+Implemented full create/read/update/delete across the four core domains over UDS: `workspace.*` (9), `note.*` (12), `task.*` (8), `comment.*` (5) — 34 JSON-RPC methods total. Added the `0002_comments` SQLite migration (comment/thread model + repo), end-to-end UDS lifecycle integration test, camelCase wire-parity fixtures, a `doctor` migration-applied check, and `cfg`-gating of the UDS listener + control client so Windows (`x86_64-pc-windows-msvc`) builds cleanly. Spans `intent-core`, `intent-services` (incl. `note_ops`), `intent-store` (incl. `comment_repo`), `intent-transport`, and the `intentd` CLI. CI green on all three build targets (incl. Windows). Submodule HEAD `c989aeb`.
+
 ## Next steps / open questions
 
 - Begin expanding the JSON-RPC method catalog beyond the read-only slice (write paths for workspaces/notes), driven by PROTOCOL.md.
@@ -64,6 +73,7 @@ This milestone: added `docs/00_initial_porting/BREADCRUMBS.md`, `docs/README.md`
 
 Append a dated entry (newest first) whenever a meaningful unit of porting work lands. Keep each entry concise: what changed, which crates/methods, and the resulting submodule HEAD.
 
+- **2026-06-18** — Milestone 1 — core domain CRUD: 34 JSON-RPC methods (`workspace.*` 9, `note.*` 12, `task.*` 8, `comment.*` 5) over UDS; `0002_comments` migration; e2e UDS lifecycle test + camelCase parity fixtures; `doctor` migration check; Windows `cfg`-gating. Touched `intent-core`, `intent-services`, `intent-store`, `intent-transport`, `intentd`. Submodule HEAD `c989aeb`.
 - **2026-06-17** — Breadcrumbs, docs index & `make dev`: added breadcrumbs trail, `docs/README.md` index, and AGENTS.md breadcrumb-update policy. Docs-only (monorepo); submodule HEAD unchanged @ `8e13a25`.
 - **2026-06-17** — READMEs: wrote README.md for both repos. Submodule HEAD `8e13a25`.
 - **UDS JSON-RPC slice** — services + transport + CLI + integration test. Submodule HEAD `2756eb4`.


### PR DESCRIPTION
## Summary

Bumps the `packages/intentd` submodule to **Milestone 1 — core domain CRUD** and records
the milestone in the porting breadcrumbs.

- Submodule gitlink: `8e13a25` → `c989aeb`
- Source PR: cloudlands-ai/intentd#1 (`feat: core domain CRUD (workspace/note/task/comment) over UDS`)
- Squash merge commit on intentd `main`: `c989aeb2c09248dfd3ee4aa6ea6b551262f001e8`

## What landed in intentd M1

34 JSON-RPC methods over UDS, backed by SQLite:

- `workspace.*` (9): list, get, create, update, archive, unarchive, delete, markSeen, dismissAttention
- `note.*` (12): list, get, create, update, setContent, add, edit, editLines, updateMetadata, listTasks, readAsset, delete
- `task.*` (8): markAsTask, update, updateStatus, updateNoteStatus, getMyTask, createPrerequisite, assignAgent, convertBlocks
- `comment.*` (5): add, list, getThread, respond, delete

Plus: `0002_comments` SQLite migration, end-to-end UDS lifecycle integration test,
camelCase wire-parity fixtures, a `doctor` migration-applied check, and `cfg`-gating of
the UDS listener + control client so `x86_64-pc-windows-msvc` builds cleanly.

intentd CI was green on all three build targets (incl. Windows) before merge.

## Changes in this PR

- `chore:` bump `packages/intentd` gitlink to `c989aeb`
- `docs:` add the Milestone 1 breadcrumb entry and update Current submodule HEAD /
  Implemented surface / Deferred sections in `docs/00_initial_porting/BREADCRUMBS.md`
