### PR TITLE
docs: add STAB-33 for agent subscription dedupe and bump intentd to 6045b49

### DIFF
--- a/docs/01_stabilizing/KNOWN_ISSUES.md
+++ b/docs/01_stabilizing/KNOWN_ISSUES.md
@@ -2,7 +2,7 @@
 
 Live issue tracker for the **01_stabilizing** self-hosting phase.
 
-**Next available ID:** STAB-35 (as of 2026-07-14)
+**Next available ID:** STAB-36 (as of 2026-07-14)
 
 ## Intake Convention
 
@@ -304,6 +304,16 @@ Flaky CI test failure: `router_read_lifecycle_arms_over_wss` in `e2e_wss_agent_l
 **Expected:** WSS e2e tests exercise real JSON-RPC transport + method catalog; flawed test removed to reduce flakiness.
 
 **Status:** resolved ([intent-hq/intentd#134](https://github.com/intent-hq/intentd/pull/134), 2026-07-14) — test removed
+
+### STAB-33 (2026-07-14, area: intentd agent events / subscription dedupe + settlement coalescing, severity: P2)
+
+Duplicate agent completion notifications when parent agents repeatedly wake/send to the same child.
+
+**Repro:** Parent agent calls `agent.wakeOrCreate` or `agent.sendToTask` multiple times for the same child task. Observed while self-hosting: each call to `agent_watch_completion_op` or `agent_watch_completion_for_sender_op` created a new subscription with a fresh UUID, even when an identical watch already existed for the same (parent, child) pair. Additionally, `agent:idle` could fire prematurely when messages were queued, creating a race where concurrent message enqueuing between the turn-end check and the worker loop's dequeue call caused duplicate completion notifications.
+
+**Expected:** Completion watches are idempotent — repeated subscribe calls for the same (parent, child) pair return the same subscription ID and deliver exactly one notification per settle cycle. Settlement coalescing ensures `agent:idle` is only published when the target agent is both idle AND its message queue is empty (one notification per settle cycle, not one per turn).
+
+**Status:** fixed ([intent-hq/intentd#171](https://github.com/intent-hq/intentd/pull/171), 2026-07-14)
 
 ### STAB-34 (2026-07-14, area: intentd CI / agent_manager process-cap test, severity: P1)
 


### PR DESCRIPTION
Tracks the fix for duplicate agent completion notifications (STAB-33) in `docs/01_stabilizing/KNOWN_ISSUES.md` and bumps `packages/intentd` to include the merged fix.

## Changes

- **STAB-33 added**: Documents the duplicate completion notification issue fixed by intent-hq/intentd#171
- **intentd submodule bump**: Updated to `6045b498` (squash SHA from PR #171)
- **Next available ID**: Updated to STAB-36

## STAB-33 Summary

**Problem**: Every call to `agent.wakeOrCreate` or `agent.sendToTask` created a new completion subscription with a fresh UUID, even when an identical watch already existed. Additionally, `agent:idle` could fire prematurely when messages were queued.

**Fix**: Both `agent_watch_completion_op` and `agent_watch_completion_for_sender_op` now deduplicate by calling `find_and_refresh_ungrouped_watch` before creating a new subscription. Settlement coalescing ensures `agent:idle` is only emitted when the agent is idle AND its message queue is empty.

**Related PR**: intent-hq/intentd#171
