### PR TITLE
docs: sweep Cloudlands branding and bump intentd submodule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Instructions for AI agents working in this monorepo.
 
 ## Repository Structure
 
-This is a private monorepo that references Cloudlands component repositories as git
+This monorepo references the Intent component repositories as git
 submodules:
 
 - `packages/intentd` → [intent-hq/intentd](https://github.com/intent-hq/intentd) — Rust backend daemon

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Cloudlands Monorepo Makefile
+# Intent Monorepo Makefile
 #
 # Three postures for local work:
 #   1. `make dev-daemon` — default dev seat. intentd on an isolated data dir,

--- a/README.md
+++ b/README.md
@@ -1,12 +1,9 @@
-# Cloudlands Monorepo
+# Intent Monorepo
 
-Internal engineering monorepo for **Cloudlands**, an agentic coding platform. This repo ties
-the Cloudlands components together via git submodules and provides unified docs, tooling, and
+Monorepo for **Intent**, an agentic coding platform. This repo ties
+the Intent components together via git submodules and provides unified docs, tooling, and
 CI/CD. It mounts the **Rust backend daemon (`intentd`)**, the **Electron + SvelteKit
 desktop frontend (`cloudlands-fe`)**, and the **SwiftUI iOS companion app (`ios`)** as submodules.
-
-> ⚠️ Private Repository — This repo is internal to the Cloudlands engineering team. The
-> component repositories it references are also private. See Related Repositories for links.
 
 ## Architecture Overview
 
@@ -72,11 +69,11 @@ monorepo/
 
 ## Submodules
 
-| Path                     | Repository                                                                    | Visibility |
-| ------------------------ | ----------------------------------------------------------------------------- | ---------- |
-| `packages/intentd`       | [intent-hq/intentd](https://github.com/intent-hq/intentd)                     | Private    |
-| `packages/cloudlands-fe` | [intent-hq/cloudlands-fe](https://github.com/intent-hq/cloudlands-fe)         | Private    |
-| `packages/ios`           | [intent-hq/ios](https://github.com/intent-hq/ios)                             | Private    |
+| Path                     | Repository                                                                    |
+| ------------------------ | ----------------------------------------------------------------------------- |
+| `packages/intentd`       | [intent-hq/intentd](https://github.com/intent-hq/intentd)                     |
+| `packages/cloudlands-fe` | [intent-hq/cloudlands-fe](https://github.com/intent-hq/cloudlands-fe)         |
+| `packages/ios`           | [intent-hq/ios](https://github.com/intent-hq/ios)                             |
 
 ## Getting Started
 
@@ -154,6 +151,6 @@ Conventions:
 
 | Repository | Description |
 | --- | --- |
-| [intent-hq/intentd](https://github.com/intent-hq/intentd) | Rust backend daemon (private) — JSON-RPC over UDS, mounted at `packages/intentd`. |
-| [intent-hq/cloudlands-fe](https://github.com/intent-hq/cloudlands-fe) | Electron + SvelteKit desktop frontend (private) — mounted at `packages/cloudlands-fe`. |
-| [intent-hq/ios](https://github.com/intent-hq/ios) | SwiftUI iOS companion app (private) — mounted at `packages/ios`. |
+| [intent-hq/intentd](https://github.com/intent-hq/intentd) | Rust backend daemon — JSON-RPC over UDS, mounted at `packages/intentd`. |
+| [intent-hq/cloudlands-fe](https://github.com/intent-hq/cloudlands-fe) | Electron + SvelteKit desktop frontend — mounted at `packages/cloudlands-fe`. |
+| [intent-hq/ios](https://github.com/intent-hq/ios) | SwiftUI iOS companion app — mounted at `packages/ios`. |

--- a/docs/01_stabilizing/KNOWN_ISSUES.md
+++ b/docs/01_stabilizing/KNOWN_ISSUES.md
@@ -2,7 +2,7 @@
 
 Live issue tracker for the **01_stabilizing** self-hosting phase.
 
-**Next available ID:** STAB-148 (as of 2026-07-21)
+**Next available ID:** STAB-149 (as of 2026-07-21)
 
 ## Intake Convention
 
@@ -19,7 +19,7 @@ Each issue entry includes:
 
 ## Fixed Issues
 
-### STAB-147 (2026-07-21, area: intentd CI / e2e coverage jobs, severity: P1)
+### STAB-148 (2026-07-21, area: intentd CI / e2e coverage jobs, severity: P1)
 
 Main's CI went red: the `coverage-e2e` and `coverage-all` jobs failed deterministically with `daemon did not start` panics at exactly the 10-second daemon-startup budget, blocking all PR merges (the `coverage-e2e` check is required with no admin bypass).
 
@@ -993,7 +993,7 @@ These items were genuinely open/deferred in [../00_initial_porting/BREADCRUMBS.m
 
 Home-screen repo selector does not default to the most recent repository; workspace-initializer persistence never re-homed after saga removal.
 
-**Repro:** Before the fix: Open the Cloudlands home screen, create a workspace from repo A, then create another workspace from repo B. Close the app, reopen, and return to the home screen. Observed: the repo selector dropdown defaults to "Select a repository" (no selection) instead of repo B. Expected: the selector should default to the most recent repository (repo B).
+**Repro:** Before the fix: Open the Intent home screen, create a workspace from repo A, then create another workspace from repo B. Close the app, reopen, and return to the home screen. Observed: the repo selector dropdown defaults to "Select a repository" (no selection) instead of repo B. Expected: the selector should default to the most recent repository (repo B).
 
 **Root cause:** The workspace-initializer component (`WorkspaceInitializer.svelte`) previously persisted its form state (selected repo, branch, prompt text) via a Redux-observable saga (`workspace-initializer-saga.ts`). The saga subscribed to form-state actions and wrote to an electron-store `workspace-initializer` bag. Commit 95d908a2 ("refactor: remove redux-observable") deleted the saga file and all persistence logic, but the component continued to read from the now-static electron-store entry. New form interactions (repo selection, branch typing, prompt edits) updated local component state and Redux store state but never persisted, so the electron-store bag stayed frozen at its last pre-saga-removal value. On app restart, the component rehydrated from the stale electron-store entry, discarding all session state. The repo selector defaulted to no selection (or the stale repo) instead of the most recent repository.
 

--- a/docs/01_stabilizing/KNOWN_ISSUES.md
+++ b/docs/01_stabilizing/KNOWN_ISSUES.md
@@ -19,6 +19,16 @@ Each issue entry includes:
 
 ## Fixed Issues
 
+### STAB-147 (2026-07-21, area: intentd CI / e2e coverage jobs, severity: P1)
+
+Main's CI went red: the `coverage-e2e` and `coverage-all` jobs failed deterministically with `daemon did not start` panics at exactly the 10-second daemon-startup budget, blocking all PR merges (the `coverage-e2e` check is required with no admin bypass).
+
+**Repro:** Any push to main or any PR triggered the coverage jobs; e2e tests panicked at ~10.2–11.0s in `await_uds`-style startup waits (e.g. `e2e_config_precedence`, `e2e_transport`, `e2e_wss_agent_lifecycle`; the specific suites varied per run). The same tests pass locally in ~0.2s uninstrumented.
+
+**Root cause:** The coverage-instrumented `intentd` binary's startup latency crept past the hardcoded 10s budget on the oversubscribed 4-vCPU runners (`NEXTEST_TEST_THREADS: 8`). The coverage scripts export `INTENTD_TEST_TIMEOUT_MULTIPLIER=3`, but only one suite (`e2e_wss_agent_rehydration`) honored it — every other suite hardcoded its startup wait.
+
+**Status:** fixed (https://github.com/intent-hq/intentd/pull/289, 2026-07-21) — daemon-startup budgets raised to 60s across all e2e/uds suites. Follow-up: hoist a shared multiplier-aware `test_timeout()` helper into `tests/common/` so budgets are centrally tunable.
+
 ### STAB-146 (2026-07-20, area: claude-code ACP adapter spawn / model catalog (intentd + cloudlands-fe), severity: P2)
 
 The Claude model list drifted from what the `claude` CLI itself offered: the model picker showed a stale catalog (missing newly released models / retaining retired ones) because the claude-code ACP adapter binary being spawned was an old, unpinned copy rather than one matching the installed CLI.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Documentation
 
-Index of the `docs/` tree for the Cloudlands monorepo.
+Index of the `docs/` tree for the Intent monorepo.
 
 ## Wire Contract — `PROTOCOL.md`
 
@@ -43,13 +43,13 @@ record of how the port progressed. The **canonical, versioned wire contract** is
 
 **Self-hosting cutover achieved**: the 00_initial_porting effort was built entirely with
 the reference app (`augmentcode/intent`); as of 2026-07-13, development moves onto the
-Cloudlands stack (`intentd` + `cloudlands-fe`) — the IDE now builds the next version of
+Intent stack (`intentd` + `cloudlands-fe`) — the IDE now builds the next version of
 itself.
 
 ## `01_stabilizing/`
 
 Documents for the **ongoing stabilization and hardening phase**, post-initial-port.
-Development now happens on the self-hosted Cloudlands stack (`intentd` + `cloudlands-fe`),
+Development now happens on the self-hosted Intent stack (`intentd` + `cloudlands-fe`),
 which now builds the next version of itself.
 
 - **[STABILIZATION.md](./01_stabilizing/STABILIZATION.md)** — the **dogfooding process**:


### PR DESCRIPTION
# Summary

Lands the Intent branding sweep across the monorepo docs and bumps the `packages/intentd` gitlink past the merged submodule PRs.

## Changes

- **docs sweep** — removes stale "Cloudlands" branding references from `README.md`, `AGENTS.md`, `Makefile`, `docs/README.md`, and `docs/01_stabilizing/KNOWN_ISSUES.md`.
- **submodule bump** — `packages/intentd` → `08937ec` (latest main), which includes:
  - [intent-hq/intentd#287](https://github.com/intent-hq/intentd/pull/287) — README branding alignment.
  - [intent-hq/intentd#289](https://github.com/intent-hq/intentd/pull/289) — e2e daemon-startup timeout fix that turned main's `coverage-e2e`/`coverage-all` jobs green again.
- **KNOWN_ISSUES** — files **STAB-148** (P1, intentd CI / e2e coverage jobs) documenting the coverage-job failures and marking it fixed via intentd#289.

The cloudlands-fe branding PR ([intent-hq/cloudlands-fe#199](https://github.com/intent-hq/cloudlands-fe/pull/199)) is already included in the `packages/cloudlands-fe` gitlink on main, so no bump is needed for it here.

## Verification

- intentd CI green at the bumped gitlink (all checks passed on #289 and #287 merges).
- Monorepo docs changes are text-only.
