### PR TITLE
chore: update intentd submodule for centralized daemon-startup timeout helper

### DIFF
--- a/docs/01_stabilizing/KNOWN_ISSUES.md
+++ b/docs/01_stabilizing/KNOWN_ISSUES.md
@@ -67,7 +67,7 @@ Main's CI went red: the `coverage-e2e` and `coverage-all` jobs failed determinis
 
 **Root cause:** The coverage-instrumented `intentd` binary's startup latency crept past the hardcoded 10s budget on the oversubscribed 4-vCPU runners (`NEXTEST_TEST_THREADS: 8`). The coverage scripts export `INTENTD_TEST_TIMEOUT_MULTIPLIER=3`, but only one suite (`e2e_wss_agent_rehydration`) honored it — every other suite hardcoded its startup wait.
 
-**Status:** fixed (https://github.com/intent-hq/intentd/pull/289, 2026-07-21) — daemon-startup budgets raised to 60s across all e2e/uds suites. Follow-up: hoist a shared multiplier-aware `test_timeout()` helper into `tests/common/` so budgets are centrally tunable.
+**Status:** fixed (https://github.com/intent-hq/intentd/pull/289, 2026-07-21) — daemon-startup budgets raised to 60s across all e2e/uds suites. Follow-up landed (https://github.com/intent-hq/intentd/pull/291, 2026-07-21): shared multiplier-aware `test_timeout()` / `daemon_startup_timeout()` helpers hoisted into `tests/common/`; all 41 suites now honor `INTENTD_TEST_TIMEOUT_MULTIPLIER`.
 
 ### STAB-146 (2026-07-20, area: claude-code ACP adapter spawn / model catalog (intentd + cloudlands-fe), severity: P2)
 


### PR DESCRIPTION
# Summary

Bumps `packages/intentd` to [intent-hq/intentd@0bce229](https://github.com/intent-hq/intentd/commit/0bce229f3ad17b2e885de2c44ad04e6758d77b14), which landed [intent-hq/intentd#291](https://github.com/intent-hq/intentd/pull/291) — the STAB-148 follow-up centralizing the e2e daemon-startup timeout into a shared, `INTENTD_TEST_TIMEOUT_MULTIPLIER`-aware helper.

## Changes

- **Submodule bump** (`packages/intentd`): all 41 e2e/uds suites now use `common::daemon_startup_timeout()` (`test_timeout(60s)`) instead of per-suite hardcoded 60s waits/poll-loop iteration counts, so the coverage jobs' ×3 multiplier applies uniformly (60s local / 180s coverage CI). Includes hardening from review: non-finite multipliers ignored, overflow saturates to `Duration::MAX`, timeout-specific panic messages, and a module-level `#![allow(dead_code)]` in `tests/common/` replacing 39 per-file attributes.
- **Docs** (`docs/01_stabilizing/KNOWN_ISSUES.md`): STAB-148 entry updated to note the follow-up landed with the PR link.

## Verification

All intentd CI (check, build, coverage-e2e, coverage-all, CodeQL) green on the submodule PR before squash-merge; `cargo fmt --check`, `cargo clippy --workspace -- -D warnings`, and targeted suite runs verified locally.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author