### PR TITLE
chore: update cloudlands-fe submodule + add STAB-59

### DIFF
--- a/docs/01_stabilizing/KNOWN_ISSUES.md
+++ b/docs/01_stabilizing/KNOWN_ISSUES.md
@@ -2,7 +2,7 @@
 
 Live issue tracker for the **01_stabilizing** self-hosting phase.
 
-**Next available ID:** STAB-59 (as of 2026-07-16)
+**Next available ID:** STAB-60 (as of 2026-07-16)
 
 ## Intake Convention
 
@@ -334,6 +334,16 @@ These items were genuinely open/deferred in [../00_initial_porting/BREADCRUMBS.m
 ---
 
 ## Fixed Issues
+
+### STAB-59 (2026-07-16, area: WSS listener settings / Settings UI, severity: P2)
+
+Enabling the WebSocket API with the port already in use failed silently (error only in daemon stderr; no toast) and the port was not editable in the UI.
+
+**Repro:** Start intentd, enable the WebSocket API via Settings UI while another process is already bound to the default port (8787). Observed while dogfooding: the toggle appeared to enable but the listener never started (error only in daemon stderr: "Address already in use"); no user-facing error toast was shown. Additionally, the port input field was disabled/non-editable in the Settings UI, so there was no way to change the port to an available one without manually editing the daemon settings file.
+
+**Expected:** When enabling the WebSocket API fails (e.g., port in use), show a user-facing error toast with the failure reason. The port input field should always be editable regardless of the toggle state, allowing the user to pick a different port before retrying.
+
+**Status:** fixed ([intent-hq/intentd#201](https://github.com/intent-hq/intentd/pull/201), [intent-hq/cloudlands-fe#85](https://github.com/intent-hq/cloudlands-fe/pull/85), 2026-07-16)
 
 ### STAB-58 (2026-07-15, area: intentd agent spawn / provider binary resolution, severity: P1)
 


### PR DESCRIPTION
Monorepo follow-up for WSS port setting + UI improvements.

## Submodule Updates

- **cloudlands-fe** → `731a033` ([#85](https://github.com/intent-hq/cloudlands-fe/pull/85))
  Made WSS port input always editable + surface toggle errors as toasts

**Note:** intentd was already bumped to `d91579e` in PR #162 (STAB-37).

## Known Issue Entry

Added **STAB-59** to `docs/01_stabilizing/KNOWN_ISSUES.md`:
- **Area:** WSS listener settings / Settings UI
- **Severity:** P2
- **Issue:** Enabling the WebSocket API with the port in use failed silently (error only in daemon stderr, no toast); port was not editable in UI
- **Status:** fixed (intent-hq/intentd#201, intent-hq/cloudlands-fe#85, 2026-07-16)

## Verification

- ✅ `make check` passed
- ⚠️  `make test` — 816/817 tests passed; 1 known flaky test (STAB-42, `uds_concurrent_dispatch`, documented as environment-dependent timing issue)
- ✅ `git submodule status` shows expected HEADs
