### PR TITLE
chore(makefile): three-posture dev workflow (dev-daemon, release-daemon, ios)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,33 +1,63 @@
 # Cloudlands Monorepo Makefile
+#
+# Three postures for local work:
+#   1. `make dev-daemon` — default dev seat. intentd on an isolated data dir,
+#      serving UDS + TCP (`--listen both --insecure`) on 127.0.0.1:$(DEV_TCP_PORT)
+#      / 0.0.0.0:$(DEV_TCP_PORT). Pairs with `make run-fe` (whose dev default is
+#      `ws://127.0.0.1:5181/ws`) and with the iOS app (`make ios-info`).
+#   2. `make release-daemon` — occasional "debug the release app with its own
+#      state" seat. intentd on the real data dir, `LISTEN=uds` by default and
+#      no `--insecure`, so it never binds $(DEV_TCP_PORT) or collides with the
+#      dev seat.
+#   3. `make run-fe` / `make ios-open` / `make ios-info` — clients pointed at
+#      the dev daemon.
+#
+# `make help` lists every documented target (any recipe whose header ends in
+# `## <description>`).
 
 INTENTD_DIR = packages/intentd
 FE_DIR = packages/cloudlands-fe
+IOS_DIR = packages/ios
 
-SUBMODULES = $(INTENTD_DIR)
+SUBMODULES = $(INTENTD_DIR) $(FE_DIR) $(IOS_DIR)
 
-# Local dev stack configuration (overridable from the env/CLI, e.g. `make dev DEV_PORT=6000`).
-# DEV_DATA_DIR is a dedicated, gitignored data dir so dev never touches the real one.
-# DEV_PORT stays clear of two reserved ranges by default:
-#   - 5179..5188 is walked by the FE's MCP bridge scanner
-#     (packages/cloudlands-fe/src/main/mcp-stdio-server.ts::getCandidatePorts);
-#     landing the dev renderer here makes it look like a spurious bridge candidate
-#     and floods the SvelteKit console with `[404] GET /health` probes.
-#   - 5177 is the FE's own default vite port (packages/cloudlands-fe/vite.config.mjs)
-#     which the intent-build seat already uses; overlapping it would collide.
-# Override for a specific seat when needed (e.g. `make dev-daemon DEV_PORT=6000`).
+# Dev-seat data + ports (overridable, e.g. `make dev-daemon DEV_TCP_PORT=6181`).
+#
+# DEV_DATA_DIR is a dedicated, gitignored dir under the monorepo so the dev
+# seat never touches the packaged app's real data dir (Config::resolve in
+# packages/intentd/crates/intent-core/src/config.rs honours INTENTD_DATA_DIR).
+#
+# DEV_TCP_PORT is the intentd TCP/WebSocket base port. 5181 matches the FE's
+# built-in dev default (`DEFAULT_DEV_WS_URL = ws://127.0.0.1:5181/ws` in
+# packages/cloudlands-fe/src/features/backend/main/backend-connection.ts), so
+# `make dev-daemon` + `make run-fe` connect with no env overrides. The daemon
+# reads it via the INTENTD_TCP_PORT env seam (ws_options_from_env in
+# packages/intentd/crates/intentd/src/main.rs).
+#
+# DEV_PORT is a separate FE-only knob: the Electron dev launcher uses it to
+# namespace its userData directory (resolveDevUserDataDirName in
+# packages/cloudlands-fe/src/main/utils/resolve-dev-instance.ts), keeping
+# parallel dev Electrons off each other's SingletonLock. It has nothing to do
+# with intentd's TCP port and is passed through to the FE unchanged.
 DEV_DATA_DIR ?= $(PWD)/.dev/intentd
+DEV_TCP_PORT ?= 5181
 DEV_PORT ?= 5190
 
-# Transport for `run-intentd`. Defaults to `both` — the local UDS socket AND the TCP
-# WebSocket listener on 0.0.0.0:5181 (fixed port; fail-fast on bind failure). Override
-# for UDS-only, e.g. `make run-intentd LISTEN=uds` (or `tcp`).
-LISTEN ?= both
+# Transport for `release-daemon`. Defaults to `uds` (UDS only) so the release
+# seat can never race the dev seat for $(DEV_TCP_PORT). Override for the
+# TCP+UDS or TCP-only postures, e.g. `make release-daemon LISTEN=both`.
+LISTEN ?= uds
 
-.PHONY: all ensure-submodules build build-intentd test test-intentd fmt clippy check clean dev-daemon run-intentd run-fe
+.PHONY: all help ensure-submodules build build-intentd test test-intentd \
+	fmt clippy check clean clean-dev dev-daemon release-daemon run-intentd \
+	run-fe ios-open ios-info
 
 all: build
 
