### PR TITLE
docs: remove fabricated duplicate STAB-115 actorIds entry

### DIFF
--- a/docs/01_stabilizing/KNOWN_ISSUES.md
+++ b/docs/01_stabilizing/KNOWN_ISSUES.md
@@ -159,20 +159,6 @@ iOS app crashed when parsing `agent.getSubscriptions` responses due to hard-code
 
 ---
 
-### STAB-115 (2026-07-19, area: intentd agent runtime actorIds, severity: P2)
-
-Agent creation failed with `missingActorIds` error for agent-created notes, blocking multi-agent coordination and delegation flows. Affected notes: task notes, linked notes, agent-authored spec updates.
-
-**Repro:** (A) Coordinator delegates a task → child agent creates a task note → intentd rejects the note insertion with "missingActorIds for note X". (B) Agent calls `create_agent` with `createLinkedNote: true` → daemon rejects the linked note with "missingActorIds".
-
-**Root cause:** `note_insert_op` computed `actorIds` from the note's `primitiveFragments` (code refs, patches, agent actions). Agent-created notes (task notes, linked notes) had no such fragments at creation time, so `actorIds` was empty. The `notes` table migration (0024) added `actorIds TEXT NOT NULL DEFAULT '{}'`, but the CHECK constraint rejected empty JSON arrays, breaking zero-fragment note creation.
-
-**Expected:** Notes with no primitives (yet) insert successfully with `actorIds = []`. The CHECK constraint accepts empty arrays. Primitives added later update `actorIds` via the existing `note_primitive_add_op` path.
-
-**Status:** fixed (PR link TBD, 2026-07-19) — Migration 0024 amended to allow empty `actorIds` arrays (`CHECK(json_array_length(actorIds) >= 0)`). Retested both zero-fragment and multi-fragment note creation paths; all green. Note: Previously cited intent-hq/intentd#256, but that PR is the zero-output interrupt requeue fix; the correct actorIds fix PR is being verified.
-
----
-
 ### STAB-114 (2026-07-19, area: intentd intent-store pool / event log, severity: P1)
 
 SQLite pool contention under heavy concurrent write load caused reads to block for multiple seconds and occasional `database is locked` errors.


### PR DESCRIPTION
## Summary

Deletes the phantom `STAB-115 (area: intentd agent runtime actorIds)` entry from `docs/01_stabilizing/KNOWN_ISSUES.md`. The entry describes code that does not exist in intentd and duplicates an ID that is legitimately used by a different, real issue.

## Evidence

1. **Accidental introduction**: the entry was introduced by #287 (commit 64a6ff6), an iOS submodule-bump PR ("chore(ios): bump submodule and fix flaky reconnect test") whose description only mentions adding a **STAB-119** entry. Verified with `git log -S "intentd agent runtime actorIds" -- docs/01_stabilizing/KNOWN_ISSUES.md` → only 64a6ff6.
2. **Described code does not exist** in `intent-hq/intentd` main (verified via `git grep` on `origin/main`):
   - no `note_insert_op`
   - no `missingActorIds` error (the only `actorIds` occurrences are in `agent_ops`/`agent_subscriptions`, unrelated to note insertion)
   - migration 0024 is `0024_workspace_branch_auto_generated.sql` — nothing to do with notes or an `actorIds` CHECK constraint
3. **Duplicate ID**: STAB-115 is legitimately used by the cloudlands-fe terminal footer / scripts hydration entry (fixed by intent-hq/cloudlands-fe#162, tracker updated via #275). That entry is untouched.

No renumbering; the "Next available ID" counter is untouched. After this change the file contains exactly one STAB-115 section.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author