### PR TITLE
docs: add STAB-94 for workspace card markdown rendering fix

### DIFF
--- a/docs/01_stabilizing/KNOWN_ISSUES.md
+++ b/docs/01_stabilizing/KNOWN_ISSUES.md
@@ -2,7 +2,7 @@
 
 Live issue tracker for the **01_stabilizing** self-hosting phase.
 
-**Next available ID:** STAB-94 (as of 2026-07-17)
+**Next available ID:** STAB-95 (as of 2026-07-17)
 
 ## Intake Convention
 
@@ -400,6 +400,18 @@ These items were genuinely open/deferred in [../00_initial_porting/BREADCRUMBS.m
 ---
 
 ## Fixed Issues
+
+### STAB-94 (2026-07-17, area: cloudlands-fe chat markdown rendering / messageParser, severity: P2)
+
+Inline-code list items like `pr-title` rendered as "Workspace not found" cards instead of code formatting in chat.
+
+**Repro:** Before the fix, the messageParser's bare-ID promotion heuristic (`promoteWorkspaceIdLists`, `classifyLineForWorkspaceCard`, `tryExtractWorkspaceIdFromLine`) matched workspace slug patterns against everyday hyphenated terms in inline code (e.g., list items like `- pr-title`, `- api-endpoint`). These were incorrectly promoted to workspace card components, which then failed to resolve and rendered as "Workspace not found" cards instead of preserving the original inline-code formatting.
+
+**Expected:** Only explicit @@@workspace ... @@@ sentinel blocks render workspace cards. Inline code, fenced code blocks, and legacy ~~~workspace / ```workspace fences render as code/text without workspace card promotion.
+
+**Resolution:** Removed bare-ID promotion heuristic entirely; added explicit @@@workspace sentinel parsing; updated chief-of-staff specialist prompt to use sentinel syntax instead of fenced blocks.
+
+**Status:** fixed ([intent-hq/cloudlands-fe#131](https://github.com/intent-hq/cloudlands-fe/pull/131), [intent-hq/intentd#229](https://github.com/intent-hq/intentd/pull/229), 2026-07-17)
 
 ### STAB-93 (2026-07-17, area: cloudlands-fe home screen / workspace list, severity: P1)
 


### PR DESCRIPTION
Document the workspace card sentinel syntax fix in KNOWN_ISSUES.md as STAB-94.

## Changes

- **STAB-94 entry**: Documents the cloudlands-fe markdown rendering bug where inline-code list items like `pr-title` were incorrectly promoted to workspace cards, and the fix via @@@workspace sentinel syntax.

## Submodule PRs

Both PRs are already merged and incorporated in main via prior monorepo PRs:
- intent-hq/cloudlands-fe#131 — fix: replace workspace card fences with @@@workspace sentinel syntax (in main via PR #229)
- intent-hq/intentd#229 — refactor: switch chief-of-staff specialist from fenced workspace blocks to sentinel syntax (in main via PR #224)

This PR adds only the STAB-94 documentation entry. No submodule gitlink changes needed.

Verified green with `make check` at monorepo root.
