### PR TITLE
fix: reconcile workspace.activity on missed edges (STAB-79)

### DIFF
--- a/docs/01_stabilizing/KNOWN_ISSUES.md
+++ b/docs/01_stabilizing/KNOWN_ISSUES.md
@@ -19,26 +19,6 @@ Each issue entry includes:
 
 ## Open Issues
 
-### STAB-82 (2026-07-17, area: intentd agent resumption / graceful shutdown, severity: P1)
-
-Agents mid-turn during graceful shutdown were settled to `RuntimeIdle` instead of being captured as interrupted, so the resumption modal never appeared after a clean restart.
-
-**Repro:** Start intentd, spawn an agent and let it run a turn, then quit intentd gracefully via `SIGINT` or `SIGTERM` (normal quit, not a crash). Expected: after restart, `agent.listInterrupted` returns the agent and the FE shows the resumption modal. Actual before fix: `agent.listInterrupted` returned an empty list because the `signal_handler_task` settled all active agent sessions to `RuntimeIdle` without capturing them as interrupted records first. The heal sweep on next startup thus saw only `RuntimeIdle` rows (not `active`/`processing`/`waiting`) and never created interruption records. The resumption modal only appeared after crash scenarios (where the signal handler never ran).
-
-**Expected:** Graceful shutdown (`SIGINT`/`SIGTERM`) captures in-flight agents (`active`, `processing`, `waiting` statuses) as interrupted records before settling them to `RuntimeIdle`, exactly like the crash-recovery heal path. The resumption modal appears after both clean and unclean shutdowns whenever agents were mid-turn.
-
-**Status:** fixed ([intent-hq/intentd#219](https://github.com/intent-hq/intentd/pull/219), 2026-07-17)
-
-### STAB-79 (2026-07-17, area: cloudlands-fe sidebar status grouping / workspace activity, severity: P1)
-
-Sidebar showed every workspace as Idle even with working agents; workspaces with running agents appeared under Complete/PR sections; running agent icons did not clear when all agents went idle.
-
-**Repro:** Before the fix, the sidebar displayed incorrect workspace statuses due to three related issues: (1) Workspace.activity field was not wired from the daemon (intentd emitted workspace:activity-changed events but the FE did not subscribe or merge them), so the FE had no knowledge of when workspaces transitioned between Idle and AgentRunning states. (2) The sidebar grouping logic did not consider running agents when determining display status — workspaces with active agents could be grouped under "Complete" or "Ready for PR" based solely on their base status (e.g., pr_merged), ignoring ongoing agent work. (3) WorkspaceCard running agent avatars were controlled only by activeStreamsTracker and cached Redux agent state, which could remain stale after all agents went idle, leaving running-state icons visible indefinitely even when workspace.activity === 'idle'.
-
-**Expected:** Sidebar accurately reflects workspace activity: workspaces with running agents always appear under "In Progress" regardless of PR/merge status, and workspace cards show no running agent avatars when workspace.activity === 'idle'.
-
-**Status:** fixed ([intent-hq/cloudlands-fe#123](https://github.com/intent-hq/cloudlands-fe/pull/123), [intent-hq/cloudlands-fe#124](https://github.com/intent-hq/cloudlands-fe/pull/124), 2026-07-17)
-
 ### STAB-63 (2026-07-17, area: intentd doctor / e2e_core_cli_commands test, severity: P2)
 
 The `doctor_checks_data_dir_and_migrations` test fails deterministically when a live intentd daemon is running.
@@ -378,6 +358,26 @@ These items were genuinely open/deferred in [../00_initial_porting/BREADCRUMBS.m
 ---
 
 ## Fixed Issues
+
+### STAB-82 (2026-07-17, area: intentd agent resumption / graceful shutdown, severity: P1)
+
+Agents mid-turn during graceful shutdown were settled to `RuntimeIdle` instead of being captured as interrupted, so the resumption modal never appeared after a clean restart.
+
+**Repro:** Start intentd, spawn an agent and let it run a turn, then quit intentd gracefully via `SIGINT` or `SIGTERM` (normal quit, not a crash). Expected: after restart, `agent.listInterrupted` returns the agent and the FE shows the resumption modal. Actual before fix: `agent.listInterrupted` returned an empty list because the `signal_handler_task` settled all active agent sessions to `RuntimeIdle` without capturing them as interrupted records first. The heal sweep on next startup thus saw only `RuntimeIdle` rows (not `active`/`processing`/`waiting`) and never created interruption records. The resumption modal only appeared after crash scenarios (where the signal handler never ran).
+
+**Expected:** Graceful shutdown (`SIGINT`/`SIGTERM`) captures in-flight agents (`active`, `processing`, `waiting` statuses) as interrupted records before settling them to `RuntimeIdle`, exactly like the crash-recovery heal path. The resumption modal appears after both clean and unclean shutdowns whenever agents were mid-turn.
+
+**Status:** fixed ([intent-hq/intentd#219](https://github.com/intent-hq/intentd/pull/219), 2026-07-17)
+
+### STAB-79 (2026-07-17, area: cloudlands-fe sidebar status grouping / workspace activity, severity: P1)
+
+Sidebar showed every workspace as Idle even with working agents; workspaces with running agents appeared under Complete/PR sections; running agent icons did not clear when all agents went idle.
+
+**Repro:** Before the fix, the sidebar displayed incorrect workspace statuses due to four related issues: (1) Workspace.activity field was not wired from the daemon (intentd emitted workspace:activity-changed events but the FE did not subscribe or merge them), so the FE had no knowledge of when workspaces transitioned between Idle and AgentRunning states. (2) The sidebar grouping logic did not consider running agents when determining display status — workspaces with active agents could be grouped under "Complete" or "Ready for PR" based solely on their base status (e.g., pr_merged), ignoring ongoing agent work. (3) WorkspaceCard running agent avatars were controlled only by activeStreamsTracker and cached Redux agent state, which could remain stale after all agents went idle, leaving running-state icons visible indefinitely even when workspace.activity === 'idle'. (4) Edge-triggered workspace:activity-changed events could be missed (e.g., coordinator-only workspaces where the 0→1 agent transition fired before FE subscription or entity seeding), leaving workspaces stuck at Idle even while agents were mid-turn.
+
+**Expected:** Sidebar accurately reflects workspace activity: workspaces with running agents always appear under "In Progress" regardless of PR/merge status, and workspace cards show no running agent avatars when workspace.activity === 'idle'. Activity reconciliation detects missed edges via agent-implying events and refetches workspace.activity when FE state is stale.
+
+**Status:** fixed ([intent-hq/cloudlands-fe#123](https://github.com/intent-hq/cloudlands-fe/pull/123), [intent-hq/cloudlands-fe#124](https://github.com/intent-hq/cloudlands-fe/pull/124), [intent-hq/cloudlands-fe#128](https://github.com/intent-hq/cloudlands-fe/pull/128), 2026-07-17)
 
 ### STAB-81 (2026-07-17, area: cloudlands-fe / settings auto-update, severity: P1)
 


### PR DESCRIPTION
## Summary
Fixes two CI test failures:
1. The hanging `completion_report_cleared_when_new_turn_begins_over_wss` test that blocked `coverage-e2e` and `coverage-all` jobs (30-min timeout) since PR #221 merged
2. The `uds_integration::uds_slice_end_to_end` test failure introduced by PR #223 (saveSetupScript repo-config-only contract)

## Root Cause 1: Hanging completion_report Test
The test waited for `agent:created` with `parentAgentId`, but that event **never includes `parentAgentId`** (emission at agent_ops.rs:1042 only sends `agentId` and `name`). The test also used `wss_event()` whose 30s timeout **resets on every WebSocket frame** — heartbeat `Ping` frames kept the wait alive forever when the expected event never arrived (exactly the footgun the `wss_event_opt` doc comment warns about).

## Root Cause 2: PR #223 Regression
PR #223 changed `saveSetupScript` to require a repository path (writes to `.intent/config.json` instead of DB). The `uds_slice_end_to_end` test used a workspace with no `repository_path`/`worktree_path`, so `saveSetupScript` now correctly returns `-32602 InvalidParams` instead of persisting. The test assertions were updated to reflect the new "repo config sole source" contract.

## Changes

### Test Fix 1: completion_report (commit 1, sha 6ae7a5c)
- Get child ID from parent's `waitingForAgentIds` after parent goes idle (delegation metadata), matching the pattern in `e2e_wss_delegation_group_persist`
- Replace all `wss_event()` calls with `wss_event_opt()` (deadline-bounded, not per-frame timeout) so heartbeat Pings cannot extend waits indefinitely
- Fix agent.get response path: check `agent.metadata.completionReport` instead of `metadata.completionReport` (missing 'agent' level in JSON structure)

Test now passes 3x consecutively in ~3s each (was hanging at 30 min job timeout).

### Nextest Hang Guard (commit 2, sha 51decfb)
Add `slow-timeout` to `.config/nextest.toml` (`period=90s, terminate-after=2`). Heavy e2e tests under llvm-cov legitimately exceed 60s but should complete within 90s. A hung test will be terminated at 270s (3 periods) rather than consuming the full 30-min coverage job.

Motivated by the completion_report hang (PR #221), but this guard ensures no single stuck test can block CI for 30 minutes going forward.

### Test Fix 2: uds_integration (commit 3, sha 6f7109a)
Update `uds_slice_end_to_end` test sections f5-f6 to assert that `saveSetupScript` without a repository path returns `-32602 InvalidParams` (aligns with PR #223's repo-config-only contract).

## Verification
- ✅ `completion_report_cleared` test passes 3x consecutively locally (~3s each)
- ✅ `uds_slice_end_to_end` test passes 3x consecutively locally (~7s each)
- ✅ `cargo fmt --check` and `cargo clippy --workspace -- -D warnings` green
- Waiting for CI: `coverage-e2e` and `coverage-all` should complete (green) in well under 30 min

## References
- Blocked by: #221 (introduced the hanging test)
- Regression from: #223 (repo-config-only contract broke uds_integration test)
- Spec: monorepo `docs/01_stabilizing/KNOWN_ISSUES.md` will be updated in follow-up PR
