### PR TITLE
docs(protocol): document comment anchor resilience + isOrphaned wire field

### DIFF
--- a/docs/00_initial_porting/PROTOCOL.md
+++ b/docs/00_initial_porting/PROTOCOL.md
@@ -477,6 +477,21 @@ each recompute so the read path is O(1) and survives restart. `note.delete` casc
 | comment.respond | noteId (req), comment (req), threadId?/commentId?, type?, author?, suggestionOriginal?, suggestionProposed? | { ok, ... } |
 | comment.delete | noteId (req), commentId (req) | { ok, ... } |
 
+**Anchor resilience on note edits (Audit D H1+M1).** `comment.add` embeds
+`<!--anchor:{commentId}:start-->` / `<!--anchor:{commentId}:end-->` markers into the
+note markdown around the anchored span, and captures up to 50 characters of
+surrounding text as `anchorBefore` / `anchorAfter` on the persisted comment
+(reference `extractAnchoredText` in `markdown-anchor-recovery.ts`). Every
+content-changing `note.*` mutation (`note.update`, `note.add`, `note.edit`,
+`note.editLines`, `note.setContent`) then runs the rewritten markdown through a
+recovery pass before persist: healthy anchors are left alone; partial anchors
+(only one marker surviving) are relocated using the stored `anchorBefore` /
+`anchorAfter` context; unrecoverable and degenerate anchors have their stray
+markers scrubbed from the persisted content and the comment is flipped to
+`isOrphaned: true`. Comments in the wire `Comment` shape carry an optional
+`isOrphaned: bool` field (omitted when unset, `true` for orphaned comments,
+`false` explicitly when a previously-orphaned comment heals).
+
 **`comment.*` extensions (new in intentd — additive; do not change the ported count of 5).** One additional method addresses an entire thread by `threadId` **or** `commentId`. Emits the `comment:resolved` event (§6.5).
 
 | Method | Params | Result |


### PR DESCRIPTION
Follow-up docs PR to [intentd#117](https://github.com/cloudlands-ai/intentd/pull/117) (`feat(intent-services): comment anchor resilience on note edits (Audit D H1+M1)`, merged at `f5399d9`).

## What

Adds an additive paragraph to §5.3 `comment.*` in `docs/00_initial_porting/PROTOCOL.md` that documents:

- **M1** — `comment.add` captures up to 50 chars of surrounding text as `anchorBefore` / `anchorAfter` on the persisted comment when embedding the `<!--anchor:{id}:start-->` / `<!--anchor:{id}:end-->` markers.
- **H1** — every content-changing `note.*` mutation (`note.update`, `note.add`, `note.edit`, `note.editLines`, `note.setContent`) runs the rewritten markdown through a recovery pass before persist: healthy anchors are untouched; partial anchors are relocated using the stored `anchorBefore` / `anchorAfter` context; unrecoverable / degenerate anchors have their stray markers scrubbed from the persisted content and the comment is flipped to `isOrphaned: true`.
- The new optional `isOrphaned: bool` field on the wire `Comment` shape (omitted when unset).

## Scope

Docs-only. Only fields owned by intentd#117 are touched — the `comment.add` idempotency-key row belongs to intentd#116 and is left alone. No submodule bump.
