### PR TITLE
chore: bump intentd for workspaceOverrides re-home and ai.* removal

### DIFF
--- a/docs/00_initial_porting/IMPLEMENTATION_SPEC.md
+++ b/docs/00_initial_porting/IMPLEMENTATION_SPEC.md
@@ -966,8 +966,9 @@ CREATE TABLE specialist (
 );
 
 -- Opaque machine-state blobs only (repos.known, workspace.changeHistory,
--- workspaceInitializer.state, permissions.rules, userRules/workspaceRules,
--- endUserRules). Human-editable settings live in config.toml (§9.8, §11.2).
+-- workspaceInitializer.state, model.workspaceOverrides, permissions.rules,
+-- userRules/workspaceRules, endUserRules). Human-editable settings live in
+-- config.toml (§9.8, §11.2).
 CREATE TABLE settings (
   key   TEXT PRIMARY KEY,
   value TEXT NOT NULL                              -- JSON-encoded value
@@ -1147,7 +1148,7 @@ Provide `intentd import --from <intent-userData-dir>` to migrate an existing ins
 | providers.paths.{auggie,claude-code,codex,…} | map<string,path> | {} | no | src/shared/app-settings-schema.ts |
 | model.default | string | provider default | no | src/shared/app-settings-schema.ts |
 | model.providerDefaults | map | {} | no | src/shared/app-settings-schema.ts |
-| model.workspaceOverrides | map | {} | no | src/shared/app-settings-schema.ts |
+| model.workspaceOverrides | map | {} | no | src/shared/app-settings-schema.ts (SQLite state blob — not TOML-backed, no origin field) |
 | backgroundAgents.defaultModel | string | — | no | src/shared/app-settings-schema.ts |
 | backgroundAgents.typeOverrides | map | {} | no | src/shared/app-settings-schema.ts |
 | backgroundAgents.providerSettings | map | {} | no | src/shared/app-settings-schema.ts |
@@ -1194,7 +1195,7 @@ Source-control provider config is namespaced as `sourceControl.<provider>.*` so 
 
 #### Persistence, validation, secrets
 
-- **Storage.** Non-secret **human-editable** settings are TOML-backed: they persist in`<data_dir>/config.toml` (§11.2), parsed strictly at startup into a typed schema (unknown key /type error / range violation ⇒ refuse to start naming the offending key; missing file ⇒ write adefault-populated, fully-commented file). At runtime a `SettingsRegistry` layers effectivevalues `defaults < config.toml < startup flags/env`; `settings.update` rewrites config.tomlatomically (temp file + rename via `toml_edit`, preserving user comments/layout), and a debouncedfile watcher live-reloads external hand-edits (invalid content keeps last-good values and logs aWARN — never crashes the daemon). Keys pinned by a startup flag/env var report `origin:"flag"`and reject wire mutation with `-32602` while pinned. Opaque **machine-state blobs**(`repos.known`, `workspace.changeHistory`, `workspaceInitializer.state`, `permissions.rules`,`userRules` / `workspaceRules`, `endUserRules`) stay in the SQLite `settings` table (§9.2) —they are high-churn, not human-editable, and would thrash the file. Definitions (label,description, category, type, enum/min/max, default, sensitive, scope) are ported from`app-settings-schema.ts` as `AppSettingDefinition`s; group B adds its own definitions.
+- **Storage.** Non-secret **human-editable** settings are TOML-backed: they persist in`<data_dir>/config.toml` (§11.2), parsed strictly at startup into a typed schema (unknown key /type error / range violation ⇒ refuse to start naming the offending key; missing file ⇒ write adefault-populated, fully-commented file). At runtime a `SettingsRegistry` layers effectivevalues `defaults < config.toml < startup flags/env`; `settings.update` rewrites config.tomlatomically (temp file + rename via `toml_edit`, preserving user comments/layout), and a debouncedfile watcher live-reloads external hand-edits (invalid content keeps last-good values and logs aWARN — never crashes the daemon). Keys pinned by a startup flag/env var report `origin:"flag"`and reject wire mutation with `-32602` while pinned. Opaque **machine-state blobs**(`repos.known`, `workspace.changeHistory`, `workspaceInitializer.state`, `model.workspaceOverrides`, `permissions.rules`,`userRules` / `workspaceRules`, `endUserRules`) stay in the SQLite `settings` table (§9.2) —they are high-churn, not human-editable, and would thrash the file. Definitions (label,description, category, type, enum/min/max, default, sensitive, scope) are ported from`app-settings-schema.ts` as `AppSettingDefinition`s; group B adds its own definitions.
 - **Validation.** Every mutation is validated against its `AppSettingDefinition` (type, enummembership, numeric min/max) via the analog of `findAppSettingDefinition` before persisting;invalid changes are rejected with an `invalid params` error and nothing is written.
 - **Secrets.** Settings marked **sensitive** (`mcp.servers`, `server.auth.token`, `sourceControl.github.token`) are stored in the daemon's file-backed secret store (`intent_core::FileSecretStore` — `~/intent/secrets.json`, `0600` file / `0700` dir on unix, `INTENTD_SECRETS_FILE` override), never in `config.toml`, never in logs, and are **never returned in plaintext over the wire** — `settings.list`/`settings.get` redact them (presence/placeholder only). `server.auth.token` is read-only via the API (regenerate, not set). `workspace.sshKeyPath` is **not** sensitive: it holds a filesystem path to the SSH key, not key material — the real secret is the key file on disk, protected by filesystem permissions — so the value is stored as a plain string and read back verbatim by `settings.get`/`settings.list` (the FE `git`-env consumer needs the real path to hand to `git` via `GIT_SSH_COMMAND`).
 - **Change notification.** A successful `settings.update`/`settings.reset` persists the changeand emits a `settings:changed` event (§10) so every connected client stays in sync.
@@ -1323,7 +1324,7 @@ Resolve paths via the `directories` crate (with env overrides `INTENTD_DATA_DIR`
 | Runtime (UDS, pidfile) | ~/Library/Application Support/intentd/ | $XDG_RUNTIME_DIR/intentd/ |
 | Logs | ~/Library/Logs/intentd/ | $XDG_STATE_HOME/intentd/logs/ |
 
-`config.toml` holds every non-secret human-editable setting (the TOML-backed catalog of §9.8:providers, model, workspace/git, mcp toggles, notifications, rtk, server/transport, sourcecontrol, ai, context, storage/runtime, logging, agents, events). It lives in the **data dir**(`<data_dir>/config.toml`, same directory as the DB/socket/secrets; `INTENTD_CONFIG` overrideretained), is strictly parsed at startup, live-reloaded on external edits, and atomicallyrewritten (comment-preserving) by `settings.update`. Secrets (bearer token, GitHub token) livein the **file-backed secret store** (`~/intent/secrets.json`, `0600` file / `0700` dir), neverin `config.toml`.
+`config.toml` holds every non-secret human-editable setting (the TOML-backed catalog of §9.8:providers, model, workspace/git, mcp toggles, notifications, rtk, server/transport, sourcecontrol, context, storage/runtime, logging, agents, events). It lives in the **data dir**(`<data_dir>/config.toml`, same directory as the DB/socket/secrets; `INTENTD_CONFIG` overrideretained), is strictly parsed at startup, live-reloaded on external edits, and atomicallyrewritten (comment-preserving) by `settings.update`. Secrets (bearer token, GitHub token) livein the **file-backed secret store** (`~/intent/secrets.json`, `0600` file / `0700` dir), neverin `config.toml`.
 
 ### 11.3 Security considerations
 

--- a/docs/00_initial_porting/PROTOCOL.md
+++ b/docs/00_initial_porting/PROTOCOL.md
@@ -1078,8 +1078,9 @@ entry) carries an additive `origin` field naming the layer the effective value c
 `"default"` (absent from the file), `"file"` (explicit in config.toml), or `"flag"` (pinned at
 boot by a startup flag / env var, e.g. `--listen`, `INTENTD_TCP_PORT`). Secrets and the opaque
 machine-state blobs (`repos.known`, `workspace.changeHistory`, `workspaceInitializer.state`,
-`permissions.rules`, `userRules` / `workspaceRules`, `endUserRules`) have **no** `origin` — they
-never live in config.toml (secrets stay in `secrets.json`, state blobs stay in SQLite).
+`model.workspaceOverrides`, `permissions.rules`, `userRules` / `workspaceRules`,
+`endUserRules`) have **no** `origin` — they never live in config.toml (secrets stay in
+`secrets.json`, state blobs stay in SQLite).
 `settings.update` on a TOML-backed key rewrites config.toml atomically (temp file + rename,
 comment/layout-preserving); external hand-edits of config.toml are live-reloaded (strict
 re-parse, debounced; invalid content keeps last-good values) and emit the same
