### PR TITLE
fix: bump intentd for grouped-failure and interrupt wake fixes (STAB-164)

### DIFF
--- a/docs/01_stabilizing/KNOWN_ISSUES.md
+++ b/docs/01_stabilizing/KNOWN_ISSUES.md
@@ -2,7 +2,7 @@
 
 Live issue tracker for the **01_stabilizing** self-hosting phase.
 
-**Next available ID:** STAB-164 (as of 2026-07-21)
+**Next available ID:** STAB-165 (as of 2026-07-21)
 
 ## Intake Convention
 
@@ -18,6 +18,16 @@ Each issue entry includes:
 ---
 
 ## Fixed Issues
+
+### STAB-164 (2026-07-21, area: intentd agent subscriptions / delegation groups, severity: P1)
+
+A parent that delegated multiple children with `waitMode: "after_all"` received no wake when a child failed mid-group — the failed child sat parked in Error while the parent stayed silent until every remaining member settled (observed 40-minute silent gaps in production).
+
+**Repro:** (a) Delegate ≥2 children with `waitMode: "after_all"`; one child hits the 1800s session/prompt idle timeout → `agent:failed`. Observed: the parent receives NO wake until every remaining group member settles, while the failed child is parked in Error awaiting coordinator intervention (STAB-52 gate — never auto-redriven). (b) Secondary: the aggregated settlement wake reported `completionStatus: completed` even when a member failed (`partial` was only used for deletions). (c) Related: `agent.sendMessage` with `priority: "interrupt"` emitted the STAB-28 synthetic `agent:idle` before the follow-up message queued, delivering a spurious "child settled" completion wake to subscribed parents.
+
+**Status:** fixed ([intent-hq/intentd#312](https://github.com/intent-hq/intentd/pull/312), [intent-hq/intentd#317](https://github.com/intent-hq/intentd/pull/317), 2026-07-21) — #312 adds an immediate grouped-failure wake (dedup-guarded) and reports the group wake status as `partial` when any member failed or was deleted; #317 makes `interrupt_send_message` suppress the synthetic idle emit (plain interrupt / `agent.stop` unchanged).
+
+---
 
 ### STAB-163 (2026-07-21, area: intentd agent runtime / direct-send events + cloudlands-fe chat edit flow, severity: P1)
 


### PR DESCRIPTION
## Summary

Bumps `packages/intentd` from `fec6a69` to `e08a189` (latest main) and files **STAB-164** in `docs/01_stabilizing/KNOWN_ISSUES.md` (fixed).

This bump newly picks up intent-hq/intentd#317 and intent-hq/intentd#314; intent-hq/intentd#312 (the other STAB-164 fix) was already an ancestor of the previous gitlink `fec6a69`.

## STAB-164 — delegation-group failure wakes (P1)

- (a) With `waitMode: "after_all"` and >=2 delegated children, a child failing (e.g. 1800s session/prompt idle timeout -> `agent:failed`) produced NO parent wake until every remaining group member settled — observed 40-minute silent gaps in production, with the failed child parked in Error awaiting coordinator intervention (STAB-52 gate).
- (b) The aggregated settlement wake reported `completionStatus: completed` even when a member failed (`partial` was only used for deletions).
- (c) `agent.sendMessage` with `priority: "interrupt"` emitted the STAB-28 synthetic `agent:idle` before the follow-up message queued, delivering a spurious "child settled" completion wake to subscribed parents.

## Submodule PRs

- intent-hq/intentd#312 — immediate grouped-failure wake (dedup-guarded); group wake status `partial` on failed/deleted members (already included in the previous gitlink `fec6a69`)
- intent-hq/intentd#317 — `interrupt_send_message` suppresses the synthetic idle emit (plain interrupt / `agent.stop` unchanged) (new in this bump)

The bump also picks up intent-hq/intentd#314 (perf: bound `workspace.list` aggregate enrichment).

Note: the tracker entry uses ID STAB-164 (not STAB-160) because STAB-160 was already claimed on main by the cloudlands-fe CI/lint issue; STAB-164 was the next available ID.

## Verification

- `make check` (cargo fmt --check, clippy -D warnings) — green
- `make test` (cargo test --workspace) — green