-ensure-submodules:
+help: ## List documented targets
+	@awk 'BEGIN {FS = ":.*## "} /^[a-zA-Z0-9_-]+:.*## / {printf "  %-16s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+
+ensure-submodules: ## Initialize any missing submodules (idempotent)
 	@for sm in $(SUBMODULES); do \
 		if [ ! -e "$$sm/.git" ]; then \
 			echo "[ensure-submodules] initializing $$sm"; \
@@ -37,58 +67,86 @@ ensure-submodules:
 		fi; \
 	done
 
-build: build-intentd
+build: build-intentd ## Build the Rust workspace (packages/intentd)
 
 build-intentd: ensure-submodules
 	cd $(INTENTD_DIR) && cargo build --workspace
 
-fmt: ensure-submodules
+fmt: ensure-submodules ## cargo fmt --check
 	cd $(INTENTD_DIR) && cargo fmt --check
 
-clippy: ensure-submodules
+clippy: ensure-submodules ## cargo clippy -- -D warnings
 	cd $(INTENTD_DIR) && cargo clippy --workspace -- -D warnings
 
-check: fmt clippy
+check: fmt clippy ## fmt + clippy
 
-test: test-intentd
+test: test-intentd ## Run the Rust test suite
 
 test-intentd: ensure-submodules
 	cd $(INTENTD_DIR) && cargo test --workspace
 
-clean:
+clean: ## Remove cargo build artifacts (packages/intentd/target)
 	rm -rf $(INTENTD_DIR)/target
 
-dev-daemon: ensure-submodules ## Run intentd alone (UDS) against a dedicated dev data dir
+clean-dev: ## Wipe the dev-seat state dir (.dev/)
+	rm -rf $(PWD)/.dev
+
+dev-daemon: ensure-submodules ## Dev seat: intentd on isolated data dir, UDS + insecure TCP on $(DEV_TCP_PORT)
 	@mkdir -p $(DEV_DATA_DIR)
-	@echo "[dev-daemon] intentd dev data dir: $(DEV_DATA_DIR) (UDS socket: $(DEV_DATA_DIR)/intentd.sock)"
-	# intentd is UDS-only today (TCP/port deferred per §5.2): the dev socket + SQLite DB
-	# live under $(DEV_DATA_DIR). DEV_PORT is reserved/forward-looking for the planned TCP
-	# listener (§5.2) and the future Tauri/Svelte FE dev server; it is exported as
-	# INTENTD_DEV_PORT now so downstream startup can pick it up without a Makefile change.
-	INTENTD_DATA_DIR=$(DEV_DATA_DIR) INTENTD_DEV_PORT=$(DEV_PORT) \
-		cargo run -p intentd --manifest-path $(INTENTD_DIR)/Cargo.toml -- serve --listen uds
+	@echo "[dev-daemon] intentd dev data dir: $(DEV_DATA_DIR) (UDS: $(DEV_DATA_DIR)/intentd.sock, TCP: 0.0.0.0:$(DEV_TCP_PORT))"
+	# `--listen both --insecure` serves the local UDS socket AND a plain ws://
+	# listener on 0.0.0.0:$(DEV_TCP_PORT) with no TLS and no bearer-token auth
+	# — matches the FE's dev default and the iOS simulator/hardware seat.
+	# The daemon fails fast if $(DEV_TCP_PORT) is already bound.
+	INTENTD_DATA_DIR=$(DEV_DATA_DIR) INTENTD_TCP_PORT=$(DEV_TCP_PORT) \
+		cargo run -p intentd --manifest-path $(INTENTD_DIR)/Cargo.toml -- serve --listen both --insecure
 
-run-intentd: ensure-submodules ## Run intentd with default settings (real data dir; LISTEN=both|uds|tcp)
+release-daemon: ensure-submodules ## Release-state debug seat: intentd on real data dir, LISTEN=uds by default, no --insecure
 	# Runs intentd against its DEFAULT data dir (no dev override): Config::resolve picks
-	# $$HOME/Library/Application Support/intentd on macOS for the socket + SQLite DB. This
-	# target is long-running and does not exit until you stop it (Ctrl-C). LISTEN selects
-	# the transport: `both` (default) serves the local UDS socket AND the TCP WebSocket
-	# listener on 0.0.0.0:5181 (fixed port; the process exits non-zero immediately if that
-	# port is occupied — no port walking); `LISTEN=uds` (UDS only) or `LISTEN=tcp`
-	# (TCP only). This target passes `--insecure` so the TCP listener serves plain
-	# `ws://` with no TLS and no bearer-token auth — the local FE dev seat's default
-	# posture. For a secure listener (TLS + bearer auth on `wss://`), invoke `cargo run`
-	# directly without `--insecure`, e.g.
-	#   cargo run -p intentd --manifest-path $(INTENTD_DIR)/Cargo.toml -- serve --listen $(LISTEN)
-	cargo run -p intentd --manifest-path $(INTENTD_DIR)/Cargo.toml -- serve --listen $(LISTEN) --insecure
+	# $$HOME/Library/Application Support/intentd on macOS for the socket + SQLite DB.
+	# LISTEN defaults to `uds` so this seat never binds $(DEV_TCP_PORT); pass
+	# `LISTEN=both` or `LISTEN=tcp` to add the WSS listener (fixed port 5181 —
+	# fails fast if the dev seat already holds it). No `--insecure`: the TCP
+	# listener, when enabled, serves wss:// with TLS + bearer auth as the
+	# packaged app expects.
+	cargo run -p intentd --manifest-path $(INTENTD_DIR)/Cargo.toml -- serve --listen $(LISTEN)
 
