### PR TITLE
docs: renumber duplicate STAB-103 known-issue entry to STAB-104

### DIFF
--- a/docs/01_stabilizing/KNOWN_ISSUES.md
+++ b/docs/01_stabilizing/KNOWN_ISSUES.md
@@ -19,7 +19,7 @@ Each issue entry includes:
 
 ## Open Issues
 
-### STAB-103 (2026-07-18, area: intentd specialists / task status lifecycle, severity: P1)
+### STAB-104 (2026-07-18, area: intentd specialists / task status lifecycle, severity: P1)
 
 Task notes got stuck in `review_required` status: when a delegated implementor called `report_to_parent`, the daemon transitioned the linked task note to `review_required`, but after a verifier approved the work, nothing marked the task `complete`.
 


### PR DESCRIPTION
Fix duplicate STAB-103 issue ID in KNOWN_ISSUES.md.

## Problem
PR #254 introduced a duplicate STAB-103 entry (there were two "### STAB-103" headings on main after merge). The 2026-07-18 "intentd specialists / task status lifecycle" entry should have been STAB-104.

## Changes
- Renumber the 2026-07-18 "intentd specialists / task status lifecycle" entry from STAB-103 to STAB-104
- Touch nothing else (no other STAB entries modified)

## Verification
After merge:
```bash
git show origin/main:docs/01_stabilizing/KNOWN_ISSUES.md | grep -c "### STAB-103"
# Should return 1

git show origin/main:docs/01_stabilizing/KNOWN_ISSUES.md | grep "### STAB-104"
# Should show exactly one STAB-104 entry
```
