### PR TITLE
chore: update intentd submodule to latest main (runtime WSS toggle under uds)

### DIFF
--- a/docs/01_stabilizing/KNOWN_ISSUES.md
+++ b/docs/01_stabilizing/KNOWN_ISSUES.md
@@ -2,7 +2,7 @@
 
 Live issue tracker for the **01_stabilizing** self-hosting phase.
 
-**Next available ID:** STAB-46 (as of 2026-07-15)
+**Next available ID:** STAB-47 (as of 2026-07-16)
 
 ## Intake Convention
 
@@ -28,6 +28,21 @@ Auto-commit subject was the agent/task title — e.g. commits titled "Coordinato
 **Expected:** Auto-commit messages should be conventional-commit-formatted (e.g., `feat:`, `fix:`, `chore:`) derived from the actual diff.
 
 **Status:** fixed (https://github.com/intent-hq/intentd/pull/186, 2026-07-15)
+
+### STAB-46 (2026-07-16, area: intentd runtime listener control, severity: P1)
+
+Sidecar/dev build (FE spawns `intentd serve --listen uds`) — toggling `server.wsApi.enabled=true` fails with Internal("WSS listener not available...") and reverts.
+
+**Repro:**
+1. Start intentd in sidecar mode (FE spawns `intentd serve --listen uds` in dev OR packaged builds)
+2. Open Settings UI → WebSocket API
+3. Toggle `server.wsApi.enabled` to `true`
+4. **Expected:** WSS listener starts, bound port visible in system.status
+5. **Actual:** Error: "WSS listener not available (daemon started with --listen uds)", setting reverted
+
+**Root cause:** `main.rs` only constructed `WsRuntimeControl` when `serve_tcp_enabled` (`--listen tcp/both`). Under `--listen uds`, `DaemonControl.ws_runtime` was `None`, so `start_ws_listener` failed with the error above.
+
+**Status:** fixed ([intent-hq/intentd#195](https://github.com/intent-hq/intentd/pull/195), 2026-07-16)
 
 ### STAB-43 (2026-07-15, area: intentd CI / intent-core unit test, severity: P2)
 


### PR DESCRIPTION
Updates packages/intentd gitlink to 56c5c9e (latest main), which includes:

- intent-hq/intentd#195 — fix(intentd): runtime WSS toggle now works when daemon started with --listen uds (Phase 4 fix @ 4df962d)
- intent-hq/intentd#197 — docs: remove misplaced KNOWN_ISSUES tracker (cleanup, canonical tracker lives in monorepo)

Also picks up intent-hq/intentd#194 (store pool max_connections=20) from parallel work merged between 4df962d and 56c5c9e.

Adds STAB-46 to the monorepo's canonical KNOWN_ISSUES tracker documenting the WSS toggle issue that was fixed in #195.

Verified: make check && make test green (one pre-existing flaky test doctor_checks_data_dir_and_migrations fails on both old and new commits; unrelated to this bump).