### PR TITLE
fix: preserve queued agent messages across intentd restart

### DIFF
--- a/docs/01_stabilizing/KNOWN_ISSUES.md
+++ b/docs/01_stabilizing/KNOWN_ISSUES.md
@@ -2,7 +2,7 @@
 
 Live issue tracker for the **01_stabilizing** self-hosting phase.
 
-**Next available ID:** STAB-144 (as of 2026-07-20)
+**Next available ID:** STAB-145 (as of 2026-07-20)
 
 ## Intake Convention
 
@@ -18,6 +18,22 @@ Each issue entry includes:
 ---
 
 ## Fixed Issues
+
+### STAB-144 (2026-07-20, area: intentd agent queue / interrupted-agent resume, severity: P1)
+
+Queued agent messages were silently dropped on intentd shutdown — the per-agent send queue lived only in memory, so any daemon restart (graceful or crash) lost everything the user had queued while an agent was working.
+
+(Planned as "STAB-142" in the shipping task; renumbered on merge because STAB-142 and STAB-143 were taken by entries that landed on main first.)
+
+**Repro:** Queue one or more messages on a busy agent (`agent.queueMessage`), then restart or kill intentd. After restart, resume the interrupted agent via `agent.resolveInterrupted { resume }`. Observed: the continuation message was delivered but `agent.getQueue` returned an empty queue — every queued message was gone.
+
+**Root cause:** `Services.agent_queues` was a purely in-memory map with no persistence; nothing snapshotted it to SQLite on mutation or rehydrated it at boot.
+
+**Expected:** Queued messages survive daemon restarts. On resume, the continuation streams first, then the preserved queue drains FIFO in original order after that turn completes. Abandoning leaves the preserved queue intact and inert.
+
+**Status:** fixed ([intent-hq/intentd#284](https://github.com/intent-hq/intentd/pull/284), 2026-07-20) — new `agent_queue` SQLite table (additive migration 0046) with write-through persistence on every queue mutation (serialized per-daemon so an older snapshot can never overwrite a newer one) and startup rehydration before RPCs are served; rehydration never auto-starts a turn and restores mid-edit entries as ready-to-send. Covered by store/services unit tests plus 3 real-SIGKILL WSS e2e tests locking in the resume ordering contract.
+
+---
 
 ### STAB-142 (2026-07-20, area: cloudlands-fe notifications, severity: P1)
 

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -438,6 +438,14 @@ Resolves interrupted agents:
 
 Per-agent failures are isolated; other agents in the same call proceed normally.
 
+#### Queued-Message Preservation
+
+**Queues survive restarts.** The per-agent send queue (`agent.queueMessage` / `agent.getQueue`) is persisted write-through to the `agent_queue` SQLite table: every enqueue, edit, remove, and drain mutation of the in-memory queue is mirrored to the store, so both graceful shutdowns and crashes preserve queued messages. At daemon startup, persisted queues are rehydrated into memory before RPCs are served. Rehydration alone never starts a turn; entries mid-edit at shutdown are restored as ready-to-send (`editing: false`), and attachment blocks plus metadata round-trip intact.
+
+**Resume ordering contract:** When an interrupted agent is resumed — via `agent.resolveInterrupted { resume }` or `serve --resume-all` — the continuation message streams **first**; the preserved queue then drains FIFO in original order after that turn completes. Abandoning an interrupted agent leaves its preserved queue intact and inert (no auto-send); entries remain visible via `agent.getQueue` and removable via `agent.removeQueuedMessage`.
+
+No RPC surface changes: `agent.getQueue`, `agent:queue:updated`, and the edit/remove/drain flows operate on the in-memory map, which is now durable.
+
 #### Delegation-Group Persistence
 
 **`after_all` groups survive restarts.** When a parent delegates children with `waitMode: "after_all"`, the delegation group is persisted in the `delegation_group` SQLite table. At daemon startup, the heal sweep rehydrates all sealed groups and re-registers the aggregated-wake delivery watch. Resumed grouped children automatically re-enroll in their persisted group; when all children complete, the daemon delivers exactly one aggregated wake to the parent containing all children's reports.


### PR DESCRIPTION
## Summary

Bumps `packages/intentd` to `f3fdb65` — the squash-merge of [intent-hq/intentd#284](https://github.com/intent-hq/intentd/pull/284) (`fix: preserve queued agent messages across daemon restart`) — and updates the docs to match.

## Changes

- **Submodule bump**: `packages/intentd` → `f3fdb65` (includes #284 plus intermediate main commits picked up by the required up-to-date merge).
- **`docs/PROTOCOL.md` §6.6**: new "Queued-Message Preservation" subsection documenting write-through persistence to the `agent_queue` table, startup rehydration, and the resume ordering contract (continuation first, then FIFO queue drain; abandon leaves the queue intact and inert).
- **`docs/01_stabilizing/KNOWN_ISSUES.md`**: files STAB-144 (queued messages dropped on intentd shutdown, P1) as fixed with the PR link. Renumbered from the planned STAB-142 because STAB-142/143 landed on main first.

## Verification

- `make check` and `make test` green at the bumped gitlink.
- Submodule PR #284 merged with all CI checks passing and all 10 review threads (Copilot + reviewer) addressed and resolved.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author
