### PR TITLE
chore: update intentd submodule to M3 Cycle A (ACP foundation)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "packages/intentd"]
 	path = packages/intentd
-	url = https://github.com/cloudlands-ai/intentd
+	url = https://github.com/Cloudlands-AI/intentd.git
 	branch = main

--- a/docs/00_initial_porting/BREADCRUMBS.md
+++ b/docs/00_initial_porting/BREADCRUMBS.md
@@ -10,7 +10,7 @@ Port Intent's backend to a standalone, headless Rust daemon (`intentd`) speaking
 
 ## Current submodule HEAD
 
-- `packages/intentd` @ `3238a73` (after the Milestone 2 — Events milestone)
+- `packages/intentd` @ `f5d2f8f` (after Milestone 3 — Cycle A: ACP foundation)
 
 ## Implemented surface so far
 
@@ -26,12 +26,13 @@ Port Intent's backend to a standalone, headless Rust daemon (`intentd`) speaking
 - **Transport:** JSON-RPC 2.0 router over UDS (newline-delimited, mode `0600`, stale-socket cleanup, SIGINT/SIGTERM handling), error codes `-32700`/`-32600`/`-32601`/`-32602`/`-32603`, plus server-initiated `events.event` notifications. UDS listener + control client are `cfg`-gated so non-Unix targets (Windows) build cleanly.
 - **Persistence:** SQLite via `sqlx` with embedded migrations (WAL, `foreign_keys`, `busy_timeout`), incl. the `0002_comments` and `0003_events` migrations.
 - **Tests:** end-to-end UDS lifecycle + events integration tests plus camelCase wire-parity fixtures.
+- **ACP foundation:** provider registry + model resolution (`intent-providers`); ACP client core — subprocess spawn, hand-rolled NDJSON JSON-RPC transport, reader/dispatch loop, `initialize` handshake, session lifecycle (`new`/`load`/`prompt`/`cancel`) with `session/update`→event-bus streaming, client-served filesystem read/write, permission-request flow, and a terminal stub (`intent-acp`); the `AgentSession` entity + `agent_repo` persistence via the `0004_agent_session` migration; and the `WorkspaceApi` trait (`intent-core`). Orchestration (AgentManager, MCP callback, `agent.*` RPC, E2E) deferred to Cycle B.
 
 ## Deferred / planned (NOT yet built)
 
 - The remaining PROTOCOL methods (106 total in the contract; ~43 implemented after Milestone 2).
 - TCP / TLS / WSS transports, mDNS discovery, bearer-token auth.
-- ACP / provider spawning, GitHub (octocrab), context engine, PTY, search.
+- ACP **orchestration** — AgentManager, MCP callback wiring, the `agent.*` RPC surface, and the end-to-end flow (the Cycle B half of Milestone 3); GitHub (octocrab), context engine, PTY, search.
 - Transport panic-safety via `catch_unwind` → `-32603` (currently relies on per-connection `tokio::spawn` isolation).
 - Event surface follow-ups deferred (verified parity-safe): `task:ready-tasks-changed` emission, saga-driven `workspace:*` events, and the `Event.metadata` field.
 - `file:*` distinct-type modelling deferred to Milestone 8 (the watcher currently emits `file:changed`).
@@ -71,6 +72,10 @@ Implemented full create/read/update/delete across the four core domains over UDS
 
 Ported Intent's event system to `intentd`. Added an append-only `Event` domain + event-type taxonomy (`intent-core`) and a durable event log via the `0003_events` migration + `event_repo` (`intent-store`). Built an in-process `EventBus` + filter engine with `subscriber_count` observability (`intent-services`), and extended the UDS transport to be bidirectional — server-initiated `events.event` notifications plus an `events.subscribe`/`events.unsubscribe` subscription fast-path (`intent-transport`). Added the seven `event.*` methods (`recentFiles`, `agentActivity`, `workspaceSummary`, `directoryChanges`, `query`, plus the deprecated singular `subscribe`/`unsubscribe` aliases), a notify-based file watcher emitting debounced `file:changed` events, and wired the M1 CRUD mutations to emit change events onto the bus. Deferred parity-safe: `task:ready-tasks-changed`, saga-driven `workspace:*` events, and `Event.metadata`; distinct `file:*` event types deferred to Milestone 8. CI green on all three build targets (incl. Windows). Submodule HEAD `3238a73`.
 
+### Milestone 3 — Cycle A (ACP foundation)
+
+Landed the **foundation half** of Milestone 3 — the ACP integration's lower layers, ahead of the orchestration half (Cycle B). Added two new crates: `intent-providers` (ACP provider registry — config loading, argument templating, model resolution) and `intent-acp` (ACP client core — subprocess spawn, a hand-rolled NDJSON JSON-RPC transport, a background reader/dispatch loop, the `initialize` handshake; session lifecycle `new`/`load`/`prompt`/`cancel` with `session/update` notifications fanned onto the event bus; client-served filesystem read/write, the permission-request flow, and a terminal stub). Added the `AgentSession` domain entity with store persistence (`agent_repo`) via the `0004_agent_session` migration, and the `WorkspaceApi` trait abstraction (`intent-core`). Accepted deviations: hand-rolled NDJSON transport (acp-tokio 0.11/0.14 incompatible with our dependency set), intentd-new `agent:permission:*` events (sanctioned by PROTOCOL §8), and a `name_explicitly_set` column. Orchestration — AgentManager, MCP callback wiring, the `agent.*` RPC surface, and the end-to-end flow — is the upcoming **Cycle B**. CI green on all three build targets (incl. Windows). Submodule HEAD `f5d2f8f`.
+
 ## Next steps / open questions
 
 - Continue expanding the JSON-RPC method catalog beyond the core CRUD + event surface, driven by PROTOCOL.md.