-run-fe: ensure-submodules ## Run the Electron + SvelteKit FE alone (packages/cloudlands-fe)
-	# Launches only the FE dev stack (vite + Electron). The FE does NOT spawn intentd;
-	# it connects to an already-running daemon, so pair this with `make run-intentd`
-	# (both use the default socket: ~/Library/Application Support/intentd/intentd.sock).
-	# Point the FE at a different daemon by setting INTENTD_SOCKET — make exports it to
-	# the FE automatically, so e.g. `INTENTD_SOCKET=$(DEV_DATA_DIR)/intentd.sock make run-fe`
-	# targets `make dev-daemon`. Left unset by default so the FE uses its default socket.
+run-intentd: release-daemon ## DEPRECATED alias for release-daemon
+	@echo "[run-intentd] DEPRECATED: use 'make release-daemon' (or 'make dev-daemon' for the dev seat)."
+
+run-fe: ensure-submodules ## Run the Electron + SvelteKit FE (pairs with dev-daemon out of the box)
+	# Launches only the FE dev stack (vite + Electron). The FE does NOT spawn
+	# intentd; pair this with `make dev-daemon` (default) — the FE's dev build
+	# defaults to `ws://127.0.0.1:5181/ws` (DEFAULT_DEV_WS_URL in
+	# packages/cloudlands-fe/src/features/backend/main/backend-connection.ts),
+	# which matches dev-daemon's DEV_TCP_PORT. Overrides:
+	#   INTENTD_SOCKET=/path/to.sock  → UDS (highest precedence; e.g. point at
+	#                                    release-daemon's default socket).
+	#   INTENTD_WS_URL=ws://host:port → plain WebSocket to a specific URL.
 	# Long-running; does not exit until you stop it (Ctrl-C).
 	@[ -d $(FE_DIR)/node_modules ] || (echo "[run-fe] installing FE deps (pnpm install)" && cd $(FE_DIR) && pnpm install)
 	cd $(FE_DIR) && pnpm run dev
+
+ios-open: ensure-submodules ## Open the iOS Xcode project (packages/ios/Intent.xcodeproj)
+	open $(IOS_DIR)/Intent.xcodeproj
+
+ios-info: ## Print how to point the iOS app at the local dev daemon
+	@echo "iOS ↔ intentd dev seat (pairs with 'make dev-daemon' on port $(DEV_TCP_PORT)):"
+	@echo ""
+	@echo "  Simulator: host 127.0.0.1  port $(DEV_TCP_PORT)"
+	@lan_ip=$$(ipconfig getifaddr en0 2>/dev/null || ipconfig getifaddr en1 2>/dev/null); \
+		if [ -n "$$lan_ip" ]; then \
+			echo "  Hardware:  host $$lan_ip  port $(DEV_TCP_PORT)   (Mac + iPhone on the same LAN)"; \
+		else \
+			echo "  Hardware:  <no LAN IP on en0/en1 — connect Wi-Fi/Ethernet and re-run 'make ios-info'>"; \
+		fi
+	@echo ""
+	@echo "  dev-daemon runs '--insecure' (plain ws://, no TLS, no bearer auth)."
+	@echo "  In the iOS 'Manual Connection' sheet, enter the host + port above; the"
+	@echo "  token field can be any non-empty value (the daemon does not enforce it"
+	@echo "  in insecure mode)."
+	@echo ""
+	@echo "  For the secure/Bonjour pairing posture (TLS + bearer auth + QR/mDNS),"
+	@echo "  run intentd WITHOUT '--insecure' and with INTENTD_DISCOVERY=1, e.g."
+	@echo "    INTENTD_DISCOVERY=1 cargo run -p intentd --manifest-path $(INTENTD_DIR)/Cargo.toml -- serve --listen both"
+	@echo "  then use the iOS 'Scan QR Code' or 'Find on Network' flows."

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,12 @@ INTENTD_DIR = packages/intentd
 FE_DIR = packages/cloudlands-fe
 IOS_DIR = packages/ios
 
