### PR TITLE
chore: update intentd submodule to TOML settings migration

### DIFF
--- a/docs/00_initial_porting/IMPLEMENTATION_SPEC.md
+++ b/docs/00_initial_porting/IMPLEMENTATION_SPEC.md
@@ -965,6 +965,9 @@ CREATE TABLE specialist (
   updated_at    TEXT NOT NULL
 );
 
+-- Opaque machine-state blobs only (repos.known, workspace.changeHistory,
+-- workspaceInitializer.state, permissions.rules, userRules/workspaceRules,
+-- endUserRules). Human-editable settings live in config.toml (§9.8, §11.2).
 CREATE TABLE settings (
   key   TEXT PRIMARY KEY,
   value TEXT NOT NULL                              -- JSON-encoded value
@@ -1191,7 +1194,7 @@ Source-control provider config is namespaced as `sourceControl.<provider>.*` so 
 
 #### Persistence, validation, secrets
 
-- **Storage.** Non-secret values persist in the `settings` table (§9.2, `key` → JSON`value`). Definitions (label, description, category, type, enum/min/max, default, sensitive,scope) are ported from `app-settings-schema.ts` as `AppSettingDefinition`s; group B adds itsown definitions. Non-secret settings may also be surfaced in `config.toml` (§11.2), but theDB row is authoritative.
+- **Storage.** Non-secret **human-editable** settings are TOML-backed: they persist in`<data_dir>/config.toml` (§11.2), parsed strictly at startup into a typed schema (unknown key /type error / range violation ⇒ refuse to start naming the offending key; missing file ⇒ write adefault-populated, fully-commented file). At runtime a `SettingsRegistry` layers effectivevalues `defaults < config.toml < startup flags/env`; `settings.update` rewrites config.tomlatomically (temp file + rename via `toml_edit`, preserving user comments/layout), and a debouncedfile watcher live-reloads external hand-edits (invalid content keeps last-good values and logs aWARN — never crashes the daemon). Keys pinned by a startup flag/env var report `origin:"flag"`and reject wire mutation with `-32602` while pinned. Opaque **machine-state blobs**(`repos.known`, `workspace.changeHistory`, `workspaceInitializer.state`, `permissions.rules`,`userRules` / `workspaceRules`, `endUserRules`) stay in the SQLite `settings` table (§9.2) —they are high-churn, not human-editable, and would thrash the file. Definitions (label,description, category, type, enum/min/max, default, sensitive, scope) are ported from`app-settings-schema.ts` as `AppSettingDefinition`s; group B adds its own definitions.
 - **Validation.** Every mutation is validated against its `AppSettingDefinition` (type, enummembership, numeric min/max) via the analog of `findAppSettingDefinition` before persisting;invalid changes are rejected with an `invalid params` error and nothing is written.
 - **Secrets.** Settings marked **sensitive** (`mcp.servers`, `server.auth.token`, `sourceControl.github.token`) are stored in the daemon's file-backed secret store (`intent_core::FileSecretStore` — `~/intent/secrets.json`, `0600` file / `0700` dir on unix, `INTENTD_SECRETS_FILE` override), never in `config.toml`, never in logs, and are **never returned in plaintext over the wire** — `settings.list`/`settings.get` redact them (presence/placeholder only). `server.auth.token` is read-only via the API (regenerate, not set). `workspace.sshKeyPath` is **not** sensitive: it holds a filesystem path to the SSH key, not key material — the real secret is the key file on disk, protected by filesystem permissions — so the value is stored as a plain string and read back verbatim by `settings.get`/`settings.list` (the FE `git`-env consumer needs the real path to hand to `git` via `GIT_SSH_COMMAND`).
 - **Change notification.** A successful `settings.update`/`settings.reset` persists the changeand emits a `settings:changed` event (§10) so every connected client stays in sync.
@@ -1320,7 +1323,7 @@ Resolve paths via the `directories` crate (with env overrides `INTENTD_DATA_DIR`
 | Runtime (UDS, pidfile) | ~/Library/Application Support/intentd/ | $XDG_RUNTIME_DIR/intentd/ |
 | Logs | ~/Library/Logs/intentd/ | $XDG_STATE_HOME/intentd/logs/ |
 
-`config.toml` holds non-secret settings (listen mode, port, discovery, default provider,GitHub base URI, log level). Secrets (bearer token, GitHub token) live in the **file-backed secret store** (`~/intent/secrets.json`, `0600` file / `0700` dir), never in `config.toml`.
+`config.toml` holds every non-secret human-editable setting (the TOML-backed catalog of §9.8:providers, model, workspace/git, mcp toggles, notifications, rtk, server/transport, sourcecontrol, ai, context, storage/runtime, logging, agents, events). It lives in the **data dir**(`<data_dir>/config.toml`, same directory as the DB/socket/secrets; `INTENTD_CONFIG` overrideretained), is strictly parsed at startup, live-reloaded on external edits, and atomicallyrewritten (comment-preserving) by `settings.update`. Secrets (bearer token, GitHub token) livein the **file-backed secret store** (`~/intent/secrets.json`, `0600` file / `0700` dir), neverin `config.toml`.
 
 ### 11.3 Security considerations
 

--- a/docs/00_initial_porting/PROTOCOL.md
+++ b/docs/00_initial_porting/PROTOCOL.md
@@ -1038,8 +1038,8 @@ non-existent or `bundled` definition → `-32602`.
 
 | Method | Params | Result |
 | --- | --- | --- |
-| settings.list | — | { settings: SettingDefinitionWithValue[] } (sensitive values redacted) |
-| settings.get | path (req) | { path, value, definition } — -32602 if path is unknown |
+| settings.list | — | { settings: SettingDefinitionWithValue[] } (sensitive values redacted; TOML-backed entries carry `origin`) |
+| settings.get | path (req) | { path, value, definition, origin? } — -32602 if path is unknown |
 | settings.update | changes (req, array of { path, value, reason? }) | { applied: [{ path, value }] }; triggers settings:changed |
 | settings.reset | path (req) | { path, value } (restores defaultValue) — -32602 if path is unknown |
 
@@ -1062,6 +1062,22 @@ interface SettingDefinition {
 ```
 
 `changes` entries use the ported `AppSettingChange` shape `{ path, value, reason? }` (`reason` is anoptional free-text audit note). `settings.update` **validates** each change against its definition(type / enum / min / max) and **persists** atomically; an unknown `path` or a value failingvalidation yields `-32602` and the whole batch is rejected (nothing applied). On success it emits a`settings:changed` notification (§6.5) carrying the applied `{ path, value }` pairs (sensitive valuesredacted).
+
+**Storage & the `origin` field.** Non-secret human-editable settings are **TOML-backed**: they
+persist in `<data_dir>/config.toml`, layered `defaults < config.toml < startup flags/env`
+(IMPLEMENTATION_SPEC.md §9.8). For TOML-backed paths, `settings.get` (and each `settings.list`
+entry) carries an additive `origin` field naming the layer the effective value came from:
+`"default"` (absent from the file), `"file"` (explicit in config.toml), or `"flag"` (pinned at
+boot by a startup flag / env var, e.g. `--listen`, `INTENTD_TCP_PORT`). Secrets and the opaque
+machine-state blobs (`repos.known`, `workspace.changeHistory`, `workspaceInitializer.state`,
+`permissions.rules`, `userRules` / `workspaceRules`, `endUserRules`) have **no** `origin` — they
+never live in config.toml (secrets stay in `secrets.json`, state blobs stay in SQLite).
+`settings.update` on a TOML-backed key rewrites config.toml atomically (temp file + rename,
+comment/layout-preserving); external hand-edits of config.toml are live-reloaded (strict
+re-parse, debounced; invalid content keeps last-good values) and emit the same
+`settings:changed` notification. A key pinned by a startup flag is **read-only over the wire**
+while pinned: `settings.update` / `settings.reset` on it yields `-32602` with a message naming
+the overriding flag ("overridden by startup flag …").
 
 **BE-exposed setting paths.** Only settings that affect daemon behavior are exposed. These are the ported, BE-owned settings (group A) plus `intentd`-specific host/daemon settings (group B):
 
@@ -1099,6 +1115,7 @@ interface SettingDefinition {
 { "jsonrpc":"2.0","id":52,"method":"settings.get","params":{ "path":"sourceControl.activeProvider" } }
 // ← response
 { "jsonrpc":"2.0","id":52,"result":{ "path":"sourceControl.activeProvider","value":"github",
+  "origin":"default",
   "definition":{ "path":"sourceControl.activeProvider","label":"Source-control provider",
     "description":"Active forge implementation","category":"sourceControl","type":"enum",
     "enumValues":["github"],"defaultValue":"github" } } }

--- a/docs/01_stabilizing/KNOWN_ISSUES.md
+++ b/docs/01_stabilizing/KNOWN_ISSUES.md
@@ -1508,3 +1508,13 @@ Agent commits do not appear in the sidebar Changes panel in a brand-new workspac
 **Expected:** Agent commits (and git pull / changes:tracked events) should trigger the Changes panel to refresh within ~2 seconds, without requiring a workspace switch.
 
 **Status:** fixed ([intent-hq/cloudlands-fe#82](https://github.com/intent-hq/cloudlands-fe/pull/82), 2026-07-16) — frontend firehose daemon event bridge now dispatches per-workspace debounced (1s) `changes/refreshRequested` on `git:commit`, `git:pull`, and `changes:tracked` events
+
+### STAB-130 (2026-07-20, area: intentd e2e tests / agent lifecycle, severity: P2)
+
+Pre-existing flaky test: `e2e_wss_agent_lifecycle` fails intermittently with a queue-drain race.
+
+**Repro:** Run `cargo test` in `packages/intentd` under load (e.g. alongside other test binaries) — `e2e_wss_agent_lifecycle` intermittently fails on a queued-message drain assertion. It is intermittent even in isolation, though it usually passes when run alone (`cargo test --test e2e_wss_agent_lifecycle`). The flake pre-dates the settings→TOML migration (fails identically at the pre-migration HEAD).
+
+**Expected:** The lifecycle e2e should deterministically wait for queue-drain events (bounded wait loops filtered by agent ID/event type, as in the STAB-34/STAB-36 fix pattern) instead of racing async event delivery.
+
+**Status:** open


### PR DESCRIPTION
Bumps `packages/intentd` to merged main `59a96ef` — the settings→TOML migration ([intent-hq/intentd#285](https://github.com/intent-hq/intentd/pull/285)).

## Submodule change

Non-secret human-editable settings move from the SQLite `settings` table to a strict, live-reloaded `<data_dir>/config.toml` with startup flag/env precedence. Wire surface is unchanged apart from an additive optional `origin` field (`default|file|flag`) on `settings.get`/`settings.list`. Opaque machine-state blobs (`repos.known`, `workspace.changeHistory`, `workspaceInitializer.state`, `permissions.rules`, rules keys) stay SQLite-backed. Migration 0047 prunes the TOML-backed keys from the settings table.

## Docs updated to match

- **PROTOCOL.md §5.12** — TOML storage semantics, the `origin` field, atomic comment-preserving write-back, live reload of hand-edits, and `-32602` rejection for flag-pinned keys.
- **IMPLEMENTATION_SPEC.md §9.2/§9.8/§11.2** — settings persistence notes: TOML-backed catalog vs SQLite state blobs, strict parse with fail-fast startup, layered `defaults < config.toml < flags` precedence, config.toml relocated to the data dir.
- **KNOWN_ISSUES.md** — files STAB-130: pre-existing `e2e_wss_agent_lifecycle` queue-drain flake (open; fails identically at pre-migration HEAD).

## Verification

- intentd gates green at the merged commit (fmt / clippy -D warnings / full test suite; CI on #285 all passing).
- FE smoke on the self-hosted stack (dev daemon + cloudlands-fe over ws://): first-boot config.toml generation, FE settings hydration, UI toggle → config.toml write-back, hand-edit → live reload → `settings:changed` in the renderer, provider settings round-trip, repo registry & change-history state blobs intact, flag-pinned key mutation rejected with `-32602`.
- `make check` green at the bumped gitlink.
