### PR TITLE
fix: update cloudlands-fe submodule for the STAB-161 global agent-idle notifications fix

### DIFF
--- a/docs/01_stabilizing/KNOWN_ISSUES.md
+++ b/docs/01_stabilizing/KNOWN_ISSUES.md
@@ -2,7 +2,7 @@
 
 Live issue tracker for the **01_stabilizing** self-hosting phase.
 
-**Next available ID:** STAB-161 (as of 2026-07-21)
+**Next available ID:** STAB-162 (as of 2026-07-21)
 
 ## Intake Convention
 
@@ -18,6 +18,20 @@ Each issue entry includes:
 ---
 
 ## Fixed Issues
+
+### STAB-161 (2026-07-21, area: cloudlands-fe desktop notifications / event subscription scope, severity: P1)
+
+`agent:idle` desktop notifications only fired for workspaces currently open in a window: the `NotificationService` was instantiated per open workspace (STAB-153's `syncNotificationServices(openWorkspaceIds)` reconciliation) and each instance subscribed with a `workspaceId` filter, so agents completing in closed/background workspaces never produced an OS banner — precisely the case where a notification matters most.
+
+**Repro:** Delegate an agent in workspace A, close its window (or never open one), let the agent run to completion. Observed: no OS notification banner when the agent goes idle.
+
+**Root cause:** STAB-153's fix scoped the subscription lifecycle to open workspaces. PROTOCOL.md §6.1 supports omitting `workspaceId` on `events.subscribe` to receive matching events across all workspaces, but the per-workspace service design couldn't use it.
+
+**Expected:** One app-lifetime notification service subscribes globally (`events.subscribe { eventTypes: ['agent:idle'] }`, no `workspaceId`) and routes each event by its `workspaceId`: per-workspace prefs/suppression/focus-gating are applied per event; when the workspace has no open window, the notification falls back to the focused (or any) window for sound delivery and navigates that window to the workspace on click.
+
+**Status:** fixed ([intent-hq/cloudlands-fe#220](https://github.com/intent-hq/cloudlands-fe/pull/220), 2026-07-21) — replaced the per-open-workspace service instances with a single boot-time global `NotificationService` (started once from `main/index.ts`), removed `syncNotificationServices`/`disposeNotificationService`, retained STAB-153's reconnect/initial-connect resubscribe hardening (plus releasing a superseded subscription id on concurrent same-epoch subscribes), and added sound + click-navigation fallbacks for workspaces without an open window, with unit tests for the wire shape, routing, and both fallbacks.
+
+---
 
 ### STAB-160 (2026-07-21, area: cloudlands-fe CI / lint, severity: P1)
 


### PR DESCRIPTION
## Summary

Bumps `packages/cloudlands-fe` to the merged fix for **STAB-161** and files the tracker entry as fixed.

- Submodule PR: intent-hq/cloudlands-fe#220 — `fix: make agent:idle notifications global across all workspaces (STAB-161)`
- Merged submodule SHA: `408959e61f4d7ac0eb024406dcd2e90659f7d1c6`

## What changed

`agent:idle` desktop notifications previously only fired for workspaces open in a window: STAB-153's fix homed the `NotificationService` lifecycle on per-open-workspace reconciliation, with each instance subscribing with a `workspaceId` filter. Agents finishing in closed/background workspaces never produced a banner.

The fix replaces the per-workspace instances with a single app-lifetime service that subscribes globally (`events.subscribe { eventTypes: ['agent:idle'] }`, no `workspaceId`, per PROTOCOL.md §6.1) and routes each event by its `workspaceId`, with sound and click-navigation fallbacks when the event's workspace has no open window. Reconnect/initial-connect resubscribe hardening from STAB-153 is retained, plus release of superseded subscription ids on concurrent same-epoch subscribes.

## KNOWN_ISSUES.md

- Files **STAB-161** as fixed (PR link + date), noting it corrects STAB-153's open-workspace scoping.
- Bumps next available ID to STAB-162.