-SUBMODULES = $(INTENTD_DIR) $(FE_DIR) $(IOS_DIR)
+# `ensure-submodules` covers the intentd submodule that every Rust target
+# (build/test/fmt/clippy/check) needs. The FE and iOS submodules are heavy and
+# not needed for backend-only workflows, so they are initialized on demand by
+# their own `ensure-fe-submodule` / `ensure-ios-submodule` targets (same
+# idempotent init-if-missing contract, just narrower).
+SUBMODULES = $(INTENTD_DIR)
 
 # Dev-seat data + ports (overridable, e.g. `make dev-daemon DEV_TCP_PORT=6181`).
 #
@@ -39,7 +44,7 @@ SUBMODULES = $(INTENTD_DIR) $(FE_DIR) $(IOS_DIR)
 # packages/cloudlands-fe/src/main/utils/resolve-dev-instance.ts), keeping
 # parallel dev Electrons off each other's SingletonLock. It has nothing to do
 # with intentd's TCP port and is passed through to the FE unchanged.
-DEV_DATA_DIR ?= $(PWD)/.dev/intentd
+DEV_DATA_DIR ?= $(CURDIR)/.dev/intentd
 DEV_TCP_PORT ?= 5181
 DEV_PORT ?= 5190
 
@@ -48,16 +53,16 @@ DEV_PORT ?= 5190
 # TCP+UDS or TCP-only postures, e.g. `make release-daemon LISTEN=both`.
 LISTEN ?= uds
 
-.PHONY: all help ensure-submodules build build-intentd test test-intentd \
-	fmt clippy check clean clean-dev dev-daemon release-daemon run-intentd \
-	run-fe ios-open ios-info
+.PHONY: all help ensure-submodules ensure-fe-submodule ensure-ios-submodule \
+	build build-intentd test test-intentd fmt clippy check clean clean-dev \
+	dev-daemon release-daemon run-intentd run-fe ios-open ios-info
 
 all: build
 
 help: ## List documented targets
 	@awk 'BEGIN {FS = ":.*## "} /^[a-zA-Z0-9_-]+:.*## / {printf "  %-16s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 
-ensure-submodules: ## Initialize any missing submodules (idempotent)
+ensure-submodules: ## Initialize any missing Rust-workflow submodules (idempotent)
 	@for sm in $(SUBMODULES); do \
 		if [ ! -e "$$sm/.git" ]; then \
 			echo "[ensure-submodules] initializing $$sm"; \
@@ -66,6 +71,26 @@ ensure-submodules: ## Initialize any missing submodules (idempotent)
 			echo "[ensure-submodules] $$sm already initialized — leaving as-is"; \
 		fi; \
 	done
+
+# On-demand init for the FE submodule — pulled in only by targets that need it
+# (`run-fe`), so backend-only workflows stay fast.
+ensure-fe-submodule:
+	@if [ ! -e "$(FE_DIR)/.git" ]; then \
+		echo "[ensure-submodules] initializing $(FE_DIR)"; \
+		git submodule update --init --recursive "$(FE_DIR)"; \
+	else \
+		echo "[ensure-submodules] $(FE_DIR) already initialized — leaving as-is"; \
+	fi
+
+# On-demand init for the iOS submodule — pulled in only by targets that need
+# it (`ios-open`); backend-only workflows stay fast.
+ensure-ios-submodule:
+	@if [ ! -e "$(IOS_DIR)/.git" ]; then \
+		echo "[ensure-submodules] initializing $(IOS_DIR)"; \
+		git submodule update --init --recursive "$(IOS_DIR)"; \
+	else \
+		echo "[ensure-submodules] $(IOS_DIR) already initialized — leaving as-is"; \
+	fi
 
 build: build-intentd ## Build the Rust workspace (packages/intentd)
 
@@ -89,7 +114,7 @@ clean: ## Remove cargo build artifacts (packages/intentd/target)
 	rm -rf $(INTENTD_DIR)/target
 
 clean-dev: ## Wipe the dev-seat state dir (.dev/)
-	rm -rf $(PWD)/.dev
+	rm -rf $(CURDIR)/.dev
 
 dev-daemon: ensure-submodules ## Dev seat: intentd on isolated data dir, UDS + insecure TCP on $(DEV_TCP_PORT)
 	@mkdir -p $(DEV_DATA_DIR)
@@ -104,17 +129,19 @@ dev-daemon: ensure-submodules ## Dev seat: intentd on isolated data dir, UDS + i
 release-daemon: ensure-submodules ## Release-state debug seat: intentd on real data dir, LISTEN=uds by default, no --insecure
 	# Runs intentd against its DEFAULT data dir (no dev override): Config::resolve picks
 	# $$HOME/Library/Application Support/intentd on macOS for the socket + SQLite DB.
