### PR TITLE
docs: renumber duplicate STAB-114/STAB-86 tracker entries

### DIFF
--- a/docs/01_stabilizing/KNOWN_ISSUES.md
+++ b/docs/01_stabilizing/KNOWN_ISSUES.md
@@ -2,7 +2,7 @@
 
 Live issue tracker for the **01_stabilizing** self-hosting phase.
 
-**Next available ID:** STAB-133 (as of 2026-07-20)
+**Next available ID:** STAB-135 (as of 2026-07-20)
 
 ## Intake Convention
 
@@ -225,7 +225,7 @@ iOS app crashed when parsing `agent.getSubscriptions` responses due to hard-code
 
 ---
 
-### STAB-114 (2026-07-19, area: intentd intent-store pool / event log, severity: P1)
+### STAB-133 (2026-07-19, area: intentd intent-store pool / event log, severity: P1)
 
 SQLite pool contention under heavy concurrent write load caused reads to block for multiple seconds and occasional `database is locked` errors.
 
@@ -855,7 +855,7 @@ Re-entering a streaming conversation shows no deltas until the next tool call (o
 
 **Status:** fixed ([intent-hq/cloudlands-fe#132](https://github.com/intent-hq/cloudlands-fe/pull/132), 2026-07-17) — `chat-read-service.ts` now merges `chat.subscribeSnapshot` in-flight message into `getConversation` hydration; `daemon-events-bridge.ts` seeds stream accumulator from snapshot (`seedStreamFromSnapshot`) so regression guard passes after app restart mid-turn
 
-### STAB-86 (2026-07-17, area: cloudlands-fe, severity: P1)
+### STAB-134 (2026-07-17, area: cloudlands-fe, severity: P1)
 
 Interrupt-send (⌘Enter while agent is mid-turn) stalls the session: stuck in "Thinking", message never appears, renderer state wedged.
 


### PR DESCRIPTION
Docs-only fix for pre-existing duplicate tracker IDs in `docs/01_stabilizing/KNOWN_ISSUES.md` found during final verification (duplicates confirmed pre-existing at 9f8a302).

## What changed

| Old heading | Landed via | Resolution |
|---|---|---|
| `### STAB-114` (cloudlands-fe / NewSpaceModal repo defaulting) | d2fa48a (#276) | **kept** — landed on main first (ancestor of #286's commit) |
| `### STAB-114` (intentd intent-store pool / event log) | 497c066 (#286) | renumbered → **STAB-133** |
| `### STAB-86` (cloudlands-fe / workspace delete) | 3cfc26b (#219) | **kept** — landed on main first (ancestor of #217's commit; verified via `git merge-base --is-ancestor`) |
| `### STAB-86` (cloudlands-fe, interrupt-send stall) | d68fe2d (#217, merged after #219) | renumbered → **STAB-134** |

- `Next available ID` header bumped STAB-133 → **STAB-135** (highest used ID is now 134).

## Cross-references

Grepped the entire `docs/` tree for `STAB-114` and `STAB-86` before renumbering: the **only** occurrences were the four duplicate headings themselves — no in-file or cross-file references point at the renumbered entries, so no reference updates were needed.

## Verification

```
grep -c '^### STAB-114 ' docs/01_stabilizing/KNOWN_ISSUES.md  # 1
grep -c '^### STAB-86 '  docs/01_stabilizing/KNOWN_ISSUES.md  # 1
grep -c 'STAB-133' docs/01_stabilizing/KNOWN_ISSUES.md        # 1 (new heading)
grep -c 'STAB-134' docs/01_stabilizing/KNOWN_ISSUES.md        # 1 (new heading)
```

Diff is exactly 3 hunks: the two renumbered headings + the next-ID header. No other content changes.
