### PR TITLE
docs: fix AGENTS.md merge section to reflect actual repo settings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,13 +42,12 @@ When changes span a submodule and the monorepo, follow this sequence: Phase 1 â†
 - **Conventional commits** are required. PR titles are validated by CI
   (`amannn/action-semantic-pull-request`) against: `feat`, `fix`, `chore`, `docs`,
   `refactor`, `test`, `ci`, `perf`.
-- **Merge queue**: `intent-hq/monorepo` main branch uses a merge queue. Do NOT use
-  `gh pr merge --squash` (it will be rejected). Instead, enqueue PRs via GraphQL:
-  `gh api graphql -f query='mutation($id: ID!) { enqueuePullRequest(input: {pullRequestId: $id}) { mergeQueueEntry { position state } } }' -f id="$(gh pr view <PR_NUMBER> --json id --jq .id)"`.
-  **Critical**: the queue's squash message defaults to the sole commit's message, NOT the
-  PR title. On single-commit PRs, ensure every branch commit message is itself a valid
-  conventional commit (amend auto-commits like "Coordinator" before pushing) to prevent
-  non-conventional commits from landing on main (e.g., PR #102 incident).
+- **Merging**: The repository allows squash and rebase merges. When squash-merging, the
+  commit title defaults to the commit message (or PR title as fallback), and the commit
+  message includes all commit messages from the PR. On single-commit PRs, ensure the branch
+  commit message is itself a valid conventional commit (amend auto-commits like
+  "Coordinator" before pushing) to prevent non-conventional commits from landing on main
+  (e.g., PR #102 incident).
 - **Changelogs** are generated with `git-cliff` (see `cliff.toml`).
 - **Rust**: keep `cargo fmt --check`, `cargo clippy -- -D warnings`, and `cargo build`
   green in `packages/intentd` before opening a PR. The **monorepo-root** `Makefile` exposes


### PR DESCRIPTION
Verified via GitHub API that the repository does NOT use a merge queue. Updated AGENTS.md to accurately reflect the actual merge behavior:

- Repository allows squash and rebase merges
- No merge queue is configured
- Squash merge title defaults to commit message (or PR title as fallback)
- Squash merge message includes all commit messages from the PR

The previous documentation incorrectly stated that a merge queue was in use and provided GraphQL commands for enqueueing PRs. This has been corrected to match the actual repository settings verified via `gh api repos/intent-hq/monorepo`.
