### PR TITLE
docs: fix duplicate STAB-68/69 IDs, renumber to STAB-71/72

### DIFF
--- a/docs/01_stabilizing/KNOWN_ISSUES.md
+++ b/docs/01_stabilizing/KNOWN_ISSUES.md
@@ -2,7 +2,7 @@
 
 Live issue tracker for the **01_stabilizing** self-hosting phase.
 
-**Next available ID:** STAB-71 (as of 2026-07-17)
+**Next available ID:** STAB-73 (as of 2026-07-17)
 
 ## Intake Convention
 
@@ -18,30 +18,6 @@ Each issue entry includes:
 ---
 
 ## Open Issues
-
-### STAB-69 (2026-07-17, area: cloudlands-fe agents-seeder / reload, severity: P1)
-
-Chat transcript clobbered to blank after workspace reload.
-
-**Repro:** Open a workspace with an agent that has existing chat messages. Reload the app (Cmd-R). Observe the agent panel — the chat transcript is completely blank even though the conversation history exists in the daemon.
-
-**Root cause:** `agents-seeder` unconditionally replaced Redux `agentSessions` with the AgentLite list from `client.agents.list()`. When AgentLite payloads have `messages: []` (daemon optimization to reduce payload size), seeder wiped existing conversation transcripts that were already hydrated in the store.
-
-**Expected:** Agent chat transcript is preserved across workspace reloads. Seeder should preserve existing session messages when incoming agent has `messages.length === 0` and existing session has `messages.length > 0`, mirroring the merge logic in `hydrateWorkspaceAgents` from `lifecycle-read-service.ts`.
-
-**Status:** fixed ([intent-hq/cloudlands-fe#122](https://github.com/intent-hq/cloudlands-fe/pull/122), 2026-07-17)
-
-### STAB-68 (2026-07-17, area: cloudlands-fe workspaces-seeder / reload, severity: P1)
-
-Sidebar Changes panel stuck in indeterminate state after workspace reload.
-
-**Repro:** Open a workspace, make some file changes visible in the Changes panel. Reload the app (Cmd-R). Observe the sidebar Changes panel — it shows indeterminate state (spinner or blank) instead of the actual workspace state, even though the workspace is correctly selected in the URL.
-
-**Root cause:** `workspaces-seeder` read `store.state` BEFORE the async `client.workspaces.list()` call, then unconditionally dispatched `setActiveWorkspaceId` + `openWorkspaceTab` for the first workspace. On reload, route loader sets `activeWorkspaceId` during the fetch; seeder's stale empty-state read clobbered it.
-
-**Expected:** Workspace selection and sidebar state correctly reflect the loaded workspace after reload. Seeder should only auto-select the first workspace when BOTH `activeWorkspaceId` AND `currentTabId` are unset (fresh boot scenario), avoiding clobbering route-driven state.
-
-**Status:** fixed ([intent-hq/cloudlands-fe#122](https://github.com/intent-hq/cloudlands-fe/pull/122), 2026-07-17)
 
 ### STAB-63 (2026-07-17, area: intentd doctor / e2e_core_cli_commands test, severity: P2)
 
@@ -382,6 +358,30 @@ These items were genuinely open/deferred in [../00_initial_porting/BREADCRUMBS.m
 ---
 
 ## Fixed Issues
+
+### STAB-72 (2026-07-17, area: cloudlands-fe agents-seeder / reload, severity: P1)
+
+Chat transcript clobbered to blank after workspace reload.
+
+**Repro:** Open a workspace with an agent that has existing chat messages. Reload the app (Cmd-R). Observe the agent panel — the chat transcript is completely blank even though the conversation history exists in the daemon.
+
+**Root cause:** `agents-seeder` unconditionally replaced Redux `agentSessions` with the AgentLite list from `client.agents.list()`. When AgentLite payloads have `messages: []` (daemon optimization to reduce payload size), seeder wiped existing conversation transcripts that were already hydrated in the store.
+
+**Expected:** Agent chat transcript is preserved across workspace reloads. Seeder should preserve existing session messages when incoming agent has `messages.length === 0` and existing session has `messages.length > 0`, mirroring the merge logic in `hydrateWorkspaceAgents` from `lifecycle-read-service.ts`.
+
+**Status:** fixed ([intent-hq/cloudlands-fe#122](https://github.com/intent-hq/cloudlands-fe/pull/122), 2026-07-17)
+
+### STAB-71 (2026-07-17, area: cloudlands-fe workspaces-seeder / reload, severity: P1)
+
+Sidebar Changes panel stuck in indeterminate state after workspace reload.
+
+**Repro:** Open a workspace, make some file changes visible in the Changes panel. Reload the app (Cmd-R). Observe the sidebar Changes panel — it shows indeterminate state (spinner or blank) instead of the actual workspace state, even though the workspace is correctly selected in the URL.
+
+**Root cause:** `workspaces-seeder` read `store.state` BEFORE the async `client.workspaces.list()` call, then unconditionally dispatched `setActiveWorkspaceId` + `openWorkspaceTab` for the first workspace. On reload, route loader sets `activeWorkspaceId` during the fetch; seeder's stale empty-state read clobbered it.
+
+**Expected:** Workspace selection and sidebar state correctly reflect the loaded workspace after reload. Seeder should only auto-select the first workspace when BOTH `activeWorkspaceId` AND `currentTabId` are unset (fresh boot scenario), avoiding clobbering route-driven state.
+
+**Status:** fixed ([intent-hq/cloudlands-fe#122](https://github.com/intent-hq/cloudlands-fe/pull/122), 2026-07-17)
 
 ### STAB-70 (2026-07-17, area: intentd agent runtime / reportToParent persistence, severity: P2)
 


### PR DESCRIPTION
## Summary

Fixes duplicate STAB ID collision introduced in PR #194.

## Problem

PR #194 added two new entries under "Open Issues" with IDs STAB-68 and STAB-69, but these IDs were already in use in the "Fixed Issues" section:

**Duplicates:**
- STAB-68: Used for both "workspaces-seeder reload" (new, PR #194) and "chat transcript hydration/rendering" (existing, fixed)
- STAB-69: Used for both "agents-seeder reload" (new, PR #194) and "opencode IPC host.exec" (existing, fixed)

**Additional issues:**
- Both new entries were under "Open Issues" despite having `Status: fixed`
- Header said "Next available ID: STAB-70" — new entries should have used 70 and 71
- **After PR #198 was created**, STAB-70 was allocated on main for the reportToParent persistence fix, requiring renumbering to 71/72

## Changes

- Renumbered workspaces-seeder reload issue from STAB-68 → **STAB-71** (was 70 in PR #198, now adjusted)
- Renumbered agents-seeder reload issue from STAB-69 → **STAB-72** (was 71 in PR #198, now adjusted)
- Moved both entries from "Open Issues" to "Fixed Issues" section
- Updated "Next available ID" header from STAB-71 → **STAB-73**
- Maintained Fixed Issues ordering convention (newest/highest first: 72, 71, 70, 69, 68...)

All entry content, PR #122 links, and fixed status preserved unchanged.

## References

- Original PR with duplicate IDs: #194
- Previous attempt (superseded): #198 — used STAB-70/71 before STAB-70 was taken
- cloudlands-fe fix PR: https://github.com/intent-hq/cloudlands-fe/pull/122
