### PR TITLE
docs: close out 00_initial_porting and scaffold 01_stabilizing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,9 +83,10 @@ current.
 - **Accuracy**: file issues as you encounter them; update status when PRs land. Known
   issues should reflect the current state of the app.
 
-Issue-tracker edits are docs-only and follow the same conventional-commit / PR conventions
-above (use a `docs:` or `fix:` commit as appropriate). They typically ship in the monorepo
-PR that bumps the submodule containing the fix.
+Issue-tracker edits follow the same conventional-commit / PR conventions above. When the
+KNOWN_ISSUES.md update is standalone (documenting a newly-discovered bug), use a `docs:`
+commit. When the tracker update rides along in the same PR as the actual code fix (marking
+an issue fixed), the PR/commit type follows the code change (`fix:`, `feat:`, etc.).
 
 ## Terminology
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,12 +47,13 @@ When changes span a submodule and the monorepo, follow this sequence: Phase 1 �
   green in `packages/intentd` before opening a PR. The **monorepo-root** `Makefile` exposes
   `make check` and `make test`, which run those checks against `packages/intentd`.
 
-## Breadcrumbs (initial porting)
+## Breadcrumbs (initial porting) — **CONCLUDED**
 
-For the duration of the **`00_initial_porting`** effort — the initial port of Intent's
-backend to the Rust daemon (`intentd`) — keep the breadcrumb trail at
-`docs/00_initial_porting/BREADCRUMBS.md` current.
+The **`00_initial_porting`** effort is complete as of 2026-07-13.
+`docs/00_initial_porting/BREADCRUMBS.md` is now **frozen** as a historical record. No
+new breadcrumb entries should be added to that file.
 
+The policy was:
 - **When**: whenever you complete a meaningful unit of porting work (a crate, a method or
   group of methods, a transport/persistence change, a submodule bump).
 - **What**: append a dated entry to the changelog, newest first. Keep it concise — what
@@ -61,12 +62,30 @@ backend to the Rust daemon (`intentd`) — keep the breadcrumb trail at
   change, and move items out of "Deferred / planned" as they ship.
 - **Accuracy**: never overstate. Only list surface that is actually implemented; everything
   else stays under deferred/planned.
-- **Scope**: this policy applies only until the initial Rust-BE port is complete; it does
-  not extend to later efforts.
 
-Breadcrumb edits are docs-only and follow the same conventional-commit / PR conventions
-above (use a `docs:` commit). They typically ship in the monorepo PR that bumps the
-submodule, so the recorded HEAD matches the gitlink.
+Breadcrumb edits were docs-only and followed the same conventional-commit / PR conventions
+(using a `docs:` commit). They typically shipped in the monorepo PR that bumped the
+submodule, so the recorded HEAD matched the gitlink.
+
+## Known Issues (stabilization)
+
+For the **`01_stabilizing`** phase — ongoing stabilization and hardening on the
+self-hosted stack — keep the issue tracker at `docs/01_stabilizing/KNOWN_ISSUES.md`
+current.
+
+- **When to file**: whenever you discover a bug while dogfooding (using intentd +
+  cloudlands-fe for daily development work).
+- **What to file**: document with id `STAB-N`, date (YYYY-MM-DD), area
+  (component/subsystem), severity (P0 crash/data-loss, P1 broken feature, P2 papercut),
+  repro steps, and status (`open` | `fixed (PR link, date)`).
+- **When to update**: when you fix an issue, mark it fixed with the PR link and resolution
+  date.
+- **Accuracy**: file issues as you encounter them; update status when PRs land. Known
+  issues should reflect the current state of the app.
+
+Issue-tracker edits are docs-only and follow the same conventional-commit / PR conventions
+above (use a `docs:` or `fix:` commit as appropriate). They typically ship in the monorepo
+PR that bumps the submodule containing the fix.
 
 ## Terminology
 

--- a/docs/00_initial_porting/BREADCRUMBS.md
+++ b/docs/00_initial_porting/BREADCRUMBS.md
@@ -1,5 +1,11 @@
 # Initial Porting — Breadcrumbs
 
+---
+**EFFORT CLOSED AS OF 2026-07-13**
+
+This file is now **frozen** as a historical record. The initial port is complete — development has moved onto the self-hosted stack (intentd + cloudlands-fe building the next version of themselves). See [docs/01_stabilizing/](../01_stabilizing/) for ongoing stabilization work.
+---
+
 A living progress log for the **initial port of Intent's backend to a headless Rust daemon** (`intentd`). This is the durable trail future agents read first to understand where the port stands, and append to as work lands.
 
 See also: [IMPLEMENTATION_SPEC.md](./IMPLEMENTATION_SPEC.md) (target architecture), [PROTOCOL.md](./PROTOCOL.md) (wire contract), and the root [AGENTS.md](../../AGENTS.md) (workflow + breadcrumb-update policy).
