### PR TITLE
fix: bump cloudlands-fe submodule + document STAB-110 sidebar loading state

### DIFF
--- a/docs/01_stabilizing/KNOWN_ISSUES.md
+++ b/docs/01_stabilizing/KNOWN_ISSUES.md
@@ -49,6 +49,17 @@ Agent failure text was held only in FE memory — after a daemon restart or FE r
 
 **Status:** fixed ([intent-hq/intentd#249](https://github.com/intent-hq/intentd/pull/249) + [intent-hq/cloudlands-fe#152](https://github.com/intent-hq/cloudlands-fe/pull/152), 2026-07-19) — daemon: migration 0045 adds `stop_reason TEXT` column to `agent_session`; `set_stop_reason` / `clear_stop_reason` in `agent_repo.rs` persist it; `agent.list` / `agent.get` serve it on AgentLite; `agent:status-changed` carries it as string when setting / JSON null when clearing / omitted when untouched; FE: `applySessionUpsert` guard preserves existing `stopReason` when incoming snapshot omits the key (mirrors Phase 1's `canonicalSessionUpdates` guard); 7 regression tests (4 slice-level, 3 live-client)
 
+### STAB-110 (2026-07-19, area: cloudlands-fe sidebar / workspaces-seeder, severity: P2)
+
+On refresh, the sidebar workspace list briefly shows a single workspace or "No workspaces yet" message until `workspace.list` resolves, creating a jarring flash of incorrect state.
+
+**Repro:** Refresh the app (Cmd-R) while viewing a workspace. Observed: the sidebar workspaces list immediately renders with either a single workspace entry or the "No workspaces yet" placeholder for a brief moment (typically <500ms) until the `workspace.list` RPC completes and hydrates the full workspace collection. This flashing interim state creates a perception of lost data or broken state, even though it resolves automatically.
+
+**Root cause:** The sidebar workspace list component (`WorkspaceList.svelte` or equivalent) was rendering the current Redux store state synchronously on mount without checking whether workspaces data was still loading. The workspace slice initialized with an empty or minimal collection, and the seeder (`workspaces-seeder.ts`) fired `workspace.list` asynchronously. The component bound to the store's transient loading state, showing whatever partial data existed before the RPC settled.
+
+**Expected:** During the initial workspace list load (on app start or refresh), the sidebar should display an indeterminate loading skeleton or spinner instead of rendering a partial/empty workspace collection. Once `workspace.list` resolves, transition to the populated list. The loading state should be tracked in the workspace slice and consumed by the UI component.
+
+**Status:** fixed ([intent-hq/cloudlands-fe#155](https://github.com/intent-hq/cloudlands-fe/pull/155) + [intent-hq/cloudlands-fe#156](https://github.com/intent-hq/cloudlands-fe/pull/156), 2026-07-19) — workspace slice tracks `isLoadingWorkspaceList` boolean; seeder sets it true before `workspace.list` and false on settle; sidebar component gates rendering on `!isLoadingWorkspaceList` and shows skeleton during load; error handling improved with user-facing toast and fallback to empty array
 
 ### STAB-108 (2026-07-18, area: intentd agent runtime / delegation group rehydration, severity: P1)
 


### PR DESCRIPTION
Documents the fix for the sidebar workspace list flashing on refresh.

## Summary
Adds STAB-110 to track the indeterminate loading state issue that was fixed in cloudlands-fe.

## Fixed cloudlands-fe PRs
- intent-hq/cloudlands-fe#155 — Sidebar workspace list skeleton gating (636293ee)
- intent-hq/cloudlands-fe#156 — Workspaces seeder error handling (cbb53077)

Both PRs have been merged to cloudlands-fe main. The submodule was already pointing to the latest commit (cbb53077658ad76abf66ee2e9f1a62c2b6bd45b6), so this PR only adds the STAB entry to document the issue and its resolution.

## Changes
- Updated docs/01_stabilizing/KNOWN_ISSUES.md:
  - Added STAB-110 entry documenting the sidebar workspace-list loading flash
  - Marked as fixed with references to cloudlands-fe #155 and #156
  - Updated next available ID to STAB-111
