### PR TITLE
chore: mark STAB-39 fixed + bump cloudlands-fe to 306ebc6c

### DIFF
--- a/docs/01_stabilizing/KNOWN_ISSUES.md
+++ b/docs/01_stabilizing/KNOWN_ISSUES.md
@@ -129,7 +129,7 @@ Flaky test failure: `auto-update-channel-persist.test.ts` fails intermittently i
 
 **Expected:** Test is deterministic. Temp directories are created and cleaned per-test without cross-test races. The `afterEach` cleanup waits for all async operations to settle (e.g., explicit service teardown, extended poll timeout, or coordinated flush) before removing the temp directory.
 
-**Status:** open
+**Status:** fixed ([intent-hq/cloudlands-fe#76](https://github.com/intent-hq/cloudlands-fe/pull/76), 2026-07-15)
 
 
 ---


### PR DESCRIPTION
## Summary

Closes STAB-39: cloudlands-fe auto-update-channel-persist test temp-directory cleanup race.

## Changes

- **KNOWN_ISSUES.md**: Mark STAB-39 as fixed
- **cloudlands-fe submodule**: Bump to 306ebc6c (includes PR #76 squash)

## Upstream Fix (cloudlands-fe#76)

**Root cause**: local-prefs.ts has a module-level writeChain that persists across vi.resetModules() calls in beforeEach. When resetModules() clears the module cache, any writes still queued in the old module's chain become orphaned, and afterEach's fs.rm() can race with those orphaned writes.

**Solution**: Added __drainLocalPrefsWriteChainForTesting() helper to local-prefs.ts that awaits the current writeChain before resetting it. Updated test's afterEach to call this helper before directory cleanup, ensuring all file writes complete before fs.rm() runs.

**Verification**: Ran the test file in a loop 20 times locally: 20/20 passes, 0 failures.

## Links

- cloudlands-fe PR: intent-hq/cloudlands-fe#76
- Squash SHA: 306ebc6c