@@ -112,6 +118,22 @@ Port Intent's backend to a standalone, headless Rust daemon (`intentd`) speaking
 - The entire frontend (Tauri/Svelte).
 
 ## Milestone history
+
+### 2026-07-13 — **00_initial_porting effort CLOSED: self-hosting cutover milestone reached**
+
+The initial port is complete. **Self-hosting cutover achieved**: the 00_initial_porting effort was built entirely with the reference app (`augmentcode/intent`); as of this close-out, development moves onto intentd + cloudlands-fe itself — the IDE now builds the next version of the IDE.
+
+**Final submodule HEADs:**
+- `packages/intentd` @ `ea2d237` (intentd PR #121 `fix: store empty title for untitled workspaces (Untitled parity)`)
+- `packages/cloudlands-fe` @ `caf3e5f5` (cloudlands-fe PR #34 `fix: make dev sidecar — connect over UDS and resolve the binary reliably`)
+
+**Implemented surface summary:** 218 JSON-RPC request methods + 1 server-initiated notification over UDS and WSS, backed by SQLite — full CRUD across workspace/note/task/comment/agent domains; the recent-repository registry; event query/aggregation and snapshot+delta subscriptions; local git operations (status/stage/commit/agentCommit/pull/discard); GitHub PR linking and the full `pr.*` + `github.*` + `linear.*` + `sentry.*` surfaces; code-review change-tracking, metrics, and accept-changes orchestration; ripgrep/symbol-backed search across files/notes/messages/events; interactive terminals and managed scripts on a unified PTY host; settings persistence with secret redaction; specialist + rules CRUD; MCP-server lifecycle management (stdio only); workspace-file CRUD; note primitives; cross-workspace sibling reads; client-callable `browser.exec` reverse RPC; the full ACP orchestration layer with agent session persistence, live MCP spawn-wiring, and a per-agent-type tool denylist; workspace activity/attention status model; locality detection and remote-only mitigations (`forward.*` tunnels, `host.openExternal` reverse RPC); data migration (`intentd import`) and event retention sweeps; and a hermetic mock ACP provider + E2E transport/lifecycle suite. The daemon serves both UDS and WSS transports with bearer-token auth, origin allow-list, TLS fingerprint pinning, mDNS discovery, single-instance enforcement, idle agent reaping, CLI control (`intentd serve/status/stop/doctor`), and launchd/systemd daemonization. The FE `make dev` sidecar connects over UDS and resolves the binary reliably; workspace reads cut over to daemon `workspace.list`/`workspace.get`. See the "Implemented surface so far" section for the full catalog.
+
+**Unresolved deferrals carried into 01_stabilizing:** Transport panic-safety via `catch_unwind`, and general stabilization/hardening work. All known issues and planned follow-ups are documented in `docs/01_stabilizing/KNOWN_ISSUES.md`.
+
+This file is now frozen as a historical record. Future work is tracked in `docs/01_stabilizing/`.
+
+---
 
 ### 2026-07-13 — `make dev` sidecar: UDS connect + reliable binary resolution; FE workspace read-path cut-over to daemon (cloudlands-fe PRs #34 + #35 merged; monorepo Makefile `dev` target exports `INTENTD_BIN` + `INTENTD_DATA_DIR`)
 

--- a/docs/00_initial_porting/BREADCRUMBS.md
+++ b/docs/00_initial_porting/BREADCRUMBS.md
@@ -3,7 +3,7 @@
 ---
 **EFFORT CLOSED AS OF 2026-07-13**
 
-This file is now **frozen** as a historical record. The initial port is complete — development has moved onto the self-hosted stack (intentd + cloudlands-fe building the next version of themselves). See [docs/01_stabilizing/](../01_stabilizing/) for ongoing stabilization work.
+This file is now **frozen** as a historical record. The initial port is complete — development has moved onto the self-hosted stack (intentd + cloudlands-fe building the next version of itself). See [docs/01_stabilizing/](../01_stabilizing/) for ongoing stabilization work.
 ---
 
 A frozen historical record of the **initial port of Intent's backend to a headless Rust daemon** (`intentd`). This is the durable trail that documents how the port progressed; no further appends will be made. New work is tracked in [docs/01_stabilizing/](../01_stabilizing/).

--- a/docs/00_initial_porting/BREADCRUMBS.md
+++ b/docs/00_initial_porting/BREADCRUMBS.md
@@ -6,7 +6,7 @@
 This file is now **frozen** as a historical record. The initial port is complete — development has moved onto the self-hosted stack (intentd + cloudlands-fe building the next version of themselves). See [docs/01_stabilizing/](../01_stabilizing/) for ongoing stabilization work.
 ---
 
-A living progress log for the **initial port of Intent's backend to a headless Rust daemon** (`intentd`). This is the durable trail future agents read first to understand where the port stands, and append to as work lands.
+A frozen historical record of the **initial port of Intent's backend to a headless Rust daemon** (`intentd`). This is the durable trail that documents how the port progressed; no further appends will be made. New work is tracked in [docs/01_stabilizing/](../01_stabilizing/).
 
 See also: [IMPLEMENTATION_SPEC.md](./IMPLEMENTATION_SPEC.md) (target architecture), [PROTOCOL.md](./PROTOCOL.md) (wire contract), and the root [AGENTS.md](../../AGENTS.md) (workflow + breadcrumb-update policy).
 

--- a/docs/00_initial_porting/BREADCRUMBS.md
+++ b/docs/00_initial_porting/BREADCRUMBS.md
@@ -3,7 +3,7 @@
 ---
 **EFFORT CLOSED AS OF 2026-07-13**
 
-This file is now **frozen** as a historical record. The initial port is complete — development has moved onto the self-hosted stack (intentd + cloudlands-fe building the next version of itself). See [docs/01_stabilizing/](../01_stabilizing/) for ongoing stabilization work.
+This file is now **frozen** as a historical record. The initial port is complete — development has moved onto the self-hosted Cloudlands stack (`intentd` + `cloudlands-fe`), which now builds the next version of itself. See [docs/01_stabilizing/](../01_stabilizing/) for ongoing stabilization work.
 ---
 
 A frozen historical record of the **initial port of Intent's backend to a headless Rust daemon** (`intentd`). This is the durable trail that documents how the port progressed; no further appends will be made. New work is tracked in [docs/01_stabilizing/](../01_stabilizing/).
@@ -121,7 +121,7 @@ Port Intent's backend to a standalone, headless Rust daemon (`intentd`) speaking
 
 ### 2026-07-13 — **00_initial_porting effort CLOSED: self-hosting cutover milestone reached**
 
-The initial port is complete. **Self-hosting cutover achieved**: the 00_initial_porting effort was built entirely with the reference app (`augmentcode/intent`); as of this close-out, development moves onto intentd + cloudlands-fe itself — the IDE now builds the next version of the IDE.
+The initial port is complete. **Self-hosting cutover achieved**: the 00_initial_porting effort was built entirely with the reference app (`augmentcode/intent`); as of this close-out, development moves onto the Cloudlands stack (`intentd` + `cloudlands-fe`) itself — the IDE now builds the next version of the IDE.
 
 **Final submodule HEADs:**
 - `packages/intentd` @ `ea2d237` (intentd PR #121 `fix: store empty title for untitled workspaces (Untitled parity)`)

--- a/docs/00_initial_porting/BREADCRUMBS.md
+++ b/docs/00_initial_porting/BREADCRUMBS.md
@@ -8,7 +8,7 @@ This file is now **frozen** as a historical record. The initial port is complete
 
 A frozen historical record of the **initial port of Intent's backend to a headless Rust daemon** (`intentd`). This is the durable trail that documents how the port progressed; no further appends will be made. New work is tracked in [docs/01_stabilizing/](../01_stabilizing/).
 
-See also: [IMPLEMENTATION_SPEC.md](./IMPLEMENTATION_SPEC.md) (target architecture), [PROTOCOL.md](./PROTOCOL.md) (wire contract), and the root [AGENTS.md](../../AGENTS.md) (workflow + breadcrumb-update policy).
+See also: [IMPLEMENTATION_SPEC.md](./IMPLEMENTATION_SPEC.md) (target architecture), [PROTOCOL.md](./PROTOCOL.md) (wire contract), and the root [AGENTS.md](../../AGENTS.md) (workflow + concluded breadcrumb policy, superseded by KNOWN_ISSUES.md tracking for stabilization).
 
 ## Goal
 

--- a/docs/01_stabilizing/KNOWN_ISSUES.md
+++ b/docs/01_stabilizing/KNOWN_ISSUES.md
@@ -1,0 +1,82 @@
+# Known Issues
+
+Live issue tracker for the **01_stabilizing** self-hosting phase.
+
+## Intake Convention
+
+Each issue entry includes:
+
+- **ID** — `STAB-N` sequential numbering
+- **Date** — when discovered (YYYY-MM-DD)
+- **Area** — component/subsystem (e.g., `intentd note persistence`, `cloudlands-fe chat UI`, `ios sync`)
+- **Severity** — P0 (crash/data-loss), P1 (broken feature), P2 (papercut)
+- **Repro** — minimal steps to reproduce
+- **Status** — `open` | `fixed (PR link, date)`
+
+---
+
+## Open Issues
+
+### STAB-1 (2026-07-13, area: intentd note persistence, severity: P1)
+
+Concurrent note writes fail with JSON-RPC `-32603` `internal error: insert note_version failed: error returned from database: (code: 5) database is locked`.
+
+**Repro:** Issue ~5 parallel `note.edit` or `note.update` calls against different notes in one workspace (e.g., via `Promise.all` in the workspace_api MCP tool). Some writes fail with SQLITE_BUSY surfaced as `-32603`.
+
+**Expected:** Writes are serialized or retried daemon-side (busy_timeout / retry-on-busy), never surfacing SQLITE_BUSY to the client. Sequential retry succeeds.
+
+**Status:** open
+
+---
+
+## Carried Over from 00_initial_porting
+
+These items were genuinely open/deferred in [../00_initial_porting/BREADCRUMBS.md](../00_initial_porting/BREADCRUMBS.md) and remain as stabilization tasks:
+
+### Transport panic-safety
+
+**Area:** intentd transport  
+**Severity:** P1  
+**Description:** Currently relies on per-connection `tokio::spawn` isolation. Should use `catch_unwind` → `-32603` to guarantee a panicked request handler never brings down the daemon or other connections.  
+**Status:** open
+
+### Real auggie e2e in CI
+
+**Area:** intentd CI  
+**Severity:** P2  
+**Description:** A real auggie turn in CI is best-effort/local only (requires auggie + login). The hermetic mock-agent E2E is the CI gate; the generated `--mcp-config` + bridge are auggie-consumable, but CI has no live auggie coverage.  
+**Status:** open (best-effort/local only)
+
+### PR↔workspace matching — branch-only
+
+**Area:** intentd sourcecontrol  
+**Severity:** P2  
+**Description:** PR↔workspace matching is **branch-only** (`head.ref`) vs the reference TS branch-OR-`baseRef` match. This is an accepted deferral from Milestone 4 — Cycle B, but may surface as a papercut if workspaces don't link when expected.  
+**Status:** open (intentional divergence, may revisit)
+
+### `pr.*` single-page reads / capability gating
+
+**Area:** intentd sourcecontrol  
+**Severity:** P2  
+**Description:** `pr.*` reads stay single-page (the separately-addressed `github.*` list reads gained real pagination in Milestone 11). Capability gating is deferred — no runtime detection of whether the active PR supports certain operations.  
+**Status:** open (intentional deferral)
+
+### Agent-Id / Linked-Note-Id commit trailers
+
+**Area:** intentd git  
+**Severity:** P2  
+**Description:** Git commits lack `Agent-Id` and `Linked-Note-Id` trailers (no agent context at the UDS layer yet). Reference TS backend added these trailers for audit/provenance.  
+**Status:** open (intentional deferral from Milestone 4)
+
+### REV-2 — Explicit reverse-dispatch target selection
+
+**Area:** intentd transport  
+**Severity:** P2  
+**Description:** REV-1 first-client-sticky reverse dispatch is an interim single-client policy while an explicit target-selection surface (REV-2 / PROTOCOL §16 client identity) is designed. Agent-initiated `browser.exec` currently goes to the first-connected client only.  
+**Status:** open (design in progress)
+
+---
+
+## Fixed Issues
+
+_(none yet — first fixes will appear here with PR links and resolution dates)_

--- a/docs/01_stabilizing/KNOWN_ISSUES.md
+++ b/docs/01_stabilizing/KNOWN_ISSUES.md
@@ -47,6 +47,16 @@ An open PR whose head branch exactly matches the workspace branch is never linke
 
 **Status:** open
 
+### STAB-4 (2026-07-13, area: intentd agent runtime / chat transcript (queue-flip path), severity: P1)
+
+Messages queued while an agent is mid-turn do not appear in the conversation when they are dequeued and delivered.
+
+**Repro:** Send message A to an agent, then send message B while the agent is still streaming A's turn; after A's turn ends, B's turn starts — B's text is absent from the transcript. Observed while self-hosting: sending a message to a busy agent queues it (expected), but when the current turn ends and the queue-flip loop flips the queued message to in-flight, the delivered user message never shows up in the conversation transcript/UI — the agent acts on it, but the transcript is missing the user message that triggered the turn.
+
+**Expected:** On dequeue, the user message is persisted to the conversation (`agent.getConversation`) and pushed to live subscribers (`chat.subscribe` delta / `agent:stream` events) exactly like a directly-delivered message.
+
+**Status:** open
+
 ---
 
 ## Carried Over from 00_initial_porting

--- a/docs/01_stabilizing/KNOWN_ISSUES.md
+++ b/docs/01_stabilizing/KNOWN_ISSUES.md
@@ -11,7 +11,7 @@ Each issue entry includes:
 - **Area** — component/subsystem (e.g., `intentd note persistence`, `cloudlands-fe chat UI`, `ios sync`)
 - **Severity** — P0 (crash/data-loss), P1 (broken feature), P2 (papercut)
 - **Repro** — minimal steps to reproduce
-- **Status** — `open` | `fixed (PR link, date)`
+- **Status** — `open` or `open (optional note)` | `fixed (PR link, date)`
 
 ---
 

--- a/docs/01_stabilizing/KNOWN_ISSUES.md
+++ b/docs/01_stabilizing/KNOWN_ISSUES.md
@@ -57,6 +57,16 @@ Messages queued while an agent is mid-turn do not appear in the conversation whe
 
 **Status:** open
 
+### STAB-5 (2026-07-13, area: intentd agent events / parent notifications, severity: P2)
+
+A child agent's completion report is re-delivered to the parent agent multiple times.
+
+**Repro:** Delegate a task to a child agent, let it complete and deliver its report, then trigger additional parent wakes (e.g. new user messages) and observe the same completion report re-delivered. Observed while self-hosting: after a delegated implementor completed and its report was delivered and acted upon, the identical "[WORKSPACE EVENTS] Child agent ... completed. Report: ..." message was delivered to the coordinator again on two subsequent turns, hours of activity later, as if the completion event was never acknowledged/marked consumed.
+
+**Expected:** A child-completion notification is delivered to the parent exactly once (or is idempotently deduplicated); already-consumed completion events are not replayed on later wakes.
+
+**Status:** open
+
 ---
 
 ## Carried Over from 00_initial_porting

--- a/docs/01_stabilizing/KNOWN_ISSUES.md
+++ b/docs/01_stabilizing/KNOWN_ISSUES.md
@@ -27,6 +27,16 @@ Concurrent note writes fail with JSON-RPC `-32603` `internal error: insert note_
 
 **Status:** open
 
+### STAB-2 (2026-07-13, area: cloudlands-fe UI — workspace timeline/feed, severity: P2)
+
+The "workspace start" indicator renders at the bottom of the workspace view instead of marking the chronological beginning of the workspace.
+
+**Repro:** Open a workspace with multiple activity items and locate the workspace start indicator. Observed while self-hosting: in a workspace whose first activity was the "Scaffold docs/01_stabilizing" work, the start indicator appeared way down at the bottom of the feed rather than at the top where the workspace began.
+
+**Expected:** The indicator anchors the beginning of the workspace (before/at the first item), regardless of feed ordering.
+
+**Status:** open
+
 ---
 
 ## Carried Over from 00_initial_porting

--- a/docs/01_stabilizing/KNOWN_ISSUES.md
+++ b/docs/01_stabilizing/KNOWN_ISSUES.md
@@ -37,6 +37,16 @@ The "workspace start" indicator renders at the bottom of the workspace view inst
 
 **Status:** open
 
+### STAB-3 (2026-07-13, area: intentd PR↔workspace linking, severity: P1)
+
+An open PR whose head branch exactly matches the workspace branch is never linked to the workspace.
+
+**Repro:** In a workspace on branch X, file a PR with head X via `gh`, wait >2 minutes, call `pr.status`. Observed while self-hosting: monorepo PR #98 was filed with head branch `any-fix` for the workspace on branch `any-fix`; well beyond several 60s background-refresh cycles, `pr.status` still returns `-32603` "No active PR", no `pr:linked` event is emitted, and the FE PR panel keeps showing "Create PR" instead of the open PR.
+
+**Expected:** The 60s background + on-demand PR refresh matches the PR by `head.ref` (branch-only matching per BREADCRUMBS Milestone 4 Cycle B), persists `activePullRequest`/`prStatus`, emits `pr:linked`, and the `pr.*` surface + FE PR panel reflect the open PR.
+
+**Status:** open
+
 ---
 
 ## Carried Over from 00_initial_porting

--- a/docs/01_stabilizing/STABILIZATION.md
+++ b/docs/01_stabilizing/STABILIZATION.md
@@ -4,7 +4,7 @@ Self-hosted development — stabilize the forked app while using it for daily wo
 
 ## Goal + Self-Hosting Premise
 
-**00_initial_porting** was developed entirely with the reference app (`augmentcode/intent`). **01_stabilizing** is the **self-hosting phase** — `intentd` + `cloudlands-fe` is now the development environment used to build the next version of itself.
+**00_initial_porting** was developed entirely with the reference app (`augmentcode/intent`). **01_stabilizing** is the **self-hosting phase** — the Cloudlands stack (`intentd` + `cloudlands-fe`) is now the development environment used to build the next version of itself.
 
 Stabilize the forked app while running it for all daily work. Bugs found while self-hosting are the primary work source, and every fix shipped through the app is itself a validation of the app.
 

--- a/docs/01_stabilizing/STABILIZATION.md
+++ b/docs/01_stabilizing/STABILIZATION.md
@@ -1,0 +1,61 @@
+# Stabilization
+
+Self-hosted development — stabilize the forked app while using it for daily work.
+
+## Goal + Self-Hosting Premise
+
+**00_initial_porting** was developed entirely with the reference app (`augmentcode/intent`). **01_stabilizing** is the **self-hosting phase** — `intentd` + `cloudlands-fe` is now the development environment used to build the next version of itself.
+
+Stabilize the forked app while running it for all daily work. Bugs found while self-hosting are the primary work source, and every fix shipped through the app is itself a validation of the app.
+
+## Process — The Dogfooding Loop
+
+Observe a bug → file it in [`KNOWN_ISSUES.md`](./KNOWN_ISSUES.md) with a repro → triage (P0 crash/data-loss, P1 broken feature, P2 papercut) → fix in the owning submodule via the standard Phase 1/Phase 2 PR workflow → mark fixed with the PR link.
+
+1. **Discover** — encounter a bug while dogfooding (self-hosted planning, delegation, fixes, PRs)
+2. **File** — document in KNOWN_ISSUES.md with id `STAB-N`, date, area, severity, repro, status
+3. **Triage** — severity determines urgency:
+   - **P0** — crash, data-loss, or corruption; blocks shipping to external users
+   - **P1** — broken feature; app still usable but with significant workaround required
+   - **P2** — papercut; annoying but does not block workflows
+4. **Fix** — land via the standard commit/PR workflow (Phase 1 → Phase 2):
+   - Phase 1: scoped commits in the owning submodule (intentd / cloudlands-fe / ios) on a feature branch → push → file PR → merge (squash merge preferred)
+   - Phase 2: pull latest main in the updated submodule → stage the submodule ref change in the monorepo → commit → push → file monorepo PR → merge
+5. **Close** — mark fixed in KNOWN_ISSUES.md with the PR link and resolution date
+
+## Fix Conventions
+
+- Fixes land as **`fix:`** conventional-commit PRs in the owning repo (`intent-hq/intentd`, `intent-hq/cloudlands-fe`, `intent-hq/ios`)
+- **Regression coverage** expected with each fix:
+  - **intentd**: `make check` + `make test` green
+  - **cloudlands-fe**: `pnpm run check` + `pnpm vitest run` green
+  - **ios**: build + test targets passing
+- Prefer minimal, focused fixes over refactors — address the reported issue directly
+- Document the fix in the submodule PR description with a link back to the KNOWN_ISSUES.md entry
+
+## Exit Criteria — Public Release Readiness
+
+The app is ready for **public release** when:
+
+- **No open P0/P1 issues** — all crashes, data-loss, and broken-feature bugs are resolved
+- **Sustained self-hosted development** — the team uses the app for planning, delegation, fixes, and PRs without falling back to the reference app (`augmentcode/intent`) or other IDEs for any workflow
+- **No shipping blockers** — no known issues that would prevent releasing the app to external users with confidence
+
+## Non-Goals
+
+This phase is stabilization only. Not in scope:
+
+- **New features** — no net-new capabilities beyond what 00_initial_porting delivered
+- **Further protocol expansion** — the JSON-RPC surface is frozen unless a bug fix requires a method addition
+- **Remote/iOS feature work** — bug fixes only; no new remote-workspace capabilities or iOS features (WSS-over-SSH and iOS companion-app polish are deferred to later efforts)
+- **Performance optimization** — unless performance is a P0/P1 blocker (e.g., UI freezes, 10s+ operation latencies)
+
+## Tracking
+
+All issues are tracked in [`KNOWN_ISSUES.md`](./KNOWN_ISSUES.md) in this directory.
+
+See also:
+- [00_initial_porting/BREADCRUMBS.md](../00_initial_porting/BREADCRUMBS.md) — the initial port's progress log (read-only; no new breadcrumbs entries during 01_stabilizing)
+- [00_initial_porting/IMPLEMENTATION_SPEC.md](../00_initial_porting/IMPLEMENTATION_SPEC.md) — the target architecture
+- [00_initial_porting/PROTOCOL.md](../00_initial_porting/PROTOCOL.md) — the wire contract
+- [../README.md](../README.md) — documentation index

--- a/docs/README.md
+++ b/docs/README.md
@@ -38,7 +38,7 @@ itself.
 
 Documents for the **ongoing stabilization and hardening phase**, post-initial-port.
 Development now happens on the self-hosted stack (intentd + cloudlands-fe building the
-next version of themselves).
+next version of itself).
 
 - **[STABILIZATION.md](./01_stabilizing/STABILIZATION.md)** — the **dogfooding process**:
   how bugs are discovered, filed, triaged, fixed, and closed; fix conventions; and the
@@ -50,5 +50,8 @@ next version of themselves).
 
 ## Workflow
 
-For the agent commit/PR workflow — and the policy requiring breadcrumbs to be kept
-current — see the root [AGENTS.md](../AGENTS.md).
+For the agent commit/PR workflow and stabilization issue tracking, see the root
+[AGENTS.md](../AGENTS.md). The Known Issues tracker at
+[docs/01_stabilizing/KNOWN_ISSUES.md](./01_stabilizing/KNOWN_ISSUES.md) is the live
+progress record; breadcrumbs in [docs/00_initial_porting/](./00_initial_porting/) are
+frozen historical records from the concluded initial-porting effort.

--- a/docs/README.md
+++ b/docs/README.md
@@ -45,8 +45,8 @@ which now builds the next version of itself.
   exit criteria for public release readiness.
 - **[KNOWN_ISSUES.md](./01_stabilizing/KNOWN_ISSUES.md)** — the **live issue tracker**:
   all open bugs discovered during self-hosting, with severity (P0/P1/P2), repro steps,
-  and status. Agents update this file when bugs are found or resolved, following the same
-  docs-only conventional-commit conventions.
+  and status. Agents update this file when bugs are found or resolved, following the
+  conventional-commit conventions in AGENTS.md.
 
 ## Workflow
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,8 +30,9 @@ was reproduced, and the **breadcrumbs** are the frozen record of how the port pr
 current work is tracked in [docs/01_stabilizing/KNOWN_ISSUES.md](./01_stabilizing/KNOWN_ISSUES.md).
 
 **Self-hosting cutover achieved**: the 00_initial_porting effort was built entirely with
-the reference app (`augmentcode/intent`); as of 2026-07-13, development moves onto intentd
-+ cloudlands-fe itself — the IDE now builds the next version of the IDE.
+the reference app (`augmentcode/intent`); as of 2026-07-13, development moves onto the
+Cloudlands stack (`intentd` + `cloudlands-fe`) — the IDE now builds the next version of
+itself.
 
 ## `01_stabilizing/`
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,8 +25,9 @@ Supporting documents:
 - **[WSS_OVER_SSH.md](./00_initial_porting/WSS_OVER_SSH.md)** — the surviving FE SSH
   surface and the WSS-over-SSH transport shape for future remote workspaces.
 
-In short: the **spec** is where we're going, the **protocol** is the contract we must
-honor, and the **breadcrumbs** are where we are right now.
+In short: the **spec** was the target architecture, the **protocol** is the contract that
+was reproduced, and the **breadcrumbs** are the frozen record of how the port progressed;
+current work is tracked in [docs/01_stabilizing/KNOWN_ISSUES.md](./01_stabilizing/KNOWN_ISSUES.md).
 
 **Self-hosting cutover achieved**: the 00_initial_porting effort was built entirely with
 the reference app (`augmentcode/intent`); as of 2026-07-13, development moves onto intentd

--- a/docs/README.md
+++ b/docs/README.md
@@ -37,8 +37,8 @@ itself.
 ## `01_stabilizing/`
 
 Documents for the **ongoing stabilization and hardening phase**, post-initial-port.
-Development now happens on the self-hosted stack (intentd + cloudlands-fe building the
-next version of itself).
+Development now happens on the self-hosted Cloudlands stack (`intentd` + `cloudlands-fe`),
+which now builds the next version of itself.
 
 - **[STABILIZATION.md](./01_stabilizing/STABILIZATION.md)** — the **dogfooding process**:
   how bugs are discovered, filed, triaged, fixed, and closed; fix conventions; and the

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,10 +2,11 @@
 
 Index of the `docs/` tree for the Cloudlands monorepo.
 
-## `00_initial_porting/`
+## `00_initial_porting/` — **COMPLETE / FROZEN**
 
 Documents for the **initial port of Intent's backend to a headless Rust daemon**
-(`intentd`). Three core documents work together:
+(`intentd`). This effort is **complete as of 2026-07-13** and the documents are now
+**frozen** as historical records. Three core documents work together:
 
 - **[IMPLEMENTATION_SPEC.md](./00_initial_porting/IMPLEMENTATION_SPEC.md)** — the
   **target architecture**: crates/modules, persistence, ACP/GitHub/context integration,
@@ -13,9 +14,8 @@ Documents for the **initial port of Intent's backend to a headless Rust daemon**
 - **[PROTOCOL.md](./00_initial_porting/PROTOCOL.md)** — the **wire contract**: transport,
   the JSON-RPC 2.0 envelope, the full method catalog, events, the permission flow, and
   error codes the backend must reproduce.
-- **[BREADCRUMBS.md](./00_initial_porting/BREADCRUMBS.md)** — the **living progress log**:
-  what has actually been built so far, what is deferred/planned, the current submodule
-  HEAD, and a dated changelog that agents append to as work lands.
+- **[BREADCRUMBS.md](./00_initial_porting/BREADCRUMBS.md)** — the **progress log**
+  (frozen): what was built, the final submodule HEADs, and the dated changelog.
 
 Supporting documents:
 
@@ -27,6 +27,24 @@ Supporting documents:
 
 In short: the **spec** is where we're going, the **protocol** is the contract we must
 honor, and the **breadcrumbs** are where we are right now.
+
+**Self-hosting cutover achieved**: the 00_initial_porting effort was built entirely with
+the reference app (`augmentcode/intent`); as of 2026-07-13, development moves onto intentd
++ cloudlands-fe itself — the IDE now builds the next version of the IDE.
+
+## `01_stabilizing/`
+
+Documents for the **ongoing stabilization and hardening phase**, post-initial-port.
+Development now happens on the self-hosted stack (intentd + cloudlands-fe building the
+next version of themselves).
+
+- **[STABILIZATION.md](./01_stabilizing/STABILIZATION.md)** — the **dogfooding process**:
+  how bugs are discovered, filed, triaged, fixed, and closed; fix conventions; and the
+  exit criteria for public release readiness.
+- **[KNOWN_ISSUES.md](./01_stabilizing/KNOWN_ISSUES.md)** — the **live issue tracker**:
+  all open bugs discovered during self-hosting, with severity (P0/P1/P2), repro steps,
+  and status. Agents update this file when bugs are found or resolved, following the same
+  docs-only conventional-commit conventions.
 
 ## Workflow
 


### PR DESCRIPTION
Docs-only. Closes the initial-porting effort and stands up the stabilization phase.

## What

- BREADCRUMBS.md: CLOSED/frozen status banner + final dated close-out entry. The entry leads with the defining milestone: 00_initial_porting was built entirely with the reference app (augmentcode/intent); from 01 onward, the Cloudlands stack (intentd + cloudlands-fe) is itself the development environment (the IDE builds the next version of the IDE). Records final submodule HEADs (packages/intentd @ ea2d237, packages/cloudlands-fe @ caf3e5f5) and points unresolved deferrals at docs/01_stabilizing/KNOWN_ISSUES.md. The intro paragraph was rewritten to reflect the frozen/read-only status; all historical log entries are unchanged.
- docs/README.md: 00_initial_porting marked complete/frozen; 01_stabilizing section added; workflow pointer updated to the stabilization tracking policy.
- AGENTS.md: the 00 breadcrumb policy is concluded; the successor policy for 01_stabilizing is keeping docs/01_stabilizing/KNOWN_ISSUES.md current (file bugs with repro, update status, record the fixing PR; standalone tracker edits use docs:, tracker updates riding a code-fix PR follow the code change type).
- docs/01_stabilizing/STABILIZATION.md (new): self-hosting premise, dogfooding loop (observe -> file -> triage P0/P1/P2 -> fix via the standard submodule PR workflow -> mark fixed), fix conventions, and public-release exit criteria (no open P0/P1, sustained self-hosted development, nothing blocking an external ship).
- docs/01_stabilizing/KNOWN_ISSUES.md (new): STAB-N intake convention; 6 carried-over open hardening items from BREADCRUMBS; five issues seeded from self-hosted dogfooding during this PR's development: STAB-1 (SQLITE_BUSY on concurrent note writes, P1), STAB-2 (workspace-start indicator placement, P2), STAB-3 (PR-workspace linking failure, P1), STAB-4 (dequeued messages missing from transcript, P1), STAB-5 (duplicate child-completion reports, P2).

## Verification

- Independently verified: docs-only diff (no submodule gitlink changes), historical BREADCRUMBS entries untouched (intro/banner edits only), carry-over items each match a genuinely-open BREADCRUMBS line, cross-links resolve, no coordinator-internal terminology.

No submodule PRs — monorepo docs only.