### PR TITLE
fix: bump cloudlands-fe for auto-update and view-mode fixes (STAB-122, STAB-123)

### DIFF
--- a/docs/01_stabilizing/KNOWN_ISSUES.md
+++ b/docs/01_stabilizing/KNOWN_ISSUES.md
@@ -19,6 +19,32 @@ Each issue entry includes:
 
 ## Fixed Issues
 
+### STAB-122 (2026-07-19, area: cloudlands-fe auto-update, severity: P1)
+
+Packaged 2.0.6 app cannot download or install updates: the Install button is a no-op, downloads stall at "Preparing download…", and clicking the "Update available" toast does nothing.
+
+**Repro:** Run the packaged 2.0.6 app with an update available on the feed. (1) Click the "Update available" toast — nothing happens (it dispatches the `downloadUpdate` trigger whose IPC channel was removed). (2) Open Settings → About and click Install — no-op. (3) Trigger a download — the UI remains stuck at "Preparing download…" indefinitely. At startup, the console logs "Auto-update is not available in this build" errors from `AutoUpdateMutationService` and `UserPreferencesBetaPersistenceService`.
+
+**Root cause:** Regression from [intent-hq/cloudlands-fe#108](https://github.com/intent-hq/cloudlands-fe/pull/108), which removed auto-update download/install IPC channels still used by the renderer.
+
+**Expected:** In packaged builds, the "Update available" toast and the Install button trigger download/install via functioning IPC channels; download progress advances past "Preparing download…"; no "Auto-update is not available in this build" errors at startup.
+
+**Status:** fixed ([intent-hq/cloudlands-fe#172](https://github.com/intent-hq/cloudlands-fe/pull/172), 2026-07-20) — restored the auto-update download/install IPC channels removed in #108, rewiring the "Update available" toast, Settings → About Install button, and download progress flow
+
+---
+
+### STAB-123 (2026-07-19, area: cloudlands-fe storage, severity: P2)
+
+`[SafeStorage]` warning at every startup: the localStorage key `intent:all-spaces-view-mode` holds the bare string `repo` instead of JSON, so `JSON.parse` fails on every launch.
+
+**Repro:** Launch the app with `intent:all-spaces-view-mode` set to the bare string `repo` in localStorage (the value the app itself writes). Observed: a `[SafeStorage]` warn is logged on every launch because `JSON.parse("repo")` throws.
+
+**Expected:** The value is written and read consistently (JSON-encoded, or the reader tolerates the legacy bare-string value); no `[SafeStorage]` warning on launch.
+
+**Status:** fixed ([intent-hq/cloudlands-fe#171](https://github.com/intent-hq/cloudlands-fe/pull/171), 2026-07-19) — legacy raw-string `all-spaces-view-mode` values are migrated without triggering the SafeStorage warning
+
+---
+
 ### STAB-120 (2026-07-19, area: intentd agent subscriptions / SUB-1 delegation-group dedupe, severity: P1)
 
 Coordinator received duplicate completion notifications when sending coordination messages to children already covered by an undelivered after_all delegation group.
@@ -233,28 +259,6 @@ Agent becomes wedged in `error` status with an undrainable queue after a mid-tur
 ---
 
 ## Open Issues
-
-### STAB-122 (2026-07-19, area: cloudlands-fe auto-update, severity: P1)
-
-Packaged 2.0.6 app cannot download or install updates: the Install button is a no-op, downloads stall at "Preparing download…", and clicking the "Update available" toast does nothing.
-
-**Repro:** Run the packaged 2.0.6 app with an update available on the feed. (1) Click the "Update available" toast — nothing happens (it dispatches the `downloadUpdate` trigger whose IPC channel was removed). (2) Open Settings → About and click Install — no-op. (3) Trigger a download — the UI remains stuck at "Preparing download…" indefinitely. At startup, the console logs "Auto-update is not available in this build" errors from `AutoUpdateMutationService` and `UserPreferencesBetaPersistenceService`.
-
-**Root cause:** Regression from [intent-hq/cloudlands-fe#108](https://github.com/intent-hq/cloudlands-fe/pull/108), which removed auto-update download/install IPC channels still used by the renderer.
-
-**Expected:** In packaged builds, the "Update available" toast and the Install button trigger download/install via functioning IPC channels; download progress advances past "Preparing download…"; no "Auto-update is not available in this build" errors at startup.
-
-**Status:** open
-
-### STAB-123 (2026-07-19, area: cloudlands-fe storage, severity: P2)
-
-`[SafeStorage]` warning at every startup: the localStorage key `intent:all-spaces-view-mode` holds the bare string `repo` instead of JSON, so `JSON.parse` fails on every launch.
-
-**Repro:** Launch the app with `intent:all-spaces-view-mode` set to the bare string `repo` in localStorage (the value the app itself writes). Observed: a `[SafeStorage]` warn is logged on every launch because `JSON.parse("repo")` throws.
-
-**Expected:** The value is written and read consistently (JSON-encoded, or the reader tolerates the legacy bare-string value); no `[SafeStorage]` warning on launch.
-
-**Status:** open
 
 ### STAB-121 (2026-07-19, area: intentd CI / coverage-all test, severity: P2)
 


### PR DESCRIPTION
Bumps `packages/cloudlands-fe` to `ede3641f` (latest main) and updates the stabilization tracker.

## Changes
- **Submodule bump**: `packages/cloudlands-fe` `75982344` → `ede3641f`, picking up:
  - intent-hq/cloudlands-fe#172 — restore auto-update download/install flow removed in #108
  - intent-hq/cloudlands-fe#171 — migrate legacy raw-string `all-spaces-view-mode` value without SafeStorage warning
- **Tracker**: `docs/01_stabilizing/KNOWN_ISSUES.md` — moved STAB-122 and STAB-123 from Open Issues to Fixed Issues:
  - STAB-122 fixed (intent-hq/cloudlands-fe#172, 2026-07-20)
  - STAB-123 fixed (intent-hq/cloudlands-fe#171, 2026-07-19)

## Verification
- `make check` passes locally (intentd submodule state unaffected).

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author