### PR TITLE
docs(protocol): comment.add accepts idempotencyKey (Audit A F5)

### DIFF
--- a/docs/00_initial_porting/PROTOCOL.md
+++ b/docs/00_initial_porting/PROTOCOL.md
@@ -471,7 +471,7 @@ each recompute so the read path is O(1) and survives restart. `note.delete` casc
 
 | Method | Params | Result |
 | --- | --- | --- |
-| comment.add | noteId (req), searchContext (req), commentTarget (req), comment (req), type?, author? | { ok, ... } (anchors by text search) |
+| comment.add | noteId (req), searchContext (req), commentTarget (req), comment (req), type?, author?, idempotencyKey? | { ok, ... } (anchors by text search). A replay with the same `(workspaceId, idempotencyKey)` returns the stored result without re-executing (no duplicate comment, no second `comment:added`); empty/whitespace-only keys are treated as absent. |
 | comment.list | noteId (req), since?, authorType?, status?, includeComments? | { threads: [...] } |
 | comment.getThread | noteId (req), threadId? or commentId? | { thread } |
 | comment.respond | noteId (req), comment (req), threadId?/commentId?, type?, author?, suggestionOriginal?, suggestionProposed? | { ok, ... } |


### PR DESCRIPTION
## Summary

Docs-only: updates the `comment.add` row in PROTOCOL.md §5.3 to document the
optional `idempotencyKey` param shipped in
[cloudlands-ai/intentd#116](https://github.com/cloudlands-ai/intentd/pull/116)
(merged as `6d0d8bf`).

Semantics documented in the row:
- A replay with the same `(workspaceId, idempotencyKey)` returns the stored
  result without re-executing — no duplicate comment, no second
  `comment:added` event.
- Empty/whitespace-only keys are treated as absent at the router boundary.

No other PROTOCOL rows are touched (the `git.discard` change owns its own row
in a separate PR).
