### PR TITLE
chore: add make run-fe, drop dead make dev target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ DEV_PORT ?= 5180
 # plus the local UDS socket). Override for UDS-only, e.g. `make run-intentd LISTEN=uds` (or `tcp`).
 LISTEN ?= both
 
-.PHONY: all ensure-submodules build build-intentd test test-intentd fmt clippy check clean dev dev-daemon run-intentd
+.PHONY: all ensure-submodules build build-intentd test test-intentd fmt clippy check clean dev-daemon run-intentd run-fe
 
 all: build
 
@@ -49,20 +49,6 @@ test-intentd: ensure-submodules
 clean:
 	rm -rf $(INTENTD_DIR)/target
 
-dev: ensure-submodules ## Run the full FE+daemon dev stack (builds intentd, launches cloudlands-fe)
-	@mkdir -p $(DEV_DATA_DIR)
-	@echo "[dev] starting cloudlands-fe + intentd dev stack"
-	@echo "[dev] intentd dev data dir: $(DEV_DATA_DIR) (UDS socket: $(DEV_DATA_DIR)/intentd.sock)"
-	# `pnpm tauri dev` runs the FE's `beforeDevCommand` (`pnpm sidecar && pnpm dev`):
-	# scripts/prepare-sidecar.mjs cargo-builds intentd (release) and stages it as the
-	# Tauri sidecar, then src-tauri/src/daemon.rs spawns that bundled intentd over UDS on
-	# app startup. So this one command builds intentd + launches the FE + spawns the daemon.
-	# INTENTD_DATA_DIR is honored by both the FE's rpc client and the spawned daemon (which
-	# inherits this env), so dev stays on the dedicated gitignored data dir. This target is
-	# long-running and does not exit until you stop the dev app (Ctrl-C).
-	@[ -d $(FE_DIR)/node_modules ] || (echo "[dev] installing FE deps (pnpm install)" && cd $(FE_DIR) && pnpm install)
-	cd $(FE_DIR) && INTENTD_DATA_DIR=$(DEV_DATA_DIR) pnpm tauri dev
-
 dev-daemon: ensure-submodules ## Run intentd alone (UDS) against a dedicated dev data dir
 	@mkdir -p $(DEV_DATA_DIR)
 	@echo "[dev-daemon] intentd dev data dir: $(DEV_DATA_DIR) (UDS socket: $(DEV_DATA_DIR)/intentd.sock)"
@@ -80,3 +66,14 @@ run-intentd: ensure-submodules ## Run intentd with default settings (real data d
 	# transport: `both` (default) serves the local UDS socket AND HTTPS+WSS on 0.0.0.0:5180
 	# for the iOS app; override with `LISTEN=uds` (UDS only) or `LISTEN=tcp` (HTTPS+WSS only).
 	cargo run -p intentd --manifest-path $(INTENTD_DIR)/Cargo.toml -- serve --listen $(LISTEN)
+
+run-fe: ensure-submodules ## Run the Electron + SvelteKit FE alone (packages/cloudlands-fe)
+	# Launches only the FE dev stack (vite + Electron). The FE does NOT spawn intentd;
+	# it connects to an already-running daemon, so pair this with `make run-intentd`
+	# (both use the default socket: ~/Library/Application Support/intentd/intentd.sock).
+	# Point the FE at a different daemon by setting INTENTD_SOCKET — make exports it to
+	# the FE automatically, so e.g. `INTENTD_SOCKET=$(DEV_DATA_DIR)/intentd.sock make run-fe`
+	# targets `make dev-daemon`. Left unset by default so the FE uses its default socket.
+	# Long-running; does not exit until you stop it (Ctrl-C).
+	@[ -d $(FE_DIR)/node_modules ] || (echo "[run-fe] installing FE deps (pnpm install)" && cd $(FE_DIR) && pnpm install)
+	cd $(FE_DIR) && pnpm run dev


### PR DESCRIPTION
## Summary

Replaces the dead `dev` Makefile target with a focused `run-fe` target.

- **Removed** the `dev` target (`pnpm tauri dev`) and its stale Tauri/sidecar comments. The Tauri sidecar tooling (`scripts/prepare-sidecar.mjs`, `src-tauri/`) no longer exists in `cloudlands-fe`, so this target was non-functional.
- **Added** `run-fe` (parallel to `run-intentd`): installs FE deps if missing, then runs `cd $(FE_DIR) && pnpm run dev` to launch the Electron + SvelteKit FE.
- Updated `.PHONY`: dropped `dev`, added `run-fe`.
- `dev-daemon` and `run-intentd` are unchanged.

The FE does **not** spawn intentd; it connects to an already-running daemon. By default `run-fe` uses the default socket (`~/Library/Application Support/intentd/intentd.sock`), pairing with `make run-intentd`. Set `INTENTD_SOCKET` to point at `make dev-daemon` instead — make exports it to the FE automatically.

## Verification

- `make -n run-fe` prints `cd packages/cloudlands-fe && pnpm run dev` (no Tauri).
- `make -n dev` fails with `No rule to make target 'dev'`.
