### PR TITLE
chore: update cloudlands-fe submodule + file STAB-92

### DIFF
--- a/docs/01_stabilizing/KNOWN_ISSUES.md
+++ b/docs/01_stabilizing/KNOWN_ISSUES.md
@@ -2,7 +2,7 @@
 
 Live issue tracker for the **01_stabilizing** self-hosting phase.
 
-**Next available ID:** STAB-87 (as of 2026-07-17)
+**Next available ID:** STAB-88 (as of 2026-07-17)
 
 ## Intake Convention
 

--- a/docs/01_stabilizing/KNOWN_ISSUES.md
+++ b/docs/01_stabilizing/KNOWN_ISSUES.md
@@ -391,6 +391,18 @@ These items were genuinely open/deferred in [../00_initial_porting/BREADCRUMBS.m
 
 ## Fixed Issues
 
+### STAB-87 (2026-07-17, area: cloudlands-fe home screen / workspace list, severity: P1)
+
+The "Show Archived" toggle on the Home screen had no effect — archived workspaces never appeared in the list even when toggled on.
+
+**Repro:** Before the fix: archive a workspace (via workspace settings or `workspace.archive` RPC), then navigate to the Home screen and toggle "Show Archived" to on. Observe: the archived workspace does not appear in the list; only active workspaces are visible regardless of toggle state.
+
+**Root cause:** The renderer `LiveWorkspacesClient.list()` (in `packages/cloudlands-fe/src/main/live-clients/live-workspaces-client.ts`) called the daemon's `workspace.list` RPC without the `includeArchived` parameter. The daemon defaults `includeArchived` to `false` when not specified (per PROTOCOL.md §5.1), so archived workspaces were never returned to the frontend store. The "Show Archived" toggle filtered an already-incomplete dataset (filtering `[]` yields `[]`), making the toggle appear completely non-functional.
+
+**Expected:** When "Show Archived" is toggled on, the Home screen displays both active and archived workspaces. The FE passes `includeArchived: true` to `workspace.list` when the toggle is enabled, and filters the full result set client-side.
+
+**Status:** fixed ([intent-hq/cloudlands-fe#134](https://github.com/intent-hq/cloudlands-fe/pull/134), 2026-07-17)
+
 ### STAB-83 (2026-07-17, area: cloudlands-fe notification settings persistence, severity: P1)
 
 Notification settings (enabled, soundEnabled, soundOnlyWhenUnfocused, volume) were not persisted to the daemon, causing them to be lost on app relaunch.


### PR DESCRIPTION
Updates cloudlands-fe submodule to latest main @ 8587c325, which includes the show-archived toggle fix from intent-hq/cloudlands-fe#134.

Files STAB-87 in KNOWN_ISSUES.md documenting the fix.

**Root cause:** Renderer LiveWorkspacesClient.list() called workspace.list without includeArchived (daemon default false), so archived workspaces never reached the store and the Show Archived toggle had nothing to reveal.

**Submodule ref:** packages/cloudlands-fe @ 8587c325f499f4473a237ad287e016a6250fe3e4