### PR TITLE
fix: restore file-content prune watcher via cloudlands-fe submodule bump

### DIFF
--- a/docs/01_stabilizing/KNOWN_ISSUES.md
+++ b/docs/01_stabilizing/KNOWN_ISSUES.md
@@ -2,7 +2,7 @@
 
 Live issue tracker for the **01_stabilizing** self-hosting phase.
 
-**Next available ID:** STAB-67 (as of 2026-07-17)
+**Next available ID:** STAB-68 (as of 2026-07-17)
 
 ## Intake Convention
 
@@ -358,6 +358,16 @@ These items were genuinely open/deferred in [../00_initial_porting/BREADCRUMBS.m
 ---
 
 ## Fixed Issues
+
+### STAB-67 (2026-07-17, area: cloudlands-fe / files store, severity: P2)
+
+File-content entries leak in the files slice when tabs are closed.
+
+**Repro:** Open a file tab, then close it. The file-content entry remains in the files slice (memory leak), persisting indefinitely even though no tab references it.
+
+**Root cause:** The file-content prune watcher (`cleanupClosedFileContentEntries`) was deleted in saga-removal commit `95d908a2` without being re-homed. The saga's cleanup logic that watched for tab-close actions and pruned orphaned file-content entries was lost, leaving no mechanism to remove file-content when tabs close.
+
+**Status:** fixed (https://github.com/intent-hq/cloudlands-fe/pull/105, https://github.com/intent-hq/cloudlands-fe/pull/109, https://github.com/intent-hq/cloudlands-fe/pull/110, https://github.com/intent-hq/cloudlands-fe/pull/111, 2026-07-17)
 
 ### STAB-66 (2026-07-17, area: cloudlands-fe / panel layout persistence, severity: P1)
 


### PR DESCRIPTION
Restores the file-content prune watcher (cleanupClosedFileContentEntries) that was lost in saga-removal commit 95d908a2.

## Problem
Opening and closing file tabs leaked file-content entries in the files slice — orphaned content persisted indefinitely with no cleanup mechanism.

## Solution
Bumps cloudlands-fe submodule to db07eff7 (origin/main), which lands:
- #105 — middleware re-home of the prune watcher
- #109 — trigger-set additions for proper action capture
- #110 — save actions in trigger set
- #111 — previousStalePaths desync fix + hot-path perf fix

All four PRs are merged and verified. All review threads resolved.

## Tracking
Documents as STAB-67 in docs/01_stabilizing/KNOWN_ISSUES.md (P2, area: cloudlands-fe / files store, fixed 2026-07-17).

## Related
- https://github.com/intent-hq/cloudlands-fe/pull/105
- https://github.com/intent-hq/cloudlands-fe/pull/109
- https://github.com/intent-hq/cloudlands-fe/pull/110
- https://github.com/intent-hq/cloudlands-fe/pull/111
