### PR TITLE
docs: fix STAB-108 ID collision (renumber session-resume entry to STAB-111)

### DIFF
--- a/docs/01_stabilizing/KNOWN_ISSUES.md
+++ b/docs/01_stabilizing/KNOWN_ISSUES.md
@@ -2,7 +2,7 @@
 
 Live issue tracker for the **01_stabilizing** self-hosting phase.
 
-**Next available ID:** STAB-111 (as of 2026-07-19)
+**Next available ID:** STAB-112 (as of 2026-07-19)
 
 ## Intake Convention
 
@@ -19,7 +19,9 @@ Each issue entry includes:
 
 ## Fixed Issues
 
-### STAB-108 (2026-07-19, area: intentd agent manager / session resume, severity: P1)
+### STAB-111 (2026-07-19, area: intentd agent manager / session resume, severity: P1)
+
+(Referenced as STAB-108 in the intent-hq/intentd#250 PR title; renumbered due to ID collision.)
 
 Agent becomes wedged in `error` status with an undrainable queue after a mid-turn provider failure, because persisted history contains dangling `tool_use` blocks (tool_use without corresponding tool_result), triggering provider rejection (`400 invalidArgument`) on every session resume attempt.
 


### PR DESCRIPTION
Fixes STAB-108 ID collision in KNOWN_ISSUES.md discovered during verification.

## Problem

Two entries claimed STAB-108:
- **Line 51** (2026-07-18): delegation group rehydration, fixed by intent-hq/intentd#248
- **Line 22** (2026-07-19): session resume error-loop, fixed by intent-hq/intentd#250

The 2026-07-18 entry claimed the ID first.

## Changes

- Renumbered the session-resume entry (2026-07-19) from STAB-108 to **STAB-111**
- Added parenthetical note: "(Referenced as STAB-108 in the intent-hq/intentd#250 PR title; renumbered due to ID collision.)"
- Bumped "Next available ID" from STAB-111 to **STAB-112**

## Verification

```bash
$ grep '^### STAB-108' docs/01_stabilizing/KNOWN_ISSUES.md | wc -l
1   # ✅ exactly 1 (delegation entry)

$ grep '^### STAB-111' docs/01_stabilizing/KNOWN_ISSUES.md | wc -l
1   # ✅ exactly 1 (session-resume entry)
```

## References

- Original session-resume fix: intent-hq/intentd#250
- Monorepo bump: intent-hq/monorepo#264
