### PR TITLE
fix: remove orphaned cloudlands-fe/intentd gitlink (STAB-61)

### DIFF
--- a/docs/01_stabilizing/KNOWN_ISSUES.md
+++ b/docs/01_stabilizing/KNOWN_ISSUES.md
@@ -2,7 +2,7 @@
 
 Live issue tracker for the **01_stabilizing** self-hosting phase.
 
-**Next available ID:** STAB-61 (as of 2026-07-16)
+**Next available ID:** STAB-62 (as of 2026-07-17)
 
 ## Intake Convention
 
@@ -344,6 +344,18 @@ These items were genuinely open/deferred in [../00_initial_porting/BREADCRUMBS.m
 ---
 
 ## Fixed Issues
+
+### STAB-61 (2026-07-17, area: cloudlands-fe repo / nested submodule gitlink, severity: P2)
+
+The cloudlands-fe repo carried an orphaned `intentd` submodule gitlink (mode `160000`) with no matching entry in its `.gitmodules`, breaking `git submodule update --init --recursive` in the parent monorepo.
+
+**Repro:** From a fresh monorepo clone, run `git submodule update --init --recursive`. It aborts with `fatal: No url found for submodule path 'packages/cloudlands-fe/intentd' in .gitmodules`, leaving `packages/ios` unpinned (checked out to `main` tip instead of the recorded commit) and `packages/intentd` with an empty working tree (index populated but files not extracted). `git -C packages/cloudlands-fe ls-files -s intentd` showed mode `160000` (gitlink) → commit `befdb2371f292ecd93886ffeee2d236123ee493b`, but `packages/cloudlands-fe/.gitmodules` had no entry for `intentd`.
+
+**Expected:** `git submodule update --init --recursive` from a fresh clone succeeds end-to-end, initializing all three top-level submodules at their pinned commits.
+
+**Root cause:** Leftover nested-submodule gitlink in the cloudlands-fe repo from before the monorepo restructure. Nothing in cloudlands-fe references the `intentd/` path anymore — the FE resolves the intentd binary by walking up from `process.cwd()` to `packages/intentd/target/{release,debug}/intentd`, and `scripts/copy-sidecar.cjs` targets a gitignored `resources/sidecar/intentd` staging path.
+
+**Status:** fixed ([intent-hq/cloudlands-fe#92](https://github.com/intent-hq/cloudlands-fe/pull/92), 2026-07-17) — `git rm --cached intentd` in cloudlands-fe removes the stray gitlink; monorepo submodule bump follows.
 
 ### STAB-59 (2026-07-16, area: WSS listener settings / Settings UI, severity: P2)
 


### PR DESCRIPTION
Phase 2 of the fix for STAB-61 — bumps the `packages/cloudlands-fe` submodule ref and files STAB-61 as fixed in `docs/01_stabilizing/KNOWN_ISSUES.md`.

## Phase 1 (cloudlands-fe PR, merged)

intent-hq/cloudlands-fe#92 removed the orphaned `intentd` submodule gitlink (mode `160000`) from the cloudlands-fe repo. The stray gitlink had no matching `.gitmodules` entry and broke `git submodule update --init --recursive` in the monorepo with:

```
fatal: No url found for submodule path 'packages/cloudlands-fe/intentd' in .gitmodules
```

## Phase 2 (this monorepo PR)

- Bumps `packages/cloudlands-fe` submodule ref from `980faae3` → `c3a44f7a` (the merged cloudlands-fe#92 commit)
- Adds **STAB-61** entry to the Fixed Issues section of `docs/01_stabilizing/KNOWN_ISSUES.md` with the actual PR link and merge date (2026-07-17)
- Updates "Next available ID" header from STAB-61 → STAB-62

Both changes land in a single commit per AGENTS.md convention ("When the tracker update rides along in the same PR as the actual code fix, the PR/commit type follows the code change").

## Verification

After this PR merges, from a fresh clone:

```bash
git clone <monorepo-url> intent-verify && cd intent-verify
git submodule update --init --recursive  # should succeed with exit 0
git submodule status                     # all three submodules at pinned commits
make check                               # should pass
```

## Related

- Closes STAB-61
- Follows intent-hq/cloudlands-fe#92
