### PR TITLE
chore: update cloudlands-fe submodule for notification test fix (STAB-83)

### DIFF
--- a/docs/01_stabilizing/KNOWN_ISSUES.md
+++ b/docs/01_stabilizing/KNOWN_ISSUES.md
@@ -389,7 +389,7 @@ Notification settings (enabled, soundEnabled, soundOnlyWhenUnfocused, volume) we
 
 **Expected:** Notification toggles persist via `settings.update` to the daemon's canonical `notifications.*` paths. Settings survive app relaunch because the daemon catalog is durable. Hydration-dispatched actions are suppressed from persistence to prevent echo-writes. Tests use fake timers and evolving state mocks.
 
-**Status:** fixed ([intent-hq/cloudlands-fe#127](https://github.com/intent-hq/cloudlands-fe/pull/127), [intent-hq/cloudlands-fe#129](https://github.com/intent-hq/cloudlands-fe/pull/129), 2026-07-17)
+**Status:** fixed ([intent-hq/cloudlands-fe#127](https://github.com/intent-hq/cloudlands-fe/pull/127), [intent-hq/cloudlands-fe#129](https://github.com/intent-hq/cloudlands-fe/pull/129), [intent-hq/cloudlands-fe#130](https://github.com/intent-hq/cloudlands-fe/pull/130), 2026-07-17)
 
 ### STAB-82 (2026-07-17, area: intentd agent resumption / graceful shutdown, severity: P1)
 


### PR DESCRIPTION
## Summary

Final close-out for STAB-83 (notification settings persistence): bumps cloudlands-fe submodule to e0be69bb to include PR #130 (test flakiness fix).

## Changes

- Update cloudlands-fe gitlink to e0be69bb (includes PR #130 merge)
- Add PR #130 link to STAB-83 Status line

## Context

PR #130 fixed test flakiness in the notification-settings hydration regression test by replacing `vi.runAllTimersAsync()` with deterministic promise-based waiting (`vi.waitFor` + explicit microtask flush). The original test could be flaky under load because `hydrateFromDaemon()` is promise-based, not timer-based.

STAB-83 now references all three PRs:
- #127: initial fix (route to daemon notifications.* paths)
- #129: echo-write guard + test improvements
- #130: test flakiness fix
