### PR TITLE
fix: workspace sidebar live re-sort on lastActivity updates (STAB-68)

### DIFF
--- a/docs/01_stabilizing/KNOWN_ISSUES.md
+++ b/docs/01_stabilizing/KNOWN_ISSUES.md
@@ -2,7 +2,7 @@
 
 Live issue tracker for the **01_stabilizing** self-hosting phase.
 
-**Next available ID:** STAB-68 (as of 2026-07-17)
+**Next available ID:** STAB-69 (as of 2026-07-17)
 
 ## Intake Convention
 
@@ -358,6 +358,16 @@ These items were genuinely open/deferred in [../00_initial_porting/BREADCRUMBS.m
 ---
 
 ## Fixed Issues
+
+### STAB-68 (2026-07-17, area: intentd workspace events / lastActivity propagation, severity: P1)
+
+Workspace sidebar does not re-sort by lastActivity when an agent makes progress — workspaces only re-sorted when clicked.
+
+**Repro:** Before this fix, workspace `lastActivity` was updated in the DB on every daemon-side activity (agent turn, commit, note edit), but no live event carried the new timestamp to the frontend. The sidebar only re-sorted when the user clicked a workspace, triggering a workspace.get fetch with the fresh `lastActivity`. Even with the WSS event stream connected, newly-active workspaces stayed at the bottom of the sidebar until clicked.
+
+**Expected:** When an agent or daemon operation updates workspace `lastActivity`, a debounced `workspace:updated` event with the new timestamp is emitted over the WSS connection, and the FE sidebar re-sorts in real-time without user interaction.
+
+**Status:** fixed ([intent-hq/intentd#224](https://github.com/intent-hq/intentd/pull/224), [intent-hq/intentd#225](https://github.com/intent-hq/intentd/pull/225), 2026-07-17) — `workspace:updated` event now emitted with debounced (200ms) trailing-edge logic; follow-up PR #225 addressed Copilot review findings: debounce insertion race condition (generation counter guard), lexicographical RFC3339 comparison bug (chrono::DateTime parsing for timestamp advancement assertions), and RAII environment variable isolation in tests (DebounceEnvGuard)
 
 ### STAB-67 (2026-07-17, area: cloudlands-fe / files store, severity: P2)
 


### PR DESCRIPTION
Fixes STAB-68: workspace sidebar now re-sorts live as agents make progress.

Phase 1 (intentd):
- PR #224 (intent-hq/intentd#224): Implemented debounced workspace:updated event emission with lastActivity on daemon-side workspace activity (agent turns, commits, note edits)
- PR #225 (intent-hq/intentd#225): Addressed 7 Copilot review threads:
  - Fixed debounce insertion race (generation counter guard prevents older schedules from overwriting newer entries)
  - Fixed RFC3339 timestamp comparison bug (chrono::DateTime parsing for real temporal comparison vs lexicographical string comparison)
  - Fixed test environment variable leaks (RAII DebounceEnvGuard for process-global env var isolation)

Both PRs merged to intentd main (HEAD: 0a72f6f).

Phase 2 (monorepo):
This PR:
- Bumps packages/intentd submodule to 0a72f6f
- Adds STAB-68 to docs/01_stabilizing/KNOWN_ISSUES.md (fixed, 2026-07-17)
- Bumps Next available ID to STAB-69

Verification:
All intentd CI gates green on both PRs (pr-title, check, build, CodeQL, Analyze).
