### PR TITLE
fix: refresh changes panel on daemon git events (cloudlands-fe bump + STAB-37)

### DIFF
--- a/docs/01_stabilizing/KNOWN_ISSUES.md
+++ b/docs/01_stabilizing/KNOWN_ISSUES.md
@@ -2,7 +2,7 @@
 
 Live issue tracker for the **01_stabilizing** self-hosting phase.
 
-**Next available ID:** STAB-37 (as of 2026-07-14)
+**Next available ID:** STAB-38 (as of 2026-07-15)
 
 ## Intake Convention
 
@@ -338,3 +338,13 @@ Flaky CI test failure: `agent_manager::tests::process_cap_events_queued_resumed_
 **Expected:** Test should pass reliably in CI without intermittent failures.
 
 **Status:** fixed ([intent-hq/intentd#164](https://github.com/intent-hq/intentd/pull/164), 2026-07-14)
+
+### STAB-37 (2026-07-15, area: cloudlands-fe changes panel / daemon event bridge, severity: P1)
+
+Agent commits do not appear in the sidebar Changes panel in a brand-new workspace until switching out of the workspace and back.
+
+**Repro:** In a brand-new workspace, have an agent make commits. Observe the sidebar Changes panel — the commits do not appear. Switch to a different workspace, then switch back to the original workspace. The commits now appear.
+
+**Expected:** Agent commits (and git pull / changes:tracked events) should trigger the Changes panel to refresh within ~2 seconds, without requiring a workspace switch.
+
+**Status:** fixed ([intent-hq/cloudlands-fe#82](https://github.com/intent-hq/cloudlands-fe/pull/82), 2026-07-15) — frontend firehose daemon event bridge now dispatches per-workspace debounced (1s) `changes/refreshRequested` on `git:commit`, `git:pull`, and `changes:tracked` events


### PR DESCRIPTION
Bumps `packages/cloudlands-fe` to include the fix for STAB-37.

## Upstream PR

- intent-hq/cloudlands-fe#82 — fix: refresh changes panel on daemon git:commit/git:pull/changes:tracked events

## STAB-37 Fix

**Area:** cloudlands-fe changes panel / daemon event bridge  
**Severity:** P1

**Bug:** In a brand-new workspace, agent commits do not appear in the sidebar Changes panel until switching out of the workspace and back.

**Fix:** Frontend firehose daemon event bridge now dispatches per-workspace debounced (1s) `changes/refreshRequested` on `git:commit`, `git:pull`, and `changes:tracked` events.

## Changes

- Bump `packages/cloudlands-fe` submodule to `76b8001caba4ca52f1242fff954b089515dbcc72` (merged cloudlands-fe#82)
- Add STAB-37 to `docs/01_stabilizing/KNOWN_ISSUES.md` (fixed, 2026-07-15)
- Bump next available STAB ID to STAB-38
