### PR TITLE
fix: restore panel-layout persistence via cloudlands-fe submodule bump

### DIFF
--- a/docs/01_stabilizing/KNOWN_ISSUES.md
+++ b/docs/01_stabilizing/KNOWN_ISSUES.md
@@ -2,7 +2,7 @@
 
 Live issue tracker for the **01_stabilizing** self-hosting phase.
 
-**Next available ID:** STAB-66 (as of 2026-07-17)
+**Next available ID:** STAB-67 (as of 2026-07-17)
 
 ## Intake Convention
 
@@ -18,16 +18,6 @@ Each issue entry includes:
 ---
 
 ## Open Issues
-
-### STAB-65 (2026-07-17, area: cloudlands-fe / panel layout persistence, severity: P1)
-
-Workspaces did not restore previously opened tabs/layouts (splits, active tab, focused panel) across relaunches.
-
-**Repro:** Open a workspace, open multiple tabs and/or create panel splits, quit and relaunch the app. Expected: the workspace reopens with the same panel layout (tabs, splits, active tab, focused panel) as before. Actual: the layout was never persisted to localStorage nor restored on workspaceMounted, and restoreStatus stayed "idle" — the workspace always opens with a default/empty layout.
-
-**Root cause:** The panel-layout-saga (which handled persistence and restore) was deleted in saga-removal commit 95d908a2 without being re-homed as a middleware. The saga's PERSIST_ACTIONS / HISTORY_ACTIONS handlers, localStorage persistence, and workspaceMounted restore logic were lost, leaving no mechanism to save or restore panel layouts.
-
-**Status:** fixed (https://github.com/intent-hq/cloudlands-fe/pull/102, 2026-07-17)
 
 ### STAB-63 (2026-07-17, area: intentd doctor / e2e_core_cli_commands test, severity: P2)
 
@@ -368,6 +358,16 @@ These items were genuinely open/deferred in [../00_initial_porting/BREADCRUMBS.m
 ---
 
 ## Fixed Issues
+
+### STAB-66 (2026-07-17, area: cloudlands-fe / panel layout persistence, severity: P1)
+
+Workspaces did not restore previously opened tabs/layouts (splits, active tab, focused panel) across relaunches.
+
+**Repro:** Open a workspace, open multiple tabs and/or create panel splits, quit and relaunch the app. Expected: the workspace reopens with the same panel layout (tabs, splits, active tab, focused panel) as before. Actual: the layout was never persisted to `localStorage` nor restored on `workspaceMounted`, and `restoreStatus` stayed `"idle"` — the workspace always opens with a default/empty layout.
+
+**Root cause:** The `panel-layout-saga` (which handled persistence and restore) was deleted in saga-removal commit `95d908a2` without being re-homed as a middleware. The saga's `PERSIST_ACTIONS` / `HISTORY_ACTIONS` handlers, `localStorage` persistence, and `workspaceMounted` restore logic were lost, leaving no mechanism to save or restore panel layouts.
+
+**Status:** fixed (https://github.com/intent-hq/cloudlands-fe/pull/102, 2026-07-17)
 
 ### STAB-65 (2026-07-17, area: cloudlands-fe Settings / Specialists persistence, severity: P1)
 

--- a/docs/01_stabilizing/KNOWN_ISSUES.md
+++ b/docs/01_stabilizing/KNOWN_ISSUES.md
@@ -2,7 +2,7 @@
 
 Live issue tracker for the **01_stabilizing** self-hosting phase.
 
-**Next available ID:** STAB-65 (as of 2026-07-17)
+**Next available ID:** STAB-66 (as of 2026-07-17)
 
 ## Intake Convention
 
@@ -18,6 +18,16 @@ Each issue entry includes:
 ---
 
 ## Open Issues
+
+### STAB-65 (2026-07-17, area: cloudlands-fe / panel layout persistence, severity: P1)
+
+Workspaces did not restore previously opened tabs/layouts (splits, active tab, focused panel) across relaunches.
+
+**Repro:** Open a workspace, open multiple tabs and/or create panel splits, quit and relaunch the app. Expected: the workspace reopens with the same panel layout (tabs, splits, active tab, focused panel) as before. Actual: the layout was never persisted to localStorage nor restored on workspaceMounted, and restoreStatus stayed "idle" — the workspace always opens with a default/empty layout.
+
+**Root cause:** The panel-layout-saga (which handled persistence and restore) was deleted in saga-removal commit 95d908a2 without being re-homed as a middleware. The saga's PERSIST_ACTIONS / HISTORY_ACTIONS handlers, localStorage persistence, and workspaceMounted restore logic were lost, leaving no mechanism to save or restore panel layouts.
+
+**Status:** fixed (https://github.com/intent-hq/cloudlands-fe/pull/102, 2026-07-17)
 
 ### STAB-64 (2026-07-17, area: intentd workspace.create / cloudlands-fe sidebar repo grouping, severity: P2)
 


### PR DESCRIPTION
Bumps `packages/cloudlands-fe` to commit 7915a636 (main), landing cloudlands-fe PR #102.

## What Changed

- **Submodule bump**: `packages/cloudlands-fe` now points to 7915a636416d198ac33958a733f314349f644654
- **STAB entry**: Added STAB-65 to `docs/01_stabilizing/KNOWN_ISSUES.md` documenting the panel-layout persistence bug and marking it fixed

## Context

Fixes STAB-65: workspaces did not restore previously opened tabs/layouts (splits, active tab, focused panel) across relaunches. The layout was never persisted to localStorage nor restored on workspaceMounted, and restoreStatus stayed "idle".

**Root cause**: The panel-layout-saga was deleted in saga-removal commit 95d908a2 without being re-homed as a middleware.

**Fix**: cloudlands-fe PR #102 re-homes the saga as a new `panel-layout-persistence-service` middleware following the established middleware pattern.

## References

- Submodule PR: https://github.com/intent-hq/cloudlands-fe/pull/102
- Merged commit: 7915a636416d198ac33958a733f314349f644654