@@ -1089,14 +1090,13 @@ the overriding flag ("overridden by startup flag …").
 
 **BE-exposed setting paths.** Only settings that affect daemon behavior are exposed. These are the ported, BE-owned settings (group A) plus `intentd`-specific host/daemon settings (group B):
 
-- **Providers / agents:** `providers.active`, `providers.enabled`, `providers.paths.{auggie,claude-code,codex,…}`,`model.default`, `model.providerDefaults`, `model.workspaceOverrides`, `backgroundAgents.defaultModel`,`backgroundAgents.typeOverrides`, `backgroundAgents.providerSettings`, `specialists.default`.
+- **Providers / agents:** `providers.active`, `providers.enabled`, `providers.paths.{auggie,claude-code,codex,…}`,`model.default`, `model.providerDefaults`, `backgroundAgents.defaultModel`,`backgroundAgents.typeOverrides`, `backgroundAgents.providerSettings`, `specialists.default`. `model.workspaceOverrides` shares this wire surface but is an opaque machine-state blob (SQLite-backed, no `origin` field — see above).
 - **Workspace / git:** `workspace.branchPrefix`, `workspace.worktreesLocation`,`workspace.sshKeyPath` *(string — filesystem path to the key, not key material; the real secret is the key file on disk, so the value is read back verbatim by the FE `git`-env consumer)*, `workspace.defaultShell`, `workspace.autoFetch`,`workspace.autoCommit`.
 - **MCP:** `mcp.enableUserServers`, `mcp.disabledServers`, `mcp.servers` *(sensitive)*.
 - **Server / transport (new in intentd):** `server.listenMode` (`uds`|`tcp`), `server.socketPath`,`server.bindAddress`, `server.port`, `server.tls.enabled`, `server.auth.enabled`,`server.auth.token` *(sensitive; read-only / regenerate)*, `server.originAllowList`,`server.discovery.enabled` (mDNS).
 - **Source control (new in intentd, provider-agnostic):** `sourceControl.activeProvider` (enum,**default **`github`; v1 ships only `github`), `sourceControl.github.tokenSource`(`env`|`gh-cli`|`explicit`), `sourceControl.github.token` *(sensitive)*,`sourceControl.github.apiBaseUrl` (GitHub Enterprise support). Per-provider config is namespaced as`sourceControl.<provider>.*` so future hosts slot in as `sourceControl.gitlab.*`,`sourceControl.bitbucket.*`, etc. (replaces any flat `github.*` keys).
 - **Linear (new in intentd):** `linear.token` *(sensitive)* — the Linear API key, persisted to the daemon's file-backed secret store (`~/intent/secrets.json`, `0600`) under account `linear.token`, the exact entry the `linear.*` namespace's secret-store-first `auto` token resolution reads (§5.28), so `settings.update` on this path is the FE "connect Linear" flow.
 - **Sentry account (new in intentd):** `accounts.sentry.token` *(sensitive)* — the Sentry API tokenused by the `sentry.*` namespace (§5.29); `accounts.sentry.organization` *(string)* — the Sentryorganization slug (non-secret companion).
