### PR TITLE
feat: npx fallback for claude-code adapter (intentd bump to 5a0ed7c)

### DIFF
--- a/docs/01_stabilizing/KNOWN_ISSUES.md
+++ b/docs/01_stabilizing/KNOWN_ISSUES.md
@@ -389,7 +389,7 @@ Agent spawn fails with `spawn provider failed: claude-agent-acp: No such file or
 
 **Expected:** The daemon resolves provider binaries to absolute paths using 3-tier precedence: (1) `providers.paths.<id>` setting, (2) `~/.augment/bin/<command>`, (3) enhanced PATH directory scan (including discovery logic from `find_auggie` / `resolve_on_path`). The resolved absolute path is used for `Command::new` AND passed as `SpawnOptions.provider_binary` so `enhanced_path` prepends its parent directory (ensuring co-located node resolves for shebang scripts). If resolution fails at all three tiers, spawn proceeds with bare name (backward-compatible fallback). Uniform across all providers — no per-provider special cases. Spawn failure errors name the unresolvable command.
 
-**Status:** fixed ([intent-hq/intentd#189](https://github.com/intent-hq/intentd/pull/189), 2026-07-16) — generalized provider binary discovery with settings → managed bin → PATH-scan precedence, wired into agent spawn
+**Status:** fixed ([intent-hq/intentd#189](https://github.com/intent-hq/intentd/pull/189), 2026-07-16) — generalized provider binary discovery with settings → managed bin → PATH-scan precedence, wired into agent spawn. The claude-code provider now falls back to `npx -y @agentclientprotocol/claude-agent-acp` when the adapter binary is absent ([intent-hq/intentd#215](https://github.com/intent-hq/intentd/pull/215), 2026-07-17).
 
 ### STAB-2 (2026-07-13, area: cloudlands-fe UI — workspace timeline/feed, severity: P2)
 


### PR DESCRIPTION
Bump `packages/intentd` to main SHA `5a0ed7c` following merge of intent-hq/intentd#215.

## Changes

- **intentd submodule**: bumped to `5a0ed7c` (feat: add npx fallback for claude-code provider spawn)
- **KNOWN_ISSUES.md**: updated STAB-58 entry to document the npx fallback behavior

## intentd PR

intent-hq/intentd#215 — add npx fallback for claude-code provider spawn

## Verification

- `make check` ✅ passed
- `make test` ✅ passed (1 unrelated test failure in `doctor_checks_data_dir_and_migrations` — appears to be a test environment isolation issue; the `doctor` command itself runs successfully)

---

Prerequisite: intent-hq/intentd#215 (merged)
