### PR TITLE
docs: graceful-shutdown capture semantics (STAB-82, intentd#219)

### DIFF
--- a/docs/01_stabilizing/KNOWN_ISSUES.md
+++ b/docs/01_stabilizing/KNOWN_ISSUES.md
@@ -2,7 +2,7 @@
 
 Live issue tracker for the **01_stabilizing** self-hosting phase.
 
-**Next available ID:** STAB-82 (as of 2026-07-17)
+**Next available ID:** STAB-83 (as of 2026-07-17)
 
 ## Intake Convention
 
@@ -18,6 +18,16 @@ Each issue entry includes:
 ---
 
 ## Open Issues
+
+### STAB-82 (2026-07-17, area: intentd agent resumption / graceful shutdown, severity: P1)
+
+Agents mid-turn during graceful shutdown were settled to `RuntimeIdle` instead of being captured as interrupted, so the resumption modal never appeared after a clean restart.
+
+**Repro:** Start intentd, spawn an agent and let it run a turn, then quit intentd gracefully via `SIGINT` or `SIGTERM` (normal quit, not a crash). Expected: after restart, `agent.listInterrupted` returns the agent and the FE shows the resumption modal. Actual before fix: `agent.listInterrupted` returned an empty list because the `signal_handler_task` settled all active agent sessions to `RuntimeIdle` without capturing them as interrupted records first. The heal sweep on next startup thus saw only `RuntimeIdle` rows (not `active`/`processing`/`waiting`) and never created interruption records. The resumption modal only appeared after crash scenarios (where the signal handler never ran).
+
+**Expected:** Graceful shutdown (`SIGINT`/`SIGTERM`) captures in-flight agents (`active`, `processing`, `waiting` statuses) as interrupted records before settling them to `RuntimeIdle`, exactly like the crash-recovery heal path. The resumption modal appears after both clean and unclean shutdowns whenever agents were mid-turn.
+
+**Status:** fixed ([intent-hq/intentd#219](https://github.com/intent-hq/intentd/pull/219), 2026-07-17)
 
 ### STAB-79 (2026-07-17, area: cloudlands-fe sidebar status grouping / workspace activity, severity: P1)
 

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -321,7 +321,7 @@ These 4 method names are **dual-role**: they appear in the dispatchable method c
 
 ### 6.6 Interrupted-Agent Resumption (v2.0 additions)
 
-The following methods manage agent resumption across daemon restarts. When `intentd` restarts, in-flight agent sessions (`active`, `processing`, `waiting` statuses) are captured as **interrupted records** before the heal sweep rewrites them to `idle`. Clients discover interrupted agents via `agent.listInterrupted` and resolve them via `agent.resolveInterrupted` (resume or abandon). For headless deployments, `intentd serve --resume-all` auto-resumes all interrupted agents at startup.
+The following methods manage agent resumption across daemon restarts. When `intentd` restarts, in-flight agent sessions (`active`, `processing`, `waiting` statuses) are captured as **interrupted records** before the heal sweep rewrites them to `idle`. This capture occurs on both graceful shutdown (`SIGINT`/`SIGTERM`) and crash scenarios, ensuring that agents mid-turn are always resumable. Clients discover interrupted agents via `agent.listInterrupted` and resolve them via `agent.resolveInterrupted` (resume or abandon). For headless deployments, `intentd serve --resume-all` auto-resumes all interrupted agents at startup.
 
 #### `agent.listInterrupted`
 


### PR DESCRIPTION
Document intentd PR #219 graceful-shutdown capture semantics.

## Changes
- **STAB-82**: document the graceful-shutdown capture gap (agents mid-turn were settled to RuntimeIdle without capture on normal quit, so the resumption modal never appeared after clean restarts) and mark it fixed with PR link and date 2026-07-17
- **PROTOCOL.md §6.6**: clarify that interruption capture occurs on both graceful shutdown (SIGINT/SIGTERM) and crash scenarios

## Context
The intentd submodule was already bumped to 282aba8 on main (feat: capture interrupted agents on graceful shutdown, intent-hq/intentd#219). This PR adds the accompanying documentation.

Before PR #219, agents mid-turn during graceful shutdown were settled to `RuntimeIdle` without being captured as interrupted, so `agent.listInterrupted` returned an empty list after restart and the resumption modal never appeared. The fix captures in-flight agents during the signal handler task before settling them.

## Related
- Upstream intentd PR: https://github.com/intent-hq/intentd/pull/219
- Spec: right-check workspace (Agent resumption on intentd restart)
