### PR TITLE
chore: add make run-intentd target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,11 @@ SUBMODULES = $(INTENTD_DIR)
 DEV_DATA_DIR ?= $(PWD)/.dev/intentd
 DEV_PORT ?= 5180
 
-.PHONY: all ensure-submodules build build-intentd test test-intentd fmt clippy check clean dev dev-daemon
+# Transport for `run-intentd`. Defaults to `uds` (matching intentd's own `serve` default).
+# Override to serve WSS/TCP for the iOS app, e.g. `make run-intentd LISTEN=both` or `LISTEN=tcp`.
+LISTEN ?= uds
+
+.PHONY: all ensure-submodules build build-intentd test test-intentd fmt clippy check clean dev dev-daemon run-intentd
 
 all: build
 
@@ -68,3 +72,11 @@ dev-daemon: ensure-submodules ## Run intentd alone (UDS) against a dedicated dev
 	# INTENTD_DEV_PORT now so downstream startup can pick it up without a Makefile change.
 	INTENTD_DATA_DIR=$(DEV_DATA_DIR) INTENTD_DEV_PORT=$(DEV_PORT) \
 		cargo run -p intentd --manifest-path $(INTENTD_DIR)/Cargo.toml -- serve --listen uds
+
+run-intentd: ensure-submodules ## Run intentd with default settings (real data dir; LISTEN=uds|tcp|both)
+	# Runs intentd against its DEFAULT data dir (no dev override): Config::resolve picks
+	# $$HOME/Library/Application Support/intentd on macOS for the socket + SQLite DB. This
+	# target is long-running and does not exit until you stop it (Ctrl-C). LISTEN selects the
+	# transport: `uds` (default) serves the local Unix socket; `tcp`/`both` also bring up
+	# HTTPS+WSS on 0.0.0.0:5180 for the iOS app.
+	cargo run -p intentd --manifest-path $(INTENTD_DIR)/Cargo.toml -- serve --listen $(LISTEN)

--- a/Makefile
+++ b/Makefile
@@ -10,9 +10,9 @@ SUBMODULES = $(INTENTD_DIR)
 DEV_DATA_DIR ?= $(PWD)/.dev/intentd
 DEV_PORT ?= 5180
 
-# Transport for `run-intentd`. Defaults to `uds` (matching intentd's own `serve` default).
-# Override to serve WSS/TCP for the iOS app, e.g. `make run-intentd LISTEN=both` or `LISTEN=tcp`.
-LISTEN ?= uds
+# Transport for `run-intentd`. Defaults to `both` (HTTPS+WSS on 0.0.0.0:5180 for the iOS app,
+# plus the local UDS socket). Override for UDS-only, e.g. `make run-intentd LISTEN=uds` (or `tcp`).
+LISTEN ?= both
 
 .PHONY: all ensure-submodules build build-intentd test test-intentd fmt clippy check clean dev dev-daemon run-intentd
 
@@ -73,10 +73,10 @@ dev-daemon: ensure-submodules ## Run intentd alone (UDS) against a dedicated dev
 	INTENTD_DATA_DIR=$(DEV_DATA_DIR) INTENTD_DEV_PORT=$(DEV_PORT) \
 		cargo run -p intentd --manifest-path $(INTENTD_DIR)/Cargo.toml -- serve --listen uds
 
-run-intentd: ensure-submodules ## Run intentd with default settings (real data dir; LISTEN=uds|tcp|both)
+run-intentd: ensure-submodules ## Run intentd with default settings (real data dir; LISTEN=both|uds|tcp)
 	# Runs intentd against its DEFAULT data dir (no dev override): Config::resolve picks
 	# $$HOME/Library/Application Support/intentd on macOS for the socket + SQLite DB. This
 	# target is long-running and does not exit until you stop it (Ctrl-C). LISTEN selects the
-	# transport: `uds` (default) serves the local Unix socket; `tcp`/`both` also bring up
-	# HTTPS+WSS on 0.0.0.0:5180 for the iOS app.
+	# transport: `both` (default) serves the local UDS socket AND HTTPS+WSS on 0.0.0.0:5180
+	# for the iOS app; override with `LISTEN=uds` (UDS only) or `LISTEN=tcp` (HTTPS+WSS only).
 	cargo run -p intentd --manifest-path $(INTENTD_DIR)/Cargo.toml -- serve --listen $(LISTEN)


### PR DESCRIPTION
## Summary

Adds a new monorepo-root Makefile target `run-intentd` that starts the intentd daemon with the **real/default data dir** (no dev override), distinct from the existing `dev-daemon` target (which uses a dedicated gitignored `.dev` data dir).

## Changes

- New `LISTEN ?= both` variable near the top. **Default is `both` (HTTPS+WSS on 0.0.0.0:5180 for the iOS app, plus the local UDS socket).** Override with `make run-intentd LISTEN=uds` (UDS only) or `LISTEN=tcp` (HTTPS+WSS only).
- New `run-intentd` target that runs intentd via cargo from the submodule manifest:
  `cargo run -p intentd --manifest-path $(INTENTD_DIR)/Cargo.toml -- serve --listen $(LISTEN)`
- Depends on `ensure-submodules`; added to `.PHONY`.
- Explanatory comment block noting it uses the DEFAULT data dir (`$HOME/Library/Application Support/intentd` on macOS via `Config::resolve`), is long-running (Ctrl-C to stop), and that `LISTEN` selects the transport (default `both` = WSS+UDS).

The existing `dev` / `dev-daemon` / `check` / `test` targets are unchanged.

## Validation

- `make -n run-intentd` expands to `... serve --listen both`.
- `make -n run-intentd LISTEN=uds` expands to `... serve --listen uds`.
