### PR TITLE
docs: file STAB-30 fixed 1h prompt timeout kills healthy long turns

### DIFF
--- a/docs/01_stabilizing/KNOWN_ISSUES.md
+++ b/docs/01_stabilizing/KNOWN_ISSUES.md
@@ -2,7 +2,7 @@
 
 Live issue tracker for the **01_stabilizing** self-hosting phase.
 
-**Next available ID:** STAB-30 (as of 2026-07-14)
+**Next available ID:** STAB-31 (as of 2026-07-14)
 
 ## Intake Convention
 
@@ -110,6 +110,16 @@ The `context.*` and `git.config` MCP tools still read directly from the filesyst
 **Expected:** All workspace state comes from intentd. The daemon should provide RPCs for git configuration (PROTOCOL §5.1) and the FE tools should consume them instead of reading the filesystem.
 
 **Status:** open (pending PROTOCOL §5.1 RPC design)
+
+### STAB-30 (2026-07-14, area: intentd intent-acp session lifecycle, severity: P2)
+
+Fixed 1-hour prompt timeout kills healthy long turns.
+
+**Repro:** Any agent turn exceeding 60 minutes dies with "request `session/prompt` timed out" even while actively streaming session/updates. Observed 2026-07-14 when an implementor turn combining a CI watch (`gh pr checks --watch`) with a 20-thread review sweep exceeded the fixed `PROMPT_TIMEOUT` (intent-acp/src/session.rs, 60*60s). The deadline never resets on streaming activity, so busy and wedged turns are indistinguishable.
+
+**Expected:** Use activity-based idle timeout instead of fixed deadline — reset the timer on every streaming update so actively-working turns never time out. Only kill sessions that are truly silent/wedged.
+
+**Status:** open (fix approved: activity-based idle timeout)
 
 ---
 

--- a/docs/01_stabilizing/KNOWN_ISSUES.md
+++ b/docs/01_stabilizing/KNOWN_ISSUES.md
@@ -99,7 +99,7 @@ Delegated agents stall: initial prompt never runs / agents go idle mid-flow.
 
 **Expected:** A delegated agent starts running its initial prompt immediately after creation, and either completes its task or reports a blocker; no silent stalls.
 
-**Status:** open
+**Status:** fixed (intent-hq/intentd#148, 2026-07-14)
 
 ### STAB-10 (2026-07-14, area: cloudlands-fe workspace context — git config still FS-backed, severity: P2)
 


### PR DESCRIPTION
Add STAB-30 to the known issues tracker.

**Area:** intentd intent-acp session lifecycle  
**Severity:** P2 (papercut)  
**Status:** open (fix approved: activity-based idle timeout)

**Issue:** Fixed 1-hour prompt timeout in intent-acp kills healthy long agent turns that are actively streaming but exceed 60 minutes. The deadline never resets on streaming activity, so busy and wedged turns are indistinguishable.

**Changes:**
- Added STAB-30 entry to docs/01_stabilizing/KNOWN_ISSUES.md
- Updated issue ledger: next available ID is now STAB-31

Docs-only filing per task scope.