### PR TITLE
chore: mark STAB-37 fixed and bump cloudlands-fe to 200ca7ff

### DIFF
--- a/docs/01_stabilizing/KNOWN_ISSUES.md
+++ b/docs/01_stabilizing/KNOWN_ISSUES.md
@@ -109,6 +109,8 @@ Repeated "Change history not initialized" warnings when change history is access
 
 **Repro:** During app startup or workspace switch, change-history accessors (`getChangeHistoryForWorkspace`, `getAllChangeHistory`, `setChangeHistoryForWorkspace`) are called from `change-detector-manager-impl.ts` (lines 923, 944, 987) and `workspace.service.ts` (line 314) before `initChangeHistory()` completes its async fetch from daemon `settings.get`. Observed while dogfooding: console logs show multiple "Change history not initialized, returning empty history for <workspaceId>" warnings from `change-history-persistence.ts:72` (`warnIfUninitialized` helper). The module fires `initChangeHistory()` asynchronously in `workspace.ipc.ts:280` at app startup, but callers do not await the `initPromise` — they synchronously access the cache while it is still initializing.
 
+**Status:** fixed ([intent-hq/cloudlands-fe#75](https://github.com/intent-hq/cloudlands-fe/pull/75), 2026-07-15) — Made change-history accessors async and added ensureInitialized() helper to gate access until initialization completes. Updated all call sites to await accessors. Added regression test.
+
 **Expected:** Accessors either wait for initialization to complete (await `initPromise` if not yet `initialized`) or trigger init on first access, ensuring no warnings during normal operation. Alternatively, callers that need history during startup/switch should explicitly await `initChangeHistory()` before accessing the cache.
 
 **Status:** open

--- a/docs/01_stabilizing/KNOWN_ISSUES.md
+++ b/docs/01_stabilizing/KNOWN_ISSUES.md
@@ -111,10 +111,6 @@ Repeated "Change history not initialized" warnings when change history is access
 
 **Status:** fixed ([intent-hq/cloudlands-fe#75](https://github.com/intent-hq/cloudlands-fe/pull/75), 2026-07-15) — Made change-history accessors async and added ensureInitialized() helper to gate access until initialization completes. Updated all call sites to await accessors. Added regression test.
 
-**Expected:** Accessors either wait for initialization to complete (await `initPromise` if not yet `initialized`) or trigger init on first access, ensuring no warnings during normal operation. Alternatively, callers that need history during startup/switch should explicitly await `initChangeHistory()` before accessing the cache.
-
-**Status:** open
-
 
 ---
 


### PR DESCRIPTION
**STAB-37 resolution**: change-history init race fixed in [intent-hq/cloudlands-fe#75](https://github.com/intent-hq/cloudlands-fe/pull/75).

**Changes:**
- Mark STAB-37 as fixed in KNOWN_ISSUES.md
- Bump packages/cloudlands-fe to 200ca7fff540bc9dee8fcd72f5747c8eb1230275

Resolves #STAB-37