@@ -81,6 +86,7 @@ Ported Intent's event system to `intentd`. Added an append-only `Event` domain +
 
 Append a dated entry (newest first) whenever a meaningful unit of porting work lands. Keep each entry concise: what changed, which crates/methods, and the resulting submodule HEAD.
 
+- **2026-06-19** — Milestone 3 — Cycle A (ACP foundation): new crates `intent-providers` (provider registry, model resolution) and `intent-acp` (client core — spawn, hand-rolled NDJSON transport, `initialize` handshake; session lifecycle `new`/`load`/`prompt`/`cancel` with `session/update`→event-bus streaming; client-served fs + permission-request flow + terminal stub); `AgentSession` entity + `agent_repo` persistence via the `0004_agent_session` migration; `WorkspaceApi` trait (`intent-core`). Deviations: hand-rolled NDJSON transport (acp-tokio 0.11/0.14 incompat), intentd-new `agent:permission:*` events (PROTOCOL §8), `name_explicitly_set` column. Foundation half; orchestration (AgentManager, MCP callback, `agent.*` RPC, E2E) is the upcoming Cycle B. Touched `intent-core`, `intent-store`, `intent-services`, `intent-providers`, `intent-acp`. Submodule HEAD `f5d2f8f`.
 - **2026-06-18** — Milestone 2 — Events: append-only `Event` domain + `0003_events` log migration/repo; in-process `EventBus` + filter engine; bidirectional UDS transport (server-initiated `events.event` + `events.subscribe`/`unsubscribe` fast-path); seven `event.*` methods (incl. deprecated singular aliases); notify-based file watcher emitting `file:changed`; M1 CRUD mutations now emit change events. Deferred parity-safe: `task:ready-tasks-changed`, saga-driven `workspace:*`, `Event.metadata`; distinct `file:*` types → Milestone 8. Touched `intent-core`, `intent-store`, `intent-services`, `intent-transport`, `intentd`. Submodule HEAD `3238a73`.
 - **2026-06-18** — Milestone 1 — core domain CRUD: 34 JSON-RPC methods (`workspace.*` 9, `note.*` 12, `task.*` 8, `comment.*` 5) over UDS; `0002_comments` migration; e2e UDS lifecycle test + camelCase parity fixtures; `doctor` migration check; Windows `cfg`-gating. Touched `intent-core`, `intent-services`, `intent-store`, `intent-transport`, `intentd`. Submodule HEAD `c989aeb`.
 - **2026-06-17** — Breadcrumbs, docs index & `make dev`: added breadcrumbs trail, `docs/README.md` index, and AGENTS.md breadcrumb-update policy. Docs-only (monorepo); submodule HEAD unchanged @ `8e13a25`.


### PR DESCRIPTION
## Bump intentd → Milestone 3 Cycle A (ACP foundation)

Bumps the `packages/intentd` gitlink `4e87cf3..f5d2f8f`, landing the
**FOUNDATION half** of Milestone 3.

- **intentd PR**: Cloudlands-AI/intentd#4
- **Squash-merge SHA on intentd `main`**: `f5d2f8ffd67e46450bf97490c6bdffeb362db9a0`

### What landed in intentd (M3.1–M3.5)

- **M3.1** — provider registry + model resolution (`intent-providers`).
- **M3.2** — `AgentSession` entity, store persistence (`agent_repo`),
  migration `0004_agent_session`, and the `WorkspaceApi` trait (`intent-core`).
- **M3.3** — ACP client core: spawn, hand-rolled NDJSON transport,
  reader/dispatch, `initialize` handshake.
- **M3.4** — session lifecycle (`new`/`load`/`prompt`/`cancel`) with
  `session/update`→event-bus streaming.
- **M3.5** — client-served fs read/write, permission-request flow, terminal stub.

Orchestration (AgentManager, MCP callback wiring, `agent.*` RPC, end-to-end
flow) is the upcoming **Cycle B** follow-up.

### Also in this PR

- Updates the submodule remote URL in `.gitmodules` to the canonical
  `https://github.com/Cloudlands-AI/intentd.git`.
- Prepends the dated **Milestone 3 — Cycle A (ACP foundation)** entry to
  `docs/00_initial_porting/BREADCRUMBS.md` and updates the current submodule HEAD.

### Verification (intentd `feat/m3-acp`, pre-merge)

- `rustc 1.96.0`; `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`,
  `cargo test --workspace` (156 tests) — all green.
- intentd CI green on all three build targets **including Windows**.
