### PR TITLE
docs: document merge-queue squash-message pitfall in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,13 @@ When changes span a submodule and the monorepo, follow this sequence: Phase 1 â†
 - **Conventional commits** are required. PR titles are validated by CI
   (`amannn/action-semantic-pull-request`) against: `feat`, `fix`, `chore`, `docs`,
   `refactor`, `test`, `ci`, `perf`.
+- **Merge queue**: `intent-hq/monorepo` main branch uses a merge queue. Do NOT use
+  `gh pr merge --squash` (it will be rejected). Instead, enqueue PRs via GraphQL:
+  `gh api graphql -f query='mutation($id: ID!) { enqueuePullRequest(input: {pullRequestId: $id}) { mergeQueueEntry { position state } } }' -f id="$(gh pr view N --json id --jq .id)"`.
+  **Critical**: the queue's squash message defaults to the sole commit's message, NOT the
+  PR title. On single-commit PRs, ensure every branch commit message is itself a valid
+  conventional commit (amend auto-commits like "Coordinator" before pushing) to prevent
+  non-conventional commits from landing on main (e.g., PR #102 incident).
 - **Changelogs** are generated with `git-cliff` (see `cliff.toml`).
 - **Rust**: keep `cargo fmt --check`, `cargo clippy -- -D warnings`, and `cargo build`
   green in `packages/intentd` before opening a PR. The **monorepo-root** `Makefile` exposes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,7 @@ When changes span a submodule and the monorepo, follow this sequence: Phase 1 â†
   `refactor`, `test`, `ci`, `perf`.
 - **Merge queue**: `intent-hq/monorepo` main branch uses a merge queue. Do NOT use
   `gh pr merge --squash` (it will be rejected). Instead, enqueue PRs via GraphQL:
-  `gh api graphql -f query='mutation($id: ID!) { enqueuePullRequest(input: {pullRequestId: $id}) { mergeQueueEntry { position state } } }' -f id="$(gh pr view N --json id --jq .id)"`.
+  `gh api graphql -f query='mutation($id: ID!) { enqueuePullRequest(input: {pullRequestId: $id}) { mergeQueueEntry { position state } } }' -f id="$(gh pr view <PR_NUMBER> --json id --jq .id)"`.
   **Critical**: the queue's squash message defaults to the sole commit's message, NOT the
   PR title. On single-commit PRs, ensure every branch commit message is itself a valid
   conventional commit (amend auto-commits like "Coordinator" before pushing) to prevent


### PR DESCRIPTION
Documents the merge-queue squash-message pitfall discovered in PR #102.

## Background
PR #102 was a single-commit branch whose commit message was auto-generated as "Coordinator". The PR title was the correct conventional message ("chore: update cloudlands-fe submodule to latest main"), but intent-hq/monorepo main uses a merge queue that defaults the squash commit message to the sole commit's message — NOT the PR title. Result: main now has a non-conventional commit "Coordinator (#102)" that git-cliff can't classify.

## Changes
- Documents that intent-hq/monorepo uses a merge queue and the correct GraphQL mutation to enqueue PRs
- Warns that single-commit PRs must have valid conventional commit messages on every branch commit
- References the PR #102 incident as a concrete example

This ensures future agents avoid the same pitfall.
