### PR TITLE
chore: restore git submodule init in workspace setup script

### DIFF
--- a/.intent/config.json
+++ b/.intent/config.json
@@ -1,5 +1,5 @@
 {
-  "setupScript": "#!/bin/bash\n# Generic setup script\n# Available variables: $MAIN_CHECKOUT, $WORKTREE_PATH, $BRANCH_NAME, $SOURCE_BRANCH\n\n# Copy environment and config files\nfor file in .env .env.local .envrc .tool-versions; do\n  if [ -f \"$MAIN_CHECKOUT/$file\" ]; then\n    cp \"$MAIN_CHECKOUT/$file\" \"./$file\"\n    echo \"Copied $file\"\n  fi\ndone\n\necho \"Config files copied\"",
+  "setupScript": "#!/bin/bash\n# Generic setup script\n# Available variables: $MAIN_CHECKOUT, $WORKTREE_PATH, $BRANCH_NAME, $SOURCE_BRANCH\n\n# Copy environment and config files\nfor file in .env .env.local .envrc .tool-versions; do\n  if [ -f \"$MAIN_CHECKOUT/$file\" ]; then\n    cp \"$MAIN_CHECKOUT/$file\" \"./$file\"\n    echo \"Copied $file\"\n  fi\ndone\n\necho \"Config files copied\"\n\n# Initialize git submodules\necho \"Initializing git submodules...\"\ngit submodule update --init --recursive\necho \"Git submodules initialized\"",
   "scripts": [
     {
       "name": "all",


### PR DESCRIPTION
## Summary

Restores the git submodule initialization block in `.intent/config.json`'s `setupScript`. This re-applies #260, which was unintentionally reverted by #270.

The `setupScript` now matches the version from commit 530d3b9c8fb65f41f4a848cfd356b46857cd7d1f exactly — current main content plus the submodule-init block appended:

```bash
# Initialize git submodules
echo "Initializing git submodules..."
git submodule update --init --recursive
echo "Git submodules initialized"
```

## Changes

- `.intent/config.json` — single-file change re-adding the submodule-init lines to `setupScript`.

## Verification

- JSON validated locally with `python3 -m json.tool` before committing.
- File content verified byte-for-byte identical to the 530d3b9 version.