-	# LISTEN defaults to `uds` so this seat never binds $(DEV_TCP_PORT); pass
-	# `LISTEN=both` or `LISTEN=tcp` to add the WSS listener (fixed port 5181 —
-	# fails fast if the dev seat already holds it). No `--insecure`: the TCP
-	# listener, when enabled, serves wss:// with TLS + bearer auth as the
-	# packaged app expects.
+	# LISTEN defaults to `uds` so this seat is UDS-only and does not bind a TCP
+	# port at all. Pass `LISTEN=both` or `LISTEN=tcp` to add the WSS listener on
+	# intentd's default TCP port (5181 unless INTENTD_TCP_PORT is set); the
+	# daemon fails fast if that port is already bound (e.g. by `make dev-daemon`
+	# on the same 5181). No `--insecure`: the TCP listener, when enabled, serves
+	# wss:// with TLS + bearer auth as the packaged app expects.
 	cargo run -p intentd --manifest-path $(INTENTD_DIR)/Cargo.toml -- serve --listen $(LISTEN)
 
-run-intentd: release-daemon ## DEPRECATED alias for release-daemon
+run-intentd: ## DEPRECATED alias for release-daemon
 	@echo "[run-intentd] DEPRECATED: use 'make release-daemon' (or 'make dev-daemon' for the dev seat)."
+	@$(MAKE) release-daemon
 
-run-fe: ensure-submodules ## Run the Electron + SvelteKit FE (pairs with dev-daemon out of the box)
+run-fe: ensure-fe-submodule ## Run the Electron + SvelteKit FE (pairs with dev-daemon out of the box)
 	# Launches only the FE dev stack (vite + Electron). The FE does NOT spawn
 	# intentd; pair this with `make dev-daemon` (default) — the FE's dev build
 	# defaults to `ws://127.0.0.1:5181/ws` (DEFAULT_DEV_WS_URL in
@@ -127,7 +154,7 @@ run-fe: ensure-submodules ## Run the Electron + SvelteKit FE (pairs with dev-dae
 	@[ -d $(FE_DIR)/node_modules ] || (echo "[run-fe] installing FE deps (pnpm install)" && cd $(FE_DIR) && pnpm install)
 	cd $(FE_DIR) && pnpm run dev
 
-ios-open: ensure-submodules ## Open the iOS Xcode project (packages/ios/Intent.xcodeproj)
+ios-open: ensure-ios-submodule ## Open the iOS Xcode project (packages/ios/Intent.xcodeproj)
 	open $(IOS_DIR)/Intent.xcodeproj
 
 ios-info: ## Print how to point the iOS app at the local dev daemon

--- a/Makefile
+++ b/Makefile
@@ -76,20 +76,20 @@ ensure-submodules: ## Initialize any missing Rust-workflow submodules (idempoten
 # (`run-fe`), so backend-only workflows stay fast.
 ensure-fe-submodule:
 	@if [ ! -e "$(FE_DIR)/.git" ]; then \
-		echo "[ensure-submodules] initializing $(FE_DIR)"; \
+		echo "[ensure-fe-submodule] initializing $(FE_DIR)"; \
 		git submodule update --init --recursive "$(FE_DIR)"; \
 	else \
-		echo "[ensure-submodules] $(FE_DIR) already initialized — leaving as-is"; \
+		echo "[ensure-fe-submodule] $(FE_DIR) already initialized — leaving as-is"; \
 	fi
 
 # On-demand init for the iOS submodule — pulled in only by targets that need
 # it (`ios-open`); backend-only workflows stay fast.
 ensure-ios-submodule:
 	@if [ ! -e "$(IOS_DIR)/.git" ]; then \
-		echo "[ensure-submodules] initializing $(IOS_DIR)"; \
+		echo "[ensure-ios-submodule] initializing $(IOS_DIR)"; \
 		git submodule update --init --recursive "$(IOS_DIR)"; \
 	else \
-		echo "[ensure-submodules] $(IOS_DIR) already initialized — leaving as-is"; \
+		echo "[ensure-ios-submodule] $(IOS_DIR) already initialized — leaving as-is"; \
 	fi
 
 build: build-intentd ## Build the Rust workspace (packages/intentd)
@@ -119,6 +119,7 @@ clean-dev: ## Wipe the dev-seat state dir (.dev/)
 dev-daemon: ensure-submodules ## Dev seat: intentd on isolated data dir, UDS + insecure TCP on $(DEV_TCP_PORT)
 	@mkdir -p $(DEV_DATA_DIR)
 	@echo "[dev-daemon] intentd dev data dir: $(DEV_DATA_DIR) (UDS: $(DEV_DATA_DIR)/intentd.sock, TCP: 0.0.0.0:$(DEV_TCP_PORT))"
