### PR TITLE
docs(protocol): §5.8 script.* methods require workspaceId

### DIFF
--- a/docs/00_initial_porting/PROTOCOL.md
+++ b/docs/00_initial_porting/PROTOCOL.md
@@ -695,7 +695,7 @@ host-agnostic.
 | Method | Params | Result |
 | --- | --- | --- |
 | script.list | workspaceId (req) | { scripts: [...] } |
-| script.create | workspaceId (req), name (req), command (req), mode (req: `service` \| `command`), cwd?, env?, category?, autoStart?, scriptId? | WorkspaceScript |
+| script.create | workspaceId (req), name (req), command (req), mode (req: `service` \| `command`), cwd?, env?, category?, autoStart?, scriptId? | { id, workspaceId, name, command, mode, source, createdAt, cwd?, env?, category?, autoStart?, updatedAt? } — the persisted `WorkspaceScript` record |
 | script.remove | workspaceId (req), scriptId (req) | { ok, scriptId } |
 | script.start | workspaceId (req), scriptId (req) | { ok, scriptId } |
 | script.stop | workspaceId (req), scriptId (req) | { ok, scriptId } |

--- a/docs/00_initial_porting/PROTOCOL.md
+++ b/docs/00_initial_porting/PROTOCOL.md
@@ -695,14 +695,14 @@ host-agnostic.
 | Method | Params | Result |
 | --- | --- | --- |
 | script.list | workspaceId (req) | { scripts: [...] } |
-| script.create | name (req), command (req), mode (req: service | command), cwd?, env?, category?, autoStart?, scriptId? |
-| script.remove | scriptId (req) | { ok, scriptId } |
-| script.start | scriptId (req) | { ok, scriptId } |
-| script.stop | scriptId (req) | { ok, scriptId } |
-| script.restart | scriptId (req) | { ok, scriptId } |
-| script.output | scriptId (req), maxLines? | output buffer text |
-| script.status | scriptId (req) | { state, pid, exitCode, url?, ... } |
-| script.run | scriptId (req), maxLines?, timeoutSeconds? (alias timeout?) | { exitCode?, output, timedOut?, warning? } |
+| script.create | workspaceId (req), name (req), command (req), mode (req: `service` \| `command`), cwd?, env?, category?, autoStart?, scriptId? | WorkspaceScript |
+| script.remove | workspaceId (req), scriptId (req) | { ok, scriptId } |
+| script.start | workspaceId (req), scriptId (req) | { ok, scriptId } |
+| script.stop | workspaceId (req), scriptId (req) | { ok, scriptId } |
+| script.restart | workspaceId (req), scriptId (req) | { ok, scriptId } |
+| script.output | workspaceId (req), scriptId (req), maxLines? | output buffer text |
+| script.status | workspaceId (req), scriptId (req) | { state, pid, exitCode, url?, ... } |
+| script.run | workspaceId (req), scriptId (req), maxLines?, timeoutSeconds? (alias timeout?) | { exitCode?, output, timedOut?, warning? } |
 
 > **Unified PTY host (new in intentd).** Scripts run inside (possibly headless) terminals on
 > the daemon and share the **unified PTY/terminal host** with interactive terminals (§5.13), so


### PR DESCRIPTION
## Why

`docs/00_initial_porting/PROTOCOL.md` §5.8 under-documented the `script.*`
methods: every row except `script.list` was missing `workspaceId (req)`.

That's not what the daemon actually enforces. Every `script.*` arm in
intentd's router calls `require_ws_note(params)?` first —
`crates/intent-transport/src/router.rs` §5.8 arms (`~L2345-2400`) —
so a request without `workspaceId` is rejected `-32602`/`invalid params`
before the service ever sees the `scriptId`.

Two secondary issues fixed at the same time:

- `script.create`'s row had no result column, because the unescaped `|`
  in `mode (req: service | command)` truncated the row into 3 pipes.
- `script.create` was also missing `workspaceId` in its params list, even
  though the router requires it.

## What changed

- Add `workspaceId (req)` to `script.create / remove / start / stop /
  restart / output / status / run`.
- Escape the pipe in the `mode` values so `script.create` renders as a
  full 3-column row.
- Document the `WorkspaceScript` result for `script.create`.

Only §5.8 is touched.

## Pairs with

- [cloudlands-fe#25](https://github.com/cloudlands-ai/cloudlands-fe/pull/25)
  — the FE fix that stopped discarding `_workspaceId` on
  `scriptsClient.remove/start/stop/restart/getStatus` and now forwards it
  in the wire payload, restoring the silent play button.

No submodule gitlink bump here — the parent coordinator handles the
consolidated bump once the paired FE PR merges.
