### PR TITLE
docs: renumber duplicate STAB-89 entry to STAB-95

### DIFF
--- a/docs/01_stabilizing/KNOWN_ISSUES.md
+++ b/docs/01_stabilizing/KNOWN_ISSUES.md
@@ -2,7 +2,7 @@
 
 Live issue tracker for the **01_stabilizing** self-hosting phase.
 
-**Next available ID:** STAB-95 (as of 2026-07-17)
+**Next available ID:** STAB-96 (as of 2026-07-17)
 
 ## Intake Convention
 
@@ -29,7 +29,7 @@ Workspace creation auto-pull failed when the configured repository has submodule
 
 **Status:** fixed ([intent-hq/intentd#232](https://github.com/intent-hq/intentd/pull/232), 2026-07-17) — `git.pull` now runs bounded submodule sync after successful pull when `.gitmodules` exists; regression test verifies submodule worktree syncs to new gitlink
 
-### STAB-89 (2026-07-17, area: intentd file-tracking / cloudlands-fe changes panel, severity: P1)
+### STAB-95 (2026-07-17, area: intentd file-tracking / cloudlands-fe changes panel, severity: P1)
 
 The "Workspace start" marker in the Changes panel sat ~50 commits in the past and pre-workspace base-branch commits were listed.
 


### PR DESCRIPTION
Fix duplicate STAB-89 entry by renumbering the new one to STAB-95.

## Issue

PR #232 added a second STAB-89 entry (intentd file-tracking / cloudlands-fe changes panel), but STAB-89 already existed (intentd intent-services / setup-script execution). This created a duplicate ID in the tracker.

## Changes

- Renumber the NEW STAB-89 entry (file-tracking / cloudlands-fe changes panel, line 32) to STAB-95
- Update "Next available ID" from STAB-95 to STAB-96
- Keep the pre-existing STAB-89 (setup-script execution, line 486) unchanged
- Entry remains in correct position (before STAB-90) per descending order convention

## Verification

- ✅ No duplicate STAB-89 entries
- ✅ STAB-95 correctly positioned in descending order
- ✅ Next available ID updated to STAB-96
- ✅ Original STAB-89 unchanged