+	@echo "[dev-daemon] WARNING: --insecure binds ws:// on 0.0.0.0:$(DEV_TCP_PORT) with no TLS and no auth — anyone on your LAN can reach it. Only run on a trusted network."
 	# `--listen both --insecure` serves the local UDS socket AND a plain ws://
 	# listener on 0.0.0.0:$(DEV_TCP_PORT) with no TLS and no bearer-token auth
 	# — matches the FE's dev default and the iOS simulator/hardware seat.
@@ -155,7 +156,11 @@ run-fe: ensure-fe-submodule ## Run the Electron + SvelteKit FE (pairs with dev-d
 	cd $(FE_DIR) && pnpm run dev
 
 ios-open: ensure-ios-submodule ## Open the iOS Xcode project (packages/ios/Intent.xcodeproj)
-	open $(IOS_DIR)/Intent.xcodeproj
+	@if [ "$$(uname -s)" != "Darwin" ]; then \
+		echo "[ios-open] ERROR: requires macOS (Xcode). Detected $$(uname -s)."; \
+		exit 1; \
+	fi
+	open "$(IOS_DIR)/Intent.xcodeproj"
 
 ios-info: ## Print how to point the iOS app at the local dev daemon
 	@echo "iOS ↔ intentd dev seat (pairs with 'make dev-daemon' on port $(DEV_TCP_PORT)):"

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,9 @@ SUBMODULES = $(INTENTD_DIR)
 DEV_DATA_DIR ?= $(CURDIR)/.dev/intentd
 DEV_TCP_PORT ?= 5181
 DEV_PORT ?= 5190
+# Export DEV_PORT so `make run-fe` (and any recipe that shells out to the FE)
+# actually sees the default/override in the child environment.
+export DEV_PORT
 
 # Transport for `release-daemon`. Defaults to `uds` (UDS only) so the release
 # seat can never race the dev seat for $(DEV_TCP_PORT). Override for the

--- a/Makefile
+++ b/Makefile
@@ -114,17 +114,17 @@ clean: ## Remove cargo build artifacts (packages/intentd/target)
 	rm -rf $(INTENTD_DIR)/target
 
 clean-dev: ## Wipe the dev-seat state dir (.dev/)
-	rm -rf $(CURDIR)/.dev
+	rm -rf "$(CURDIR)/.dev"
 
 dev-daemon: ensure-submodules ## Dev seat: intentd on isolated data dir, UDS + insecure TCP on $(DEV_TCP_PORT)
-	@mkdir -p $(DEV_DATA_DIR)
+	@mkdir -p "$(DEV_DATA_DIR)"
 	@echo "[dev-daemon] intentd dev data dir: $(DEV_DATA_DIR) (UDS: $(DEV_DATA_DIR)/intentd.sock, TCP: 0.0.0.0:$(DEV_TCP_PORT))"
 	@echo "[dev-daemon] WARNING: --insecure binds ws:// on 0.0.0.0:$(DEV_TCP_PORT) with no TLS and no auth — anyone on your LAN can reach it. Only run on a trusted network."
 	# `--listen both --insecure` serves the local UDS socket AND a plain ws://
 	# listener on 0.0.0.0:$(DEV_TCP_PORT) with no TLS and no bearer-token auth
 	# — matches the FE's dev default and the iOS simulator/hardware seat.
 	# The daemon fails fast if $(DEV_TCP_PORT) is already bound.
-	INTENTD_DATA_DIR=$(DEV_DATA_DIR) INTENTD_TCP_PORT=$(DEV_TCP_PORT) \
+	INTENTD_DATA_DIR="$(DEV_DATA_DIR)" INTENTD_TCP_PORT=$(DEV_TCP_PORT) \
 		cargo run -p intentd --manifest-path $(INTENTD_DIR)/Cargo.toml -- serve --listen both --insecure
 
 release-daemon: ensure-submodules ## Release-state debug seat: intentd on real data dir, LISTEN=uds by default, no --insecure

--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,9 @@
 #
 # Three postures for local work:
 #   1. `make dev-daemon` — default dev seat. intentd on an isolated data dir,
-#      serving UDS + TCP (`--listen both --insecure`) on 127.0.0.1:$(DEV_TCP_PORT)
-#      / 0.0.0.0:$(DEV_TCP_PORT). Pairs with `make run-fe` (whose dev default is
-#      `ws://127.0.0.1:5181/ws`) and with the iOS app (`make ios-info`).
+#      serving UDS + TCP (`--listen both --insecure`) bound on 0.0.0.0:$(DEV_TCP_PORT)
+#      (reachable from loopback and LAN). Pairs with `make run-fe` (whose dev default
+#      is `ws://127.0.0.1:5181/ws`) and with the iOS app (`make ios-info`).
 #   2. `make release-daemon` — occasional "debug the release app with its own
 #      state" seat. intentd on the real data dir, `LISTEN=uds` by default and
 #      no `--insecure`, so it never binds $(DEV_TCP_PORT) or collides with the
