### PR TITLE
chore: init submodules recursively in workspace setupScript

### DIFF
--- a/.intent/config.json
+++ b/.intent/config.json
@@ -1,5 +1,5 @@
 {
-  "setupScript": "#!/bin/bash\n# Generic setup script\n# Available variables: $MAIN_CHECKOUT, $WORKTREE_PATH, $BRANCH_NAME, $SOURCE_BRANCH\n\n# Copy environment and config files\nfor file in .env .env.local .envrc .tool-versions; do\n  if [ -f \"$MAIN_CHECKOUT/$file\" ]; then\n    cp \"$MAIN_CHECKOUT/$file\" \"./$file\"\n    echo \"Copied $file\"\n  fi\ndone\n\necho \"Config files copied\"",
+  "setupScript": "#!/bin/bash\n# Generic setup script\n# Available variables: $MAIN_CHECKOUT, $WORKTREE_PATH, $BRANCH_NAME, $SOURCE_BRANCH\n\n# Copy environment and config files\nfor file in .env .env.local .envrc .tool-versions; do\n  if [ -f \"$MAIN_CHECKOUT/$file\" ]; then\n    cp \"$MAIN_CHECKOUT/$file\" \"./$file\"\n    echo \"Copied $file\"\n  fi\ndone\n\necho \"Config files copied\"\n\n# Initialize git submodules\necho \"Initializing submodules\"\ngit submodule update --init --recursive",
   "scripts": [
     {
       "name": "all",


### PR DESCRIPTION
## Summary

Updates the `setupScript` in `.intent/config.json` so that new Intent workspaces (worktrees) initialize git submodules automatically. After the existing env/config file copy loop, the script now runs:

- `git submodule update --init --recursive`

This matches the local setup documented in `AGENTS.md`, so fresh workspaces come up with all three submodules (intentd, cloudlands-fe, ios) initialized.

## Verification

- `python3 -m json.tool .intent/config.json` passes (valid JSON).
- Diff touches only the `setupScript` line; no other keys modified.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author