### PR TITLE
chore: update cloudlands-fe submodule to latest main

### DIFF
--- a/docs/01_stabilizing/KNOWN_ISSUES.md
+++ b/docs/01_stabilizing/KNOWN_ISSUES.md
@@ -19,6 +19,20 @@ Each issue entry includes:
 
 ## Fixed Issues
 
+### STAB-114 (2026-07-19, area: cloudlands-fe / NewSpaceModal repo defaulting, severity: P2)
+
+After previously using a repo, opening the New Workspace modal (Cmd+N or sidebar +) showed 'Select a repository' instead of the most recent repo.
+
+**Repro:** Open the New Workspace modal (Cmd+N or sidebar +) after previously using a repo. Observed: the repository selector shows 'Select a repository' instead of the most recent repo, forcing the user to manually re-select their working repo every time.
+
+**Root cause:** NewSpaceModal never called `applyPrefill()` so stale workspace-prefill sessionStorage blocked last-repo hydration forever, and there was no fallback to recent repos when `lastSelectedRepo` was unset.
+
+**Expected:** The repository selector defaults to the most recently used repo when opening the New Workspace modal.
+
+**Status:** fixed (https://github.com/intent-hq/cloudlands-fe/pull/161, 2026-07-19)
+
+---
+
 ### STAB-115 (2026-07-19, area: cloudlands-fe terminal footer / scripts hydration, severity: P2)
 
 Switching workspaces briefly flashed "Detect Scripts" in the terminal footer before the detected script count appeared, creating a jarring UX and implying no scripts were detected when they were.


### PR DESCRIPTION
Updates packages/cloudlands-fe submodule from 21029c67 to 326fea79, completing Phase 2 of the AGENTS.md workflow for STAB-114.

## Background

This is the missing piece from Phase 2: the submodule gitlink update to point at the merged fix from cloudlands-fe PR #161. PR #276 added the STAB-114 tracker entry but did not update the gitlink.

## Submodule Changes

Updates packages/cloudlands-fe to include:

1. **fix: apply prefill and default repo in New Workspace modal (#161, commit 49416007)**
   - Root cause: NewSpaceModal never called applyPrefill() so stale sessionStorage blocked last-repo hydration
   - Fix: Added applyPrefill() call and fallback to recent repos
   - Documented as STAB-114 in monorepo PR #276

2. **fix: use bg-secondary for skeleton visibility in dark mode (#164, commit 326fea79)**
   - Additional fix for skeleton component visibility

## Changes

- packages/cloudlands-fe: 21029c67 → 326fea79

## References

- Submodule fix PR: https://github.com/intent-hq/cloudlands-fe/pull/161
- Tracker entry PR: https://github.com/intent-hq/monorepo/pull/276
- STAB-114 issue entry in docs/01_stabilizing/KNOWN_ISSUES.md
