### PR TITLE
fix: surface agent:failed error text in chat error card (cloudlands-fe bump)

### DIFF
--- a/docs/01_stabilizing/KNOWN_ISSUES.md
+++ b/docs/01_stabilizing/KNOWN_ISSUES.md
@@ -19,18 +19,6 @@ Each issue entry includes:
 
 ## Open Issues
 
-### STAB-103 (2026-07-18, area: cloudlands-fe chat error card / agent-session state, severity: P2)
-
-Agent turn failures rendered as generic "Agent spawn failed" instead of the daemon's `agent:failed` error text (observed with a session/prompt idle-timeout failure on 2026-07-18).
-
-**Repro:** Before the fix: trigger an agent turn failure that emits `agent:failed` with an error message (e.g., session idle timeout). The chat error card displayed "Agent spawn failed" instead of the actual error text from the daemon event.
-
-**Root cause:** Two issues: (1) `handleAgentFailedStream` in `daemon-events-bridge.ts` early-returned before dispatching `chatSendFailed` when `streamsByAgent` had no state for the agent (occurred when agent spawn failed before any streaming started, e.g., before `agent:stream:chunk` arrived); (2) `canonicalSessionUpdates` in `agent-session-slice.ts` unconditionally set `updates.stopReason = fields.stopReason` even when `fields.stopReason` was `undefined`, so the trailing `agent:status-changed` event (which arrived milliseconds after `agent:failed` without its own `stopReason` field) overwrote the error text with `undefined`.
-
-**Expected:** Chat error card displays the daemon's actual error text from `agent:failed` events.
-
-**Status:** fixed ([intent-hq/cloudlands-fe#147](https://github.com/intent-hq/cloudlands-fe/pull/147), 2026-07-18)
-
 ### STAB-102 (2026-07-18, area: intentd e2e tests / local environment, severity: P2)
 
 The `agent_message_event_emitted_for_queue_drain_and_wake_over_wss` e2e test fails intermittently when run in parallel (`make test`) on a developer machine with multiple live intentd daemons running, but passes consistently in isolation.
@@ -414,6 +402,18 @@ These items were genuinely open/deferred in [../00_initial_porting/BREADCRUMBS.m
 ---
 
 ## Fixed Issues
+
+### STAB-103 (2026-07-18, area: cloudlands-fe chat error card / agent-session state, severity: P2)
+
+Agent turn failures rendered as generic "Agent spawn failed" instead of the daemon's `agent:failed` error text (observed with a session/prompt idle-timeout failure on 2026-07-18).
+
+**Repro:** Before the fix: trigger an agent turn failure that emits `agent:failed` with an error message (e.g., session idle timeout). The chat error card displayed "Agent spawn failed" instead of the actual error text from the daemon event.
+
+**Root cause:** Two issues: (1) `handleAgentFailedStream` in `daemon-events-bridge.ts` early-returned before dispatching `chatSendFailed` when `streamsByAgent` had no state for the agent (occurred when agent spawn failed before any streaming started, e.g., before `agent:stream:chunk` arrived); (2) `canonicalSessionUpdates` in `agent-session-slice.ts` unconditionally set `updates.stopReason = fields.stopReason` even when `fields.stopReason` was `undefined`, so the trailing `agent:status-changed` event (which arrived milliseconds after `agent:failed` without its own `stopReason` field) overwrote the error text with `undefined`.
+
+**Expected:** Chat error card displays the daemon's actual error text from `agent:failed` events.
+
+**Status:** fixed ([intent-hq/cloudlands-fe#147](https://github.com/intent-hq/cloudlands-fe/pull/147), 2026-07-18)
 
 ### STAB-101 (2026-07-17, area: intentd + cloudlands-fe / user message events, severity: P1)
 

--- a/docs/01_stabilizing/KNOWN_ISSUES.md
+++ b/docs/01_stabilizing/KNOWN_ISSUES.md
@@ -2,7 +2,7 @@
 
 Live issue tracker for the **01_stabilizing** self-hosting phase.
 
-**Next available ID:** STAB-103 (as of 2026-07-18)
+**Next available ID:** STAB-104 (as of 2026-07-18)
 
 ## Intake Convention
 
@@ -18,6 +18,18 @@ Each issue entry includes:
 ---
 
 ## Open Issues
+
+### STAB-103 (2026-07-18, area: cloudlands-fe chat error card / agent-session state, severity: P2)
+
+Agent turn failures rendered as generic "Agent spawn failed" instead of the daemon's `agent:failed` error text (observed with a session/prompt idle-timeout failure on 2026-07-18).
+
+**Repro:** Before the fix: trigger an agent turn failure that emits `agent:failed` with an error message (e.g., session idle timeout). The chat error card displayed "Agent spawn failed" instead of the actual error text from the daemon event.
+
+**Root cause:** Two issues: (1) `handleAgentFailedStream` in `daemon-events-bridge.ts` early-returned before dispatching `chatSendFailed` when `streamsByAgent` had no state for the agent (occurred when agent spawn failed before any streaming started, e.g., before `agent:stream:chunk` arrived); (2) `canonicalSessionUpdates` in `agent-session-slice.ts` unconditionally set `updates.stopReason = fields.stopReason` even when `fields.stopReason` was `undefined`, so the trailing `agent:status-changed` event (which arrived milliseconds after `agent:failed` without its own `stopReason` field) overwrote the error text with `undefined`.
+
+**Expected:** Chat error card displays the daemon's actual error text from `agent:failed` events.
+
+**Status:** fixed ([intent-hq/cloudlands-fe#147](https://github.com/intent-hq/cloudlands-fe/pull/147), 2026-07-18)
 
 ### STAB-102 (2026-07-18, area: intentd e2e tests / local environment, severity: P2)
 


### PR DESCRIPTION
Updates `packages/cloudlands-fe` submodule to d1d54364 ([intent-hq/cloudlands-fe#147](https://github.com/intent-hq/cloudlands-fe/pull/147)).

## Summary

Fixes chat error card to display the daemon's real `agent:failed` error text instead of the generic "Agent spawn failed" fallback. Observed incident: session/prompt idle-timeout failures rendered as "Agent spawn failed" instead of the actual error message from intentd.

## Changes

### cloudlands-fe submodule (d1d54364)

1. **daemon-events-bridge.ts** (`handleAgentFailedStream`):
   - Now dispatches `chatSendFailed` even when no stream state exists
   - Fixes case where agent spawn failed before streaming started

2. **agent-session-slice.ts** (`canonicalSessionUpdates`):
   - Guards all canonical fields (`status`, `activationState`, `isActive`, `isStreaming`, `isProcessing`, `isResponding`, `stopReason`) against undefined clobbering
   - Prevents `agent:status-changed` from overwriting error text with undefined

3. **Regression tests**:
   - Bridge test: `agent:failed` with no prior stream chunks dispatches `chatSendFailed`
   - Slice test: `agent:failed` → `agent:status-changed` preserves `stopReason` and `activationState`

### KNOWN_ISSUES.md

Adds STAB-103 documenting the incident, root causes, and fix.

## Verification

- ✅ cloudlands-fe PR #147: all CI checks passing, merged via squash
- ✅ Conventional commit message on monorepo feature branch
