### PR TITLE
fix: bump cloudlands-fe for beta-updates toggle fix (STAB-81)

### DIFF
--- a/docs/01_stabilizing/KNOWN_ISSUES.md
+++ b/docs/01_stabilizing/KNOWN_ISSUES.md
@@ -2,7 +2,7 @@
 
 Live issue tracker for the **01_stabilizing** self-hosting phase.
 
-**Next available ID:** STAB-81 (as of 2026-07-17)
+**Next available ID:** STAB-82 (as of 2026-07-17)
 
 ## Intake Convention
 
@@ -368,6 +368,16 @@ These items were genuinely open/deferred in [../00_initial_porting/BREADCRUMBS.m
 ---
 
 ## Fixed Issues
+
+### STAB-81 (2026-07-17, area: cloudlands-fe / settings auto-update, severity: P1)
+
+Beta-updates toggle in Settings unresponsive when clicked. Toggle does not reflect actual update channel on app boot in real (non-mock) mode.
+
+**Repro:** Launch app in real mode (not mock). Open Settings → About → Beta Updates. Click the beta-updates toggle. Observe: toggle does not flip, no channel switch occurs. Relaunch app. Observe: toggle shows wrong state (doesn't match actual channel).
+
+**Root cause:** (1) Middleware called dead `invoke('settings:set')` with no main-process handler — the IPC call silently failed. (2) Real-mode boot hydration missing — only mock seeder synced Redux `betaUpdatesEnabled` with main-process channel from `autoUpdateClient.getState()`. The middleware also called `autoUpdateClient.setChannel()` which already persisted via local-prefs, making the dead settings:set call redundant.
+
+**Status:** fixed (https://github.com/intent-hq/cloudlands-fe/pull/125, 2026-07-17)
 
 ### STAB-80 (2026-07-17, area: intentd workspace events / lastActivity propagation, severity: P1)
 


### PR DESCRIPTION
## Summary

Bumps packages/cloudlands-fe submodule from 51d0d9f6 to 60e18cc8 to include the beta-updates toggle fix from cloudlands-fe PR #125.

## Included Fix

**STAB-81**: Beta-updates toggle in Settings was unresponsive when clicked and did not reflect actual update channel on app boot in real (non-mock) mode.

## Root Cause

1. Middleware called dead invoke('settings:set') with no main-process handler — the IPC call silently failed
2. Real-mode boot hydration missing — only mock seeder synced Redux betaUpdatesEnabled with main-process channel from autoUpdateClient.getState()
3. The middleware also called autoUpdateClient.setChannel() which already persisted via local-prefs, making the dead settings:set call redundant

## Changes

- Updates packages/cloudlands-fe gitlink: 51d0d9f6 → 60e18cc8
- Adds STAB-81 entry to docs/01_stabilizing/KNOWN_ISSUES.md
- Updates next available ID to STAB-82

## Related

- Cloudlands-fe PR: https://github.com/intent-hq/cloudlands-fe/pull/125
- STAB-81 documented in KNOWN_ISSUES.md
