### PR TITLE
fix: close STAB-38 + bump cloudlands-fe to edd0428c

### DIFF
--- a/docs/01_stabilizing/KNOWN_ISSUES.md
+++ b/docs/01_stabilizing/KNOWN_ISSUES.md
@@ -119,7 +119,7 @@ Force-send during agent processing queues the message instead of interrupting; r
 
 **Expected:** Force-send interrupts the current turn and delivers immediately when the agent is streaming (one interrupt, even if pressed multiple times before the turn ends). The FE send path should pass `priority: "interrupt"` to `agent.sendMessage` when `forceSubmit: true`, and the daemon should deduplicate repeated interrupt delivery with the same client-supplied `messageId` per PROTOCOL.md §5.5 ("duplicate interrupt delivery with the same `messageId` is absorbed idempotently as `{ success: true, queued: false, messageId, deduplicated: true }`").
 
-**Status:** open
+**Status:** fixed ([intent-hq/cloudlands-fe#77](https://github.com/intent-hq/cloudlands-fe/pull/77), 2026-07-15) — Root cause: FE middleware never extracted `forceSubmit` from the action payload or set `priority: "interrupt"` on the IPC call. Fixed by threading `forceSubmit` through `dispatchToLifecycle`, bypassing queue-on-send check when true, and passing `priority: forceSubmit ? "interrupt" : undefined` to the daemon. Also added `priority` field to `AgentBackendStreamMessageSchema` so Zod doesn't strip it. Regression test added asserting force-send bypasses queue and passes priority to lifecycle.
 
 ### STAB-39 (2026-07-15, area: cloudlands-fe CI / auto-update-channel-persist test temp-dir cleanup race, severity: P2)
 


### PR DESCRIPTION
## Summary

Close STAB-38 + bump cloudlands-fe submodule to edd0428c.

## Root Cause

Force-send (⌘Enter) during agent processing queued the message instead of interrupting. The FE middleware never extracted `forceSubmit` from the action payload or set `priority: "interrupt"` on the IPC call to the daemon.

## Fix

Fixed in [intent-hq/cloudlands-fe#77](https://github.com/intent-hq/cloudlands-fe/pull/77) (squash SHA: edd0428c):

1. **chat-send-service.ts**: Extract `forceSubmit` in middleware, bypass queue-on-send check when `forceSubmit === true`, pass `priority: forceSubmit ? "interrupt" : undefined` to lifecycle
2. **agent-stream-lifecycle.ts**: Add `priority?: 'interrupt'` to sendMessage options, forward to IPC call
3. **ipc-schemas.ts**: Add `priority: z.enum(['interrupt']).optional()` to `AgentBackendStreamMessageSchema` (Zod was stripping the field)
4. **chat-send-service.test.ts**: Regression test asserting force-send bypasses queue and passes priority to lifecycle

## Verification

- cloudlands-fe#77 CI: ✅ all checks passed
- Regression test covers force-send bypass + priority wiring

## References

- Closes STAB-38
- cloudlands-fe submodule: edd0428c
