### PR TITLE
docs: mark STAB-8 fixed (intent-hq/intentd#148, 2026-07-14)

### DIFF
--- a/docs/01_stabilizing/KNOWN_ISSUES.md
+++ b/docs/01_stabilizing/KNOWN_ISSUES.md
@@ -99,7 +99,7 @@ Delegated agents stall: initial prompt never runs / agents go idle mid-flow.
 
 **Expected:** A delegated agent starts running its initial prompt immediately after creation, and either completes its task or reports a blocker; no silent stalls.
 
-**Status:** open
+**Status:** fixed (intent-hq/intentd#148, 2026-07-14)
 
 ### STAB-10 (2026-07-14, area: cloudlands-fe workspace context — git config still FS-backed, severity: P2)
 


### PR DESCRIPTION
Evidence-driven close for STAB-8 (delegated agents stalling).

## Evidence

1. **Root cause identified**: STAB-8 symptoms (agents stalling mid-flow, completion watches not firing) match the bug fixed in intent-hq/intentd#148 (STAB-28). When agents were interrupted, the worker was aborted before emitting agent:idle events, causing completion watches to never fire and leaving parent agents stuck waiting.

2. **Fix merged**: PR #148 was merged on 2026-07-14 at 06:38:12 UTC (commit 2faaf363).

3. **Running daemon contains fix**: Current intentd binary at /Users/clement/src/intent/packages/intentd/target/release/intentd was built on 2026-07-14 at 12:01 UTC (after merge) and contains commit 2faaf36 (PR #148).

4. **Post-fix delegations successful**: Multiple agents delegated after 12:01 UTC completed successfully without stalling:
   - agent-ecf73ac7 (12:13:48 - 12:17:27) ✅
   - agent-0fdf5c68 (12:17:34 - 12:49:18) ✅
   - agent-7f0e9358 (12:17:34 - 12:47:19) ✅
   - agent-1afb5a07 (12:49:54 - 12:54:44) ✅

No delegation stalls observed since the fix was deployed.

## Changes

Single-line docs update: marks STAB-8 status as fixed (intent-hq/intentd#148, 2026-07-14) in docs/01_stabilizing/KNOWN_ISSUES.md.