### PR TITLE
fix: update intentd submodule for STAB-121 burst-collapse flake

### DIFF
--- a/docs/01_stabilizing/KNOWN_ISSUES.md
+++ b/docs/01_stabilizing/KNOWN_ISSUES.md
@@ -321,11 +321,11 @@ The `burst_above_threshold_collapses_to_directory_summaries` test in the coverag
 
 **Repro:** In `packages/intentd`, run `cargo test --workspace` or `make test`, or observe the coverage-all CI job on main. The test `burst_above_threshold_collapses_to_directory_summaries` fails approximately 1-2 out of 5 runs with an assertion error: expected fewer than 80 events, got 98 (or similar counts exceeding the threshold).
 
-**Root cause:** Unknown. The test validates event batching/collapsing logic under high-volume file-change scenarios. Intermittent failures suggest a race condition or non-deterministic event emission pattern that occasionally produces more events than the collapse threshold.
+**Root cause:** Product defect in the file-watcher debounce loop, not the test. `tokio::select!` ingests one raw notify event per iteration, so slow event publishes (e.g. SQLite INSERTs under coverage instrumentation, ~24 ms each) starve ingestion and spread per-path debounce deadlines; the burst decision in `flush_due` only counted paths due at a single flush instant, so a 150-file churn came due across many small flushes that never crossed the collapse threshold and was emitted as individual events.
 
 **Expected:** The test passes reliably on all runs, or the event count assertions are made more lenient to account for legitimate variance in event emission patterns.
 
-**Status:** open
+**Status:** fixed ([intentd#266](https://github.com/intent-hq/intentd/pull/266), 2026-07-20). Batch-drains the raw channel before each flush, bases the burst decision on the whole pending backlog, and adds a bounded 1 s burst cooldown so trailing waves of the same churn collapse too. Verified with deterministic `flush_due` regression tests plus 15 consecutive coverage-instrumented full-suite runs green.
 
 ---
 


### PR DESCRIPTION
Bumps `packages/intentd` to `c4bd91b` — the squash-merge of [intent-hq/intentd#266](https://github.com/intent-hq/intentd/pull/266), which fixes **STAB-121** (flaky `burst_above_threshold_collapses_to_directory_summaries` in coverage-all).

## What landed in the submodule

Product defect in the file-watcher debounce loop, diagnosed under coverage instrumentation:

1. `tokio::select!` ingested one raw notify event per iteration, so slow publishes (~24 ms SQLite INSERTs under coverage) starved ingestion and spread per-path debounce deadlines.
2. The burst decision only counted paths due at a single flush instant, so a 150-file churn came due across many small flushes and was emitted as individual events instead of directory summaries.

Fix: batch-drain the raw channel (capped at 10k/call) before each flush, base the burst decision on the whole pending backlog, and add a bounded 1 s burst cooldown (refreshed only while the backlog exceeds the threshold) so trailing waves collapse without keeping the watcher in summary mode indefinitely.

Verification: deterministic `flush_due` regression tests (confirmed to fail against the old logic), 15 consecutive coverage-instrumented full-suite runs green locally, and all submodule CI checks green including coverage-all.

## Also in this PR

- Marks STAB-121 **fixed** in `docs/01_stabilizing/KNOWN_ISSUES.md` with the PR link and root-cause summary.