-- **Primary AI provider (new in intentd):** `ai.apiToken` *(sensitive)*, `ai.apiUrl` *(string)*,`ai.model` *(string)*, `ai.temperature` *(number, 0..=2, default 0.7)*, `ai.maxTokens` *(number,>=1, default 4096)*, `ai.streamingSpeed` *(number, >=0, default 0)*. Ports the FE`workspace-config` `config.ai.*` blob one-to-one; `ai.apiToken` is redacted on the wire.
 - **Persisted policy & rules (new in intentd):** `permissions.rules` *(object)* — persisted commandallow/deny/ask entries; `userRules` *(object)* — global user prompt-rule content;`workspaceRules` *(object)* — workspace-scoped prompt-rule content. Each is an opaque bagvalidated by shape only; downstream consumers own the internal schema.
 - **Cross-workspace repos & history (new in intentd):** `repos.known` *(object)* — the known-repositorylist the FE previously kept in the `repo-registry` electron-store; `workspace.changeHistory`*(object)* — per-workspace diff-history bags the FE previously kept in the default `config.json`electron-store. Both are non-sensitive; the daemon persists the JSON opaquely.
 - **Workspace initializer (new in intentd):** `workspaceInitializer.state` *(object, non-sensitive, default `{}`)* — persisted home-screen workspace-initializer form state, opaque bag owned by the FE.


### PR DESCRIPTION
Follow-up to intent-hq/intentd#285 / #331: ships the three fixes verified while dogfooding the TOML-backed settings stack, plus the matching protocol/spec docs.

## Submodule bumps

- **packages/intentd → `196a10e`** ([intent-hq/intentd#302](https://github.com/intent-hq/intentd/pull/302)): re-homes `model.workspaceOverrides` from the `config.toml` schema to the SQLite state-blob (no `origin` on the wire) with a one-time legacy import → comment-preserving strip on boot, and removes the deprecated `ai.*` config group (`[ai]` table + `ai.apiToken` secret) with the same boot-tolerant discard-and-strip path.
- **packages/cloudlands-fe → `30c5b4f3`** (includes [intent-hq/cloudlands-fe#213](https://github.com/intent-hq/cloudlands-fe/pull/213)): fixes compound model-id provider attribution (`opencode:model` picks land under the provider encoded in the id, not the active provider) and drops the retired `ai.*` group from `AppConfig`/`ConfigManager` and the daemon-sync key lists.

## Docs

- `docs/00_initial_porting/PROTOCOL.md` §5.12: `model.workspaceOverrides` moved to the SQLite state-blob list; `ai.*` references removed.
- `docs/00_initial_porting/IMPLEMENTATION_SPEC.md`: settings tables/storage descriptions updated to match.

## Verification

- intentd #302: fmt/clippy/full test suite green locally and in CI (including new legacy import/strip unit + two-boot e2e coverage); squash-merged after review with all threads addressed.
- cloudlands-fe #213: lint/check/3× tsc/unit suite (9200+ tests) green locally and in CI; squash-merged after review with all threads addressed.
- Monorepo: `make check` green against the bumped intentd gitlink.
