### PR TITLE
chore: update cloudlands-fe submodule to latest main

### DIFF
--- a/docs/01_stabilizing/KNOWN_ISSUES.md
+++ b/docs/01_stabilizing/KNOWN_ISSUES.md
@@ -33,7 +33,7 @@ Chat drafts are not persisted to the backend, causing them to be lost when switc
 
 **Expected:** The frontend should call `appClient.drafts.get(workspaceId, agentId)` on workspace mount to restore drafts and `appClient.drafts.set(workspaceId, agentId, text)` (debounced) as the user types. The backend persists drafts keyed by `(workspaceId, agentId, clientId)` with `ON DELETE CASCADE` to workspace, so drafts survive workspace switches and are properly cleaned up when workspaces are deleted.
 
-**Status:** open
+**Status:** fixed ([intent-hq/cloudlands-fe#126](https://github.com/intent-hq/cloudlands-fe/pull/126), 2026-07-17)
 
 ### STAB-79 (2026-07-17, area: cloudlands-fe sidebar status grouping / workspace activity, severity: P1)
 

--- a/docs/01_stabilizing/KNOWN_ISSUES.md
+++ b/docs/01_stabilizing/KNOWN_ISSUES.md
@@ -19,22 +19,6 @@ Each issue entry includes:
 
 ## Open Issues
 
-### STAB-80 (2026-07-17, area: cloudlands-fe chat drafts persistence, severity: P1)
-
-Chat drafts are not persisted to the backend, causing them to be lost when switching workspaces.
-
-**Repro:**
-1. Open a workspace and start typing a message in the chat input (do not send it)
-2. Switch to a different workspace
-3. Switch back to the original workspace
-4. Observe: the draft message is lost
-
-**Root cause:** The frontend is still using the old localStorage-based draft persistence (via `transient-ui-slice` Redux state, lines 14, 27, 75-80, 127-144 in `transient-ui-slice.ts`) instead of the backend `drafts.get`/`drafts.set`/`drafts.clear` RPC methods specified in IMPLEMENTATION_SPEC.md §9.10/§15 and PROTOCOL.md §5.16. The backend methods are implemented (in `intent-services/src/drafts.rs`) and tested (see `intentd/tests/uds_integration.rs`, `intentd/tests/wss_integration.rs`), but the frontend never calls them. `ChatPanel.svelte` (lines 940-973) restores and saves drafts using Redux actions `setChatDraft`/`clearChatDraft`, which only update in-memory state that's lost on workspace unmount (line 145: `workspaceUnmounted` clears the workspace's transient state).
-
-**Expected:** The frontend should call `appClient.drafts.get(workspaceId, agentId)` on workspace mount to restore drafts and `appClient.drafts.set(workspaceId, agentId, text)` (debounced) as the user types. The backend persists drafts keyed by `(workspaceId, agentId, clientId)` with `ON DELETE CASCADE` to workspace, so drafts survive workspace switches and are properly cleaned up when workspaces are deleted.
-
-**Status:** fixed ([intent-hq/cloudlands-fe#126](https://github.com/intent-hq/cloudlands-fe/pull/126), 2026-07-17)
-
 ### STAB-79 (2026-07-17, area: cloudlands-fe sidebar status grouping / workspace activity, severity: P1)
 
 Sidebar showed every workspace as Idle even with working agents; workspaces with running agents appeared under Complete/PR sections; running agent icons did not clear when all agents went idle.
@@ -394,6 +378,22 @@ Beta-updates toggle in Settings unresponsive when clicked. Toggle does not refle
 **Root cause:** (1) Middleware called dead `invoke('settings:set')` with no main-process handler — the IPC call silently failed. (2) Real-mode boot hydration missing — only mock seeder synced Redux `betaUpdatesEnabled` with main-process channel from `autoUpdateClient.getState()`. The middleware also called `autoUpdateClient.setChannel()` which already persisted via local-prefs, making the dead settings:set call redundant.
 
 **Status:** fixed (https://github.com/intent-hq/cloudlands-fe/pull/125, 2026-07-17)
+
+### STAB-80 (2026-07-17, area: cloudlands-fe chat drafts persistence, severity: P1)
+
+Chat drafts are not persisted to the backend, causing them to be lost when switching workspaces.
+
+**Repro:**
+1. Open a workspace and start typing a message in the chat input (do not send it)
+2. Switch to a different workspace
+3. Switch back to the original workspace
+4. Observe: the draft message is lost
+
+**Root cause:** The frontend is still using the old localStorage-based draft persistence (via `transient-ui-slice` Redux state, lines 14, 27, 75-80, 127-144 in `transient-ui-slice.ts`) instead of the backend `drafts.get`/`drafts.set`/`drafts.clear` RPC methods specified in IMPLEMENTATION_SPEC.md §9.10/§15 and PROTOCOL.md §5.16. The backend methods are implemented (in `intent-services/src/drafts.rs`) and tested (see `intentd/tests/uds_integration.rs`, `intentd/tests/wss_integration.rs`), but the frontend never calls them. `ChatPanel.svelte` (lines 940-973) restores and saves drafts using Redux actions `setChatDraft`/`clearChatDraft`, which only update in-memory state that's lost on workspace unmount (line 145: `workspaceUnmounted` clears the workspace's transient state).
+
+**Expected:** The frontend should call `appClient.drafts.get(workspaceId, agentId)` on workspace mount to restore drafts and `appClient.drafts.set(workspaceId, agentId, text)` (debounced) as the user types. The backend persists drafts keyed by `(workspaceId, agentId, clientId)` with `ON DELETE CASCADE` to workspace, so drafts survive workspace switches and are properly cleaned up when workspaces are deleted.
+
+**Status:** fixed ([intent-hq/cloudlands-fe#126](https://github.com/intent-hq/cloudlands-fe/pull/126), 2026-07-17)
 
 ### STAB-80 (2026-07-17, area: intentd workspace events / lastActivity propagation, severity: P1)
 

--- a/docs/01_stabilizing/KNOWN_ISSUES.md
+++ b/docs/01_stabilizing/KNOWN_ISSUES.md
@@ -2,7 +2,7 @@
 
 Live issue tracker for the **01_stabilizing** self-hosting phase.
 
-**Next available ID:** STAB-80 (as of 2026-07-17)
+**Next available ID:** STAB-81 (as of 2026-07-17)
 
 ## Intake Convention
 
@@ -18,6 +18,22 @@ Each issue entry includes:
 ---
 
 ## Open Issues
+
+### STAB-80 (2026-07-17, area: cloudlands-fe chat drafts persistence, severity: P1)
+
+Chat drafts are not persisted to the backend, causing them to be lost when switching workspaces.
+
+**Repro:**
+1. Open a workspace and start typing a message in the chat input (do not send it)
+2. Switch to a different workspace
+3. Switch back to the original workspace
+4. Observe: the draft message is lost
+
+**Root cause:** The frontend is still using the old localStorage-based draft persistence (via `transient-ui-slice` Redux state, lines 14, 27, 75-80, 127-144 in `transient-ui-slice.ts`) instead of the backend `drafts.get`/`drafts.set`/`drafts.clear` RPC methods specified in IMPLEMENTATION_SPEC.md §9.10/§15 and PROTOCOL.md §5.16. The backend methods are implemented (in `intent-services/src/drafts.rs`) and tested (see `intentd/tests/uds_integration.rs`, `intentd/tests/wss_integration.rs`), but the frontend never calls them. `ChatPanel.svelte` (lines 940-973) restores and saves drafts using Redux actions `setChatDraft`/`clearChatDraft`, which only update in-memory state that's lost on workspace unmount (line 145: `workspaceUnmounted` clears the workspace's transient state).
+
+**Expected:** The frontend should call `appClient.drafts.get(workspaceId, agentId)` on workspace mount to restore drafts and `appClient.drafts.set(workspaceId, agentId, text)` (debounced) as the user types. The backend persists drafts keyed by `(workspaceId, agentId, clientId)` with `ON DELETE CASCADE` to workspace, so drafts survive workspace switches and are properly cleaned up when workspaces are deleted.
+
+**Status:** open
 
 ### STAB-79 (2026-07-17, area: cloudlands-fe sidebar status grouping / workspace activity, severity: P1)
 

--- a/pr-body-task-creation-docs.md
+++ b/pr-body-task-creation-docs.md
@@ -1,0 +1,32 @@
+## Problem
+
+When prompted to 'create a task', agents may not know which method to use:
+- `@@@task` blocks in notes (auto-converts to task notes)
+- Task management tools (`add_tasks`, `update_tasks`)
+- Direct task note creation via `ws.note.create`
+
+This can lead to:
+- Using the wrong method for the context
+- Duplicating content instead of linking
+- Missing the auto-conversion feature of `@@@task` blocks
+
+## Solution
+
+Added a clear decision tree to the 'Creating Tasks' section in `workspace.md`:
+
+1. **For tasks in the spec or notes** → Use `@@@task` blocks (auto-converts to task notes)
+2. **For conversation-level task tracking** → Use task management tools
+3. **Direct task note creation** → Rarely needed; prefer `@@@task` blocks
+
+Also added emphasis that `@@@task` is the **preferred method** for planning/spec tasks.
+
+## Changes
+
+- Updated `crates/intent-services/resources/agent-instructions/workspace.md`
+- Added decision tree at the top of 'Creating Tasks' section
+- Clarified when each method should be used
+- Emphasized `@@@task` as the preferred method for spec tasks
+
+## Testing
+
+This is a documentation-only change to agent instructions. No code changes, no tests needed.


### PR DESCRIPTION
Brings in cloudlands-fe#126: Chat drafts persistence (STAB-80 fix).

Frontend now persists drafts via backend RPC methods instead of localStorage.

**Submodule PRs:**
- https://github.com/intent-hq/cloudlands-fe/pull/126 (merged)

**Known Issues:**
- Closes STAB-80 in `docs/01_stabilizing/KNOWN_ISSUES.md`
