### PR TITLE
chore: update intentd and cloudlands-fe submodules for ws.app.* support

### DIFF
--- a/docs/01_stabilizing/KNOWN_ISSUES.md
+++ b/docs/01_stabilizing/KNOWN_ISSUES.md
@@ -2,7 +2,7 @@
 
 Live issue tracker for the **01_stabilizing** self-hosting phase.
 
-**Next available ID:** STAB-80 (as of 2026-07-17)
+**Next available ID:** STAB-81 (as of 2026-07-17)
 
 ## Intake Convention
 
@@ -18,6 +18,18 @@ Each issue entry includes:
 ---
 
 ## Open Issues
+
+### STAB-80 (2026-07-17, area: intentd intent-acp / workspace_api MCP, severity: P1)
+
+Chief of Staff agent broken: cannot enumerate workspaces or access app-level operations.
+
+**Repro:** Create a Chief of Staff workspace agent and try to use it. The agent reports that the `ws.app` namespace (which provides `workspaces.list`, `agents.list`, UI navigation, and proposal management) is not registered in the session. Only the single-workspace API surface is available, and since the Chief workspace has no repository attached, there's no way for the agent to enumerate or manage user workspaces.
+
+**Root cause:** The `ws.app.*` MCP tool bindings were not registered in the daemon's MCP server for chief-workspace sessions. The bindings existed in `intent-acp/src/mcp_server/bindings/app/` but were not exposed in the workspace_api tool description for chief agents.
+
+**Expected:** Chief of Staff agents should have access to `ws.app.workspaces.list/get/archive`, `ws.app.agents.list/readConversation`, `ws.app.settings.list/get`, `ws.app.specialists.list/get`, `ws.app.proposal.show`, `ws.app.ui.navigate/highlight/targets`, and `ws.app.workspaces.open` to perform cross-workspace management tasks.
+
+**Status:** open (fix in progress on branch `feat/ws-app-parity` in both `packages/intentd` and `packages/cloudlands-fe`; will mark fixed once PRs land)
 
 ### STAB-79 (2026-07-17, area: cloudlands-fe sidebar status grouping / workspace activity, severity: P1)
 

--- a/docs/01_stabilizing/KNOWN_ISSUES.md
+++ b/docs/01_stabilizing/KNOWN_ISSUES.md
@@ -29,7 +29,7 @@ Chief of Staff agent broken: cannot enumerate workspaces or access app-level ope
 
 **Expected:** Chief of Staff agents should have access to `ws.app.workspaces.list/get/archive`, `ws.app.agents.list/readConversation`, `ws.app.settings.list/get`, `ws.app.specialists.list/get`, `ws.app.proposal.show`, `ws.app.ui.navigate/highlight/targets`, and `ws.app.workspaces.open` to perform cross-workspace management tasks.
 
-**Status:** open (fix in progress on branch `feat/ws-app-parity` in both `packages/intentd` and `packages/cloudlands-fe`; will mark fixed once PRs land)
+**Status:** fixed (intentd: commit bd4cf8a, b4b78ab, 5834cc0 on branch `feat/ws-app-parity`; E2E coverage added for WSS + MCP paths, 2026-07-17)
 
 ### STAB-79 (2026-07-17, area: cloudlands-fe sidebar status grouping / workspace activity, severity: P1)
 

--- a/docs/01_stabilizing/KNOWN_ISSUES.md
+++ b/docs/01_stabilizing/KNOWN_ISSUES.md
@@ -29,7 +29,7 @@ Chief of Staff agent broken: cannot enumerate workspaces or access app-level ope
 
 **Expected:** Chief of Staff agents should have access to `ws.app.workspaces.list/get/archive`, `ws.app.agents.list/readConversation`, `ws.app.settings.list/get`, `ws.app.specialists.list/get`, `ws.app.proposal.show`, `ws.app.ui.navigate/highlight/targets`, and `ws.app.workspaces.open` to perform cross-workspace management tasks.
 
-**Status:** fixed (intentd: commit bd4cf8a, b4b78ab, 5834cc0 on branch `feat/ws-app-parity`; E2E coverage added for WSS + MCP paths, 2026-07-17)
+**Status:** fixed (intent-hq/intentd#241, intent-hq/cloudlands-fe#139, 2026-07-18)
 
 ### STAB-79 (2026-07-17, area: cloudlands-fe sidebar status grouping / workspace activity, severity: P1)
 


### PR DESCRIPTION
Updates both submodules to include ws.app.* surface support for Chief of Staff workspace agents.

## Submodule PRs

- intent-hq/intentd#241: Add ws.app.* MCP methods (workspaces, agents, settings, specialists, proposal, UI navigation)
- intent-hq/cloudlands-fe#139: Bridge daemon app UI events (navigate/highlight/workspace-open) into FE routing

## Changes

### intentd (6452959)
- Registered ws.app.* tool bindings for chief-workspace agents
- Added E2E WSS + MCP coverage for all ws.app methods
- Implemented proposal show, workspace list/archive, agent audit, settings/specialists read, UI navigation

### cloudlands-fe (bb588763 includes 9344628)
- Bridged daemon app-UI events into renderer routing
- Added highlight/navigate/workspace-open handlers
- Fixed main-process TypeScript build issues

## Fixed

Resolves STAB-80 (Chief of Staff agent broken - cannot enumerate workspaces or access app-level operations)
