### PR TITLE
chore: bump intentd for interruption recovery marker and partial-content flush

### DIFF
--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -429,7 +429,7 @@ Rows with `resolution='pending'` survive multiple restarts (idempotent capture).
 ```
 
 Resolves interrupted agents:
-- **Resume:** Atomically marks row `resolved='resumed'` (claim-first), re-registers parent completion watches (if delegated), delivers a continuation message (`"intentd restarted while you were working. Review your last steps and continue the task."`) via `agent.sendMessage`. Delivery lazily respawns the ACP provider and resumes via `session/load` (with `session/new` recreate fallback). If any post-claim step fails, the row is reset to `pending` (resolution=NULL) to restore retryability, and the error is returned.
+- **Resume:** Atomically marks row `resolved='resumed'` (claim-first), re-registers parent completion watches (if delegated), delivers a continuation message (`"You were interrupted because the harness shut down. You now have a chance to continue the work — review your last steps and pick up where you left off."`) via `agent.sendMessage`. Delivery lazily respawns the ACP provider and resumes via `session/load` (with `session/new` recreate fallback). If any post-claim step fails, the row is reset to `pending` (resolution=NULL) to restore retryability, and the error is returned.
 - **Abandon:** Marks row `resolved='abandoned'`, appends a system-role interruption message (text block with `meta.kind="interruption"`: `"This conversation was interrupted because intentd restarted. The agent's in-flight work was terminated."`), emits `agent:message` + `agent:updated` events.
 
 **Errors:**


### PR DESCRIPTION
Phase 2 monorepo follow-up for intent-hq/intentd#274 and intent-hq/intentd#277.

## Changes

- Bump `packages/intentd` submodule to `fbd138e` (squash commit of intent-hq/intentd#277 on `main`), which includes:
  - **System interruption marker on resume** (`agent.resolveInterrupted` resume path): an idempotent system-role transcript row (`meta.kind = "interruption"`) is appended before the continuation prompt, so the transcript shows the interruption boundary across restarts.
  - **Partial in-flight content flush at graceful shutdown**: `AgentManager::shutdown` snapshots the live-turn slot before aborting the worker and persists streamed-so-far assistant blocks tagged `metadata.interrupted = true` + `stopReason = "interrupted"` (FE stopped-indicator convention).
  - Earlier reworded continuation message from intent-hq/intentd#274.
- Update the quoted continuation string in `docs/PROTOCOL.md` (`agent.resolveInterrupted` **Resume:** bullet) to match the new wording:

  > "You were interrupted because the harness shut down. You now have a chance to continue the work — review your last steps and pick up where you left off."

## Verification

- Submodule PR intent-hq/intentd#277 merged with all CI checks green (fmt/clippy/build, coverage-all, coverage-e2e, CodeQL) and all 10 review threads addressed and resolved.
- Local gates on the merged branch: `cargo fmt --check`, `cargo clippy -- -D warnings`, targeted tests (`shutdown_flushes_partial_live_turn`, `resume_interrupted_marker_is_idempotent`, `e2e_wss_resolve_interrupted`) all green.