@@ -163,6 +163,10 @@ ios-open: ensure-ios-submodule ## Open the iOS Xcode project (packages/ios/Inten
 	open "$(IOS_DIR)/Intent.xcodeproj"
 
 ios-info: ## Print how to point the iOS app at the local dev daemon
+	@if [ "$$(uname -s)" != "Darwin" ]; then \
+		echo "[ios-info] ERROR: requires macOS (uses ipconfig getifaddr). Detected $$(uname -s)."; \
+		exit 1; \
+	fi
 	@echo "iOS ↔ intentd dev seat (pairs with 'make dev-daemon' on port $(DEV_TCP_PORT)):"
 	@echo ""
 	@echo "  Simulator: host 127.0.0.1  port $(DEV_TCP_PORT)"

--- a/README.md
+++ b/README.md
@@ -96,8 +96,10 @@ make clean      # remove build artifacts
 
 # Local dev runs as two long-running processes, one per terminal
 # (each is long-running; Ctrl-C to stop). The default dev seat runs intentd
-# on an isolated data dir with UDS + a plain ws:// listener on 127.0.0.1:5181,
-# which is the FE's built-in dev default:
+# on an isolated data dir with UDS + a plain ws:// listener on port 5181
+# (reachable from loopback and from other devices on the same LAN — the
+# FE's built-in dev default is `ws://127.0.0.1:5181/ws`; the iOS app on a
+# phone talks to `ws://<Mac LAN IP>:5181`; see `make ios-info`):
 #
 #   # Terminal 1 — dev daemon: isolated data dir under .dev/intentd, --listen both --insecure
 #   make dev-daemon

--- a/README.md
+++ b/README.md
@@ -95,21 +95,27 @@ make build      # cargo build --workspace
 make clean      # remove build artifacts
 
 # Local dev runs as two long-running processes, one per terminal
-# (each is long-running; Ctrl-C to stop):
+# (each is long-running; Ctrl-C to stop). The default dev seat runs intentd
+# on an isolated data dir with UDS + a plain ws:// listener on 127.0.0.1:5181,
+# which is the FE's built-in dev default:
 #
-#   # Terminal 1 — the intentd daemon on its default (real) data dir + socket
-#   make run-intentd
+#   # Terminal 1 — dev daemon: isolated data dir under .dev/intentd, --listen both --insecure
+#   make dev-daemon
 #
-#   # Terminal 2 — the Electron + SvelteKit frontend (packages/cloudlands-fe),
-#   # launched via `pnpm run dev`. By default it connects to the daemon's
-#   # default intentd socket, so it pairs directly with `make run-intentd`.
+#   # Terminal 2 — Electron + SvelteKit frontend (packages/cloudlands-fe);
+#   # connects to ws://127.0.0.1:5181/ws out of the box.
 #   make run-fe
 #
-# Isolated dev-data variant: run the daemon against a dedicated gitignored dev
-# data dir, then point the frontend at that socket instead of the default:
+# Occasional "debug the release app with its own state" variant: run intentd
+# against its default (real) data dir over UDS only, no TCP listener bound:
 #
-#   make dev-daemon                                          # intentd (UDS) on the dev data dir
-#   INTENTD_SOCKET=$(DEV_DATA_DIR)/intentd.sock make run-fe  # FE → dev-data socket
+#   make release-daemon                                      # UDS only on the real data dir
+#   INTENTD_SOCKET=~/Library/Application\ Support/intentd/intentd.sock make run-fe
+#
+# `make run-intentd` is a deprecated alias for `make release-daemon`.
+# `make ios-info` prints the host/port for the iOS simulator and hardware, and
+# `make ios-open` opens the Xcode project (`packages/ios/Intent.xcodeproj`).
+# `make help` lists every documented target.
 ```
 
 ## Contributing & Workflow


### PR DESCRIPTION
## Summary

Restructures the root `Makefile` around three explicit postures so the dev seat, the release-state debug seat, and the iOS clients each have one obvious target.

1. **`make dev-daemon`** — default dev seat. `intentd` on an **isolated** `INTENTD_DATA_DIR` (`.dev/intentd`), serving `--listen both --insecure` with `INTENTD_TCP_PORT=$(DEV_TCP_PORT)` (default `5181`). That matches the FE's `DEFAULT_DEV_WS_URL = ws://127.0.0.1:5181/ws` (`packages/cloudlands-fe/src/features/backend/main/backend-connection.ts`) so `make run-fe` connects with **no env overrides**, and it's the same host/port the iOS app talks to.
2. **`make release-daemon`** — "debug the release app with its state" seat. `intentd` on the real data dir, `LISTEN=uds` by default and **no `--insecure`**, so it never binds `5181` or races the dev seat.
3. **`make run-fe` / `make ios-open` / `make ios-info`** — clients pointed at the dev daemon. `ios-info` prints simulator + LAN hardware host/port and the pairing options; no tokens/fingerprints are ever printed.

