### PR TITLE
docs: renumber duplicate STAB-33 (subscription dedupe) to STAB-35

### DIFF
--- a/docs/01_stabilizing/KNOWN_ISSUES.md
+++ b/docs/01_stabilizing/KNOWN_ISSUES.md
@@ -305,7 +305,7 @@ Flaky CI test failure: `router_read_lifecycle_arms_over_wss` in `e2e_wss_agent_l
 
 **Status:** resolved ([intent-hq/intentd#134](https://github.com/intent-hq/intentd/pull/134), 2026-07-14) — test removed
 
-### STAB-33 (2026-07-14, area: intentd agent events / subscription dedupe + settlement coalescing, severity: P2)
+### STAB-35 (2026-07-14, area: intentd agent events / subscription dedupe + settlement coalescing, severity: P2)
 
 Duplicate agent completion notifications when parent agents repeatedly wake/send to the same child.
 


### PR DESCRIPTION
Fixes duplicate STAB-33 ID in docs/01_stabilizing/KNOWN_ISSUES.md.

The FIRST STAB-33 (line 114, area 'intentd intent-acp session lifecycle') is the legitimate entry.
The SECOND STAB-33 (line 308, area 'intentd agent events / subscription dedupe + settlement coalescing', added by PR #130) has been renumbered to STAB-35, which was previously skipped.

The ledger already correctly shows next available ID as STAB-36 and remains unchanged.

Verification:
- Exactly ONE '### STAB-33' heading remains (line 114)
- Exactly ONE '### STAB-35' heading now exists (line 308)
- Ledger unchanged: next available ID is STAB-36