### PR TITLE
fix: update intentd submodule and mark STAB-70 fixed

### DIFF
--- a/docs/01_stabilizing/KNOWN_ISSUES.md
+++ b/docs/01_stabilizing/KNOWN_ISSUES.md
@@ -2,7 +2,7 @@
 
 Live issue tracker for the **01_stabilizing** self-hosting phase.
 
-**Next available ID:** STAB-70 (as of 2026-07-17)
+**Next available ID:** STAB-71 (as of 2026-07-17)
 
 ## Intake Convention
 
@@ -382,6 +382,16 @@ These items were genuinely open/deferred in [../00_initial_porting/BREADCRUMBS.m
 ---
 
 ## Fixed Issues
+
+### STAB-70 (2026-07-17, area: intentd agent runtime / reportToParent persistence, severity: P2)
+
+A delegated agent's completion report stays sticky in agent metadata and the FE agent card footer forever, even after the parent sends new work and the agent goes active again.
+
+**Repro:** Delegate a task to an agent, let it complete and call `report_to_parent`. The completion report appears in the agent metadata (`completionReport` field) and the FE agent card footer. Send a new message to the same agent (or delegate new work). The agent becomes active again and processes the new turn, but the old completion report remains visible in the metadata and UI — it never clears when the new turn begins.
+
+**Expected:** The completion report should clear when a new turn begins (when the agent transitions from a completed state back to active work). The `completionReport` field should be reset to `null` in agent metadata when the agent starts processing a new message.
+
+**Status:** fixed (https://github.com/intent-hq/intentd/pull/221, 2026-07-17)
 
 ### STAB-69 (2026-07-17, area: cloudlands-fe opencode IPC / host.exec, severity: P1)
 


### PR DESCRIPTION
Updates packages/intentd to 7e818ae (main), which includes the fix for STAB-70 (completion reports now clear when a new turn begins).

**Submodule PR:** https://github.com/intent-hq/intentd/pull/221

**Changes:**
- Bump packages/intentd gitlink to commit 7e818ae (includes PR #221: 13b679e fix: clear completion report when new turn begins)
- Add STAB-70 entry to docs/01_stabilizing/KNOWN_ISSUES.md documenting the fix

**Verification:**
- make check passes
- Conventional commit format verified