## Changes

- **Makefile**
  - `SUBMODULES` stays scoped to `$(INTENTD_DIR)` only, so `ensure-submodules` (and by extension `build` / `test` / `fmt` / `clippy` / `check`) never touches the FE + iOS submodules. Adds separate on-demand `ensure-fe-submodule` and `ensure-ios-submodule` targets (idempotent init-if-missing) that are wired only into `run-fe` and `ios-open`, so backend-only workflows stay fast.
  - Renames `run-intentd` → `release-daemon`. `run-intentd` is kept as a **deprecated alias** that prints the deprecation notice first and then forwards to `release-daemon` via a nested `$(MAKE)` call (so the notice shows before the long-running recipe blocks).
  - Introduces `DEV_TCP_PORT` (default `5181`) for the daemon's TCP/WebSocket listener. Documents `DEV_PORT` (default `5190`) as the FE dev userData namespacing knob (`resolveDevUserDataDirName` in `packages/cloudlands-fe/src/main/utils/resolve-dev-instance.ts`) — distinct from `DEV_TCP_PORT`.
  - Drops the no-op `INTENTD_DEV_PORT` export and the stale "UDS-only today" comment block from `dev-daemon`. The env seams referenced by the recipes now all exist in code: `INTENTD_TCP_PORT` / `INTENTD_DISCOVERY` (`ws_options_from_env` in `packages/intentd/crates/intentd/src/main.rs`) and `INTENTD_DATA_DIR` (`Config::resolve` in `packages/intentd/crates/intent-core/src/config.rs`).
  - `dev-daemon` prints an explicit runtime **WARNING** before starting the daemon, calling out that `--insecure` binds `ws://` on `0.0.0.0:$(DEV_TCP_PORT)` with no TLS and no auth and should only be run on a trusted network.
  - Uses `$(CURDIR)` (not `$(PWD)`) for `DEV_DATA_DIR` and `clean-dev` so recipes are safe under `make -C` and in environments where `PWD` is unset.
  - Adds `clean-dev` (wipes `.dev/`) and a self-documenting `help` target (`grep '##'` pattern) so the postures are discoverable.
  - `ios-open` opens `packages/ios/Intent.xcodeproj` after `ensure-ios-submodule`, with a macOS guard (`uname -s` check) and a quoted path so failure modes are explicit on non-macOS hosts and repo paths with spaces are safe.
  - `ios-info` prints the LAN IP via `ipconfig getifaddr en0` with `en1` fallback, notes that the iOS **Manual Connection** sheet (which does support host/port entry) can be used with any placeholder token against `--insecure`, and documents the **secure/Bonjour** alternative (`INTENTD_DISCOVERY=1`, TLS + bearer auth via the **Scan QR Code** / **Find on Network** flows).
- **README.md**
  - `Getting Started` snippet updated to the `dev-daemon` + `run-fe` default flow, mentions `release-daemon` for the release-state debug seat, and points at `make help` / `make ios-open` / `make ios-info`. Describes the dev-daemon TCP listener as reachable from loopback and LAN rather than pinning it to a specific bind address.

## Verification

- `make help` — lists every documented target with descriptions.
- `make -n dev-daemon` — expands to `INTENTD_DATA_DIR=.../intentd INTENTD_TCP_PORT=5181 cargo run … -- serve --listen both --insecure` and echoes the LAN-exposure warning first.
- `make -n release-daemon` — expands to `cargo run … -- serve --listen uds` (no `--insecure`, no `5181` bind).
- `make -n run-intentd` — prints the deprecation notice and then forwards to `release-daemon` via a nested `$(MAKE)` call.
- `make dev-daemon` (against the prebuilt binary from the parent checkout, to avoid a full rebuild in the throwaway worktree) — created `.dev/intentd/{intentd.db,intentd.sock}`, logged `intentd WSS listening port=5181` and `intentd WS listening (insecure, no TLS) port=5181`, `lsof -i :5181 -sTCP:LISTEN` showed `intentd … TCP *:5181 (LISTEN)`, and `curl http://127.0.0.1:5181/` returned `404` from the WSS transport (WebSocket lives at `/ws`). Killed cleanly and `.dev/` cleaned up.
- `make ios-info` — prints correct simulator + LAN host/port lines (LAN IP resolved via `ipconfig getifaddr en0`); no tokens or fingerprints in output.

No submodule gitlink changes — monorepo-only PR.

Task: `intent://local/task/1456caa4-0dd9-428a-ac07-6cf9eb63d27d`
