### PR TITLE
fix: bump cloudlands-fe to beeeddba (sidebar agent icons fix)

### DIFF
--- a/docs/01_stabilizing/KNOWN_ISSUES.md
+++ b/docs/01_stabilizing/KNOWN_ISSUES.md
@@ -2,7 +2,7 @@
 
 Live issue tracker for the **01_stabilizing** self-hosting phase.
 
-**Next available ID:** STAB-86 (as of 2026-07-17)
+**Next available ID:** STAB-87 (as of 2026-07-17)
 
 ## Intake Convention
 
@@ -28,6 +28,18 @@ The `completion_report_cleared_when_new_turn_begins_over_wss` e2e test hung inde
 **Expected:** E2e tests use deadline-bounded event waits that fail fast when expected events never arrive. The `wss_event_opt` helper (with a single overall deadline, no heartbeat resets) should be used for waits that may legitimately time out, and child agent IDs should be retrieved from the parent agent's `waitingForAgentIds` field rather than expecting a `parentAgentId` on `agent:created`.
 
 **Status:** fixed ([intent-hq/intentd#227](https://github.com/intent-hq/intentd/pull/227), 2026-07-17) — test switched to `wss_event_opt` for deadline-bounded waits and retrieves child ID from parent's `waitingForAgentIds`; added nextest slow-timeout guard (~5 min) to catch similar hangs; intentd main ruleset now requires coverage-e2e and coverage-all as merge-queue checks to prevent merging PRs with failing coverage jobs
+
+### STAB-86 (2026-07-17, area: cloudlands-fe sidebar / active-streams tracker, severity: P1)
+
+Sidebar agent-running icons never appeared for workspaces with active agents after app boot.
+
+**Repro:** Before the fix: start the app with a workspace that has one or more active agents (mid-turn). Open that workspace in the sidebar. Observe: the sidebar WorkspaceCard shows no running-agent icons (the avatars with "🔄" overlay or equivalent) for the active agents, even though the agents are actively processing turns and visible in the chat UI. The workspace appears idle in the sidebar.
+
+**Root cause:** The tracker→Redux `bumpActiveStreamsVersion` bridge was lost in the saga removal. The `activeStreamsTracker` (in `features/agent/stream/active-streams-tracker.ts`) maintained correct live state of active agents and fired `activeStreamsChanged` events when agents started or stopped streaming, but the saga that previously listened to these events and dispatched `activeStreamsVersionBumped` Redux actions (to trigger WorkspaceCard re-renders) was removed in commit `95d908a2` without being re-homed as middleware. After boot, when active-stream data arrived from the daemon (via `agent:stream` or `agent:updated` WSS events), the tracker updated its internal state but the Redux store's `activeStreamsVersion` counter never incremented, so the sidebar WorkspaceCard components never re-rendered to reflect the newly active agents.
+
+**Expected:** When `activeStreamsTracker` fires `activeStreamsChanged` events (agent started or stopped), a middleware immediately dispatches `activeStreamsVersionBumped` to bump the Redux store's version counter, triggering WorkspaceCard re-renders that reflect the current set of running agents in the sidebar.
+
+**Status:** fixed ([intent-hq/cloudlands-fe#100](https://github.com/intent-hq/cloudlands-fe/pull/100), 2026-07-17)
 
 ### STAB-84 (2026-07-17, area: intentd workspace RPC / setup scripts, severity: P1)
 


### PR DESCRIPTION
Updates packages/cloudlands-fe submodule to beeeddba1952d010077e5b3550c66346aa28e193, landing the fix for sidebar agent-running icons never appearing after app boot.

Also adds STAB-86 entry to docs/01_stabilizing/KNOWN_ISSUES.md documenting the root cause (tracker→Redux bumpActiveStreamsVersion bridge lost in saga removal) and fix.

**Root cause:** The tracker→Redux bumpActiveStreamsVersion bridge was lost in the saga removal. After boot, when active-stream data arrived from the daemon, the tracker updated its internal state but the Redux store's activeStreamsVersion counter never incremented, so the sidebar WorkspaceCard components never re-rendered to reflect active agents.

Fixes cloudlands-fe#100

Ref: intent-hq/cloudlands-fe#100
