### PR TITLE
chore: update intentd submodule to latest main (STAB-7 fix)

### DIFF
--- a/docs/01_stabilizing/KNOWN_ISSUES.md
+++ b/docs/01_stabilizing/KNOWN_ISSUES.md
@@ -89,7 +89,7 @@ Flaky CI test failure: `database is locked` in `workspace_duplicate_provisions_w
 
 **Expected:** e2e tests ride out SQLite write contention (busy_timeout should absorb it); no intermittent `database is locked` failures.
 
-**Status:** open
+**Status:** fixed ([intent-hq/intentd#147](https://github.com/intent-hq/intentd/pull/147), 2026-07-14)
 
 ### STAB-8 (2026-07-13, area: intentd agent runtime / delegation (self-hosted stack), severity: P1)
 


### PR DESCRIPTION
Updates `packages/intentd` to bd25ffe (intent-hq/intentd#147), which eliminates intermittent `SQLITE_BUSY (code: 5) database is locked` failures under CI parallelism.

## Changes

- Bump `packages/intentd` gitlink to bd25ffe
- Mark STAB-7 fixed in `docs/01_stabilizing/KNOWN_ISSUES.md`

## Fix Summary (intentd#147)

Implements bounded whole-transaction retry (up to 10 attempts, ~10s total, jittered backoff) for 4 write transaction paths:
- `delete_workspace`
- `adopt_stray_spec_note`
- `replace_workspace_context_items`
- `replace_agent_messages`

Keeps DEFERRED `.begin()` to preserve read concurrency, but retries the entire transaction on `SQLITE_BUSY` instead of failing immediately. Eliminates lock-upgrade race without BEGIN IMMEDIATE's lock contention.

## Validation

- ✅ intentd CI green (all checks passed)
- ✅ E2e worktree test: 10/10 passes
- ✅ Local test suite: 973 passed

Fixes STAB-7.
