### PR TITLE
fix: derive repositoryOwner from origin remote (STAB-64)

### DIFF
--- a/docs/00_initial_porting/PROTOCOL.md
+++ b/docs/00_initial_porting/PROTOCOL.md
@@ -202,7 +202,7 @@ Conventions used below: parameters marked **(req)** are required (a missing/`nul
 
 | Method | Params | Result |
 | --- | --- | --- |
-| workspace.list | includeArchived?: boolean (default false) | { workspaces: Workspace[] } |
+| workspace.list | includeArchived?: boolean (default false) | { workspaces: Workspace[] } — triggers background backfill: existing workspaces with a repositoryPath but missing repositoryOwner/Name are enriched from the origin remote URL (same GitHub derivation as workspace.create, non-blocking spawn, deduped per workspace per daemon lifecycle, skips non-GitHub remotes, persists updates, emits workspace:updated with changed fields) |
 | workspace.get | workspaceId (req) | { workspace: Workspace } — -32602 if not found |
 | workspace.create | workspace fields (incl. repositoryPath?, baseRef?, branch?, remote?, skipWorktree?, githubUrl?, clonePath?); optional initialAgent: { agentId, prompt, name?, model?, specialist?, provider?, behaviorPrompt?, agentType?, imageBlocks?, metadata? } | { workspace: Workspace, initialAgent?: { agentId } } — daemon-owned orchestration inside one idempotent op (see notes: clone → worktree → spec seed → initial agent). |
 | workspace.update | workspaceId (req) + fields to change | { workspace: Workspace } |
@@ -267,9 +267,11 @@ On success the checkout becomes the workspace's `repositoryPath` and, when the U
 carries an `owner/name` pair (`github.com/OWNER/REPO(.git)?` on https or ssh), the
 daemon best-effort derives `repositoryOwner`/`repositoryName` from it when the caller
 left them blank. Independently of cloning, any create that ends up with a local
-`repositoryPath` but no caller-supplied `repositoryName` persists the path basename as
-`repositoryName`; `repositoryOwner` is never derived from local paths (no remote
-inspection).
+`repositoryPath` but no caller-supplied `repositoryOwner`/`repositoryName` best-effort
+derives them from the local repository's `origin` remote URL (local git config read only,
+no network) when the remote is a GitHub URL (https or ssh forms, strict `github.com` host
+check); non-GitHub or missing remotes leave `repositoryOwner` unset. Caller-supplied
+values always win; `repositoryName` persists the path basename as a last resort when blank.
 
 **Spec note seeding (`workspace.create`).** Every successful create seeds the well-known
 `spec` note in the new workspace (reference `notes.service.ts ensureSpecExists` parity):

--- a/docs/01_stabilizing/KNOWN_ISSUES.md
+++ b/docs/01_stabilizing/KNOWN_ISSUES.md
@@ -19,18 +19,6 @@ Each issue entry includes:
 
 ## Open Issues
 
-### STAB-64 (2026-07-17, area: intentd workspace.create / cloudlands-fe sidebar repo grouping, severity: P2)
-
-Sidebar repo groups show no GitHub avatar for workspaces created from local repo paths, unlike the reference app.
-
-**Repro:** Create a workspace from a local repository path that has a `github.com` origin remote (e.g., `intentd workspace create --path ~/code/monorepo`). Open the cloudlands-fe sidebar All-Workspaces repo view. The repo group for that workspace shows no GitHub owner avatar next to the repo group, even though the repository has a valid GitHub origin.
-
-**Expected:** The GitHub owner avatar appears next to the repo group in the sidebar, matching the reference app behavior. The sidebar (`AllWorkspacesCard.svelte`, repo view) renders the avatar when `group.owner` is set, which requires `workspace.repositoryOwner`.
-
-**Root cause:** The daemon never derives `repositoryOwner` from local paths. intentd only sets `repository_owner` when the caller explicitly supplies it or when the workspace is created by cloning a `github.com/OWNER/REPO` URL. PROTOCOL.md states: "`repositoryOwner` is never derived from local paths (no remote inspection)". The reference app (augmentcode/intent) backfilled `repositoryOwner` and `repositoryName` in the Electron main process (`performBackgroundEnrichment` → `git remote get-url origin`), but that enrichment path is out of the daemon-canonical data path in the ported stack — the cloudlands-fe sidebar lists workspaces straight from intentd `workspace.list` (`LiveWorkspacesClient`) with fields passing through untouched.
-
-**Status:** open
-
 ### STAB-63 (2026-07-17, area: intentd doctor / e2e_core_cli_commands test, severity: P2)
 
 The `doctor_checks_data_dir_and_migrations` test fails deterministically when a live intentd daemon is running.
@@ -370,6 +358,18 @@ These items were genuinely open/deferred in [../00_initial_porting/BREADCRUMBS.m
 ---
 
 ## Fixed Issues
+
+### STAB-64 (2026-07-17, area: intentd workspace.create / cloudlands-fe sidebar repo grouping, severity: P2)
+
+Sidebar repo groups show no GitHub avatar for workspaces created from local repo paths, unlike the reference app.
+
+**Repro:** Create a workspace from a local repository path that has a `github.com` origin remote (e.g., `intentd workspace create --path ~/code/monorepo`). Open the cloudlands-fe sidebar All-Workspaces repo view. The repo group for that workspace shows no GitHub owner avatar next to the repo group, even though the repository has a valid GitHub origin.
+
+**Expected:** The GitHub owner avatar appears next to the repo group in the sidebar, matching the reference app behavior. The sidebar (`AllWorkspacesCard.svelte`, repo view) renders the avatar when `group.owner` is set, which requires `workspace.repositoryOwner`.
+
+**Root cause:** The daemon never derives `repositoryOwner` from local paths. intentd only sets `repository_owner` when the caller explicitly supplies it or when the workspace is created by cloning a `github.com/OWNER/REPO` URL. PROTOCOL.md states: "`repositoryOwner` is never derived from local paths (no remote inspection)". The reference app (augmentcode/intent) backfilled `repositoryOwner` and `repositoryName` in the Electron main process (`performBackgroundEnrichment` → `git remote get-url origin`), but that enrichment path is out of the daemon-canonical data path in the ported stack — the cloudlands-fe sidebar lists workspaces straight from intentd `workspace.list` (`LiveWorkspacesClient`) with fields passing through untouched.
+
+**Status:** fixed (https://github.com/intent-hq/intentd/pull/218, 2026-07-17)
 
 ### STAB-61 (2026-07-17, area: cloudlands-fe repo / nested submodule gitlink, severity: P2)
 


### PR DESCRIPTION
Bumps packages/intentd submodule to d62b1c5 (intent-hq/intentd#218) and updates documentation.

## Changes

- **Submodule bump:** packages/intentd → d62b1c5 (PR #218: derive repositoryOwner from github.com origin remote on workspace.create, plus workspace.list backfill for existing workspaces)
- **PROTOCOL.md updates:**
  - workspace.create: best-effort derivation from origin remote URL (local git config only, strict github.com host check, caller-supplied values win)  
  - workspace.list: document background backfill behavior (non-blocking spawn, deduped per workspace, emits workspace:updated)
- **KNOWN_ISSUES.md:** Mark STAB-64 fixed (intent-hq/intentd#218, 2026-07-17) and move to Fixed Issues section

## Verification

✅ make check green at bumped ref

## References

- Fixes STAB-64 (sidebar repo GitHub icon missing)
- intent-hq/intentd#218
