### PR TITLE
docs(protocol): §5 terminal.readOutput requires workspaceId

### DIFF
--- a/docs/00_initial_porting/PROTOCOL.md
+++ b/docs/00_initial_porting/PROTOCOL.md
@@ -720,7 +720,7 @@ host-agnostic.
 | browser.exec | actions (req, non-empty array), tabId?, agentId?, workspaceId? | single action → the action's `{ action, success, result?, error? }` envelope; multi-action → `{ results: [...] }` — **client-callable trigger** whose real work is served by the connected FE via a reverse RPC (`browser.exec`, `id: "rev-<n>"`), see below |
 | browser.docs | topic (req) | docs string |
 | terminal.list | workspaceId (req) | { terminals: [...] } |
-| terminal.readOutput | terminalId (req), maxLines? | output buffer text |
+| terminal.readOutput | workspaceId (req), terminalId (req), maxLines? | output buffer text |
 | file.read | path (req) | file contents — paths outside the workspace rejected (-32603) |
 | file.write | path (req), content (req) | { ok, path, size } |
 | file.list | path? (default .) | [{ name, type }] |


### PR DESCRIPTION
Update `docs/00_initial_porting/PROTOCOL.md` §5 `terminal.readOutput` row so the params column matches what the router (`router.rs:2220`) actually requires: `workspaceId (req)` alongside `terminalId (req)`.

The FE fix that threads `workspaceId` through the seam is cloudlands-ai/cloudlands-fe#27. Mirrors #85's row update for `script.*`.

## Verification

- Docs-only change; no `make check` / `make test` impact.
