### PR TITLE
chore: update intentd and cloudlands-fe submodules for Changes-tab and workspace.list performance work

### DIFF
--- a/docs/01_stabilizing/KNOWN_ISSUES.md
+++ b/docs/01_stabilizing/KNOWN_ISSUES.md
@@ -2,7 +2,7 @@
 
 Live issue tracker for the **01_stabilizing** self-hosting phase.
 
-**Next available ID:** STAB-165 (as of 2026-07-21)
+**Next available ID:** STAB-166 (as of 2026-07-21)
 
 ## Intake Convention
 
@@ -18,6 +18,16 @@ Each issue entry includes:
 ---
 
 ## Fixed Issues
+
+### STAB-165 (2026-07-21, area: intentd / intent-services (workspace.list, workspace.get), severity: P1)
+
+`workspace.list` times out on large worktrees or many workspaces.
+
+**Repro:** With several large repos or many workspaces, FE polls `workspace.list` and hits "JSON-RPC request timed out: workspace.list" — the call ran synchronous git diffs (`head_diff_rollup`) and live CoW filesystem probes per workspace inline on the async runtime.
+
+**Status:** fixed ([intent-hq/intentd#314](https://github.com/intent-hq/intentd/pull/314), 2026-07-21) — enrichment offloaded to the blocking pool, parallelized with bounded concurrency, cached (5s TTL for diffs, per-pair lifetime for CoW), and time-budgeted (1.5s/aggregate) so the call degrades to stale/omitted aggregates instead of blocking.
+
+---
 
 ### STAB-164 (2026-07-21, area: intentd agent subscriptions / delegation groups, severity: P1)
 


### PR DESCRIPTION
Final bump for the Changes-tab performance effort plus the workspace.list timeout fix, and files STAB-165 in the issue tracker.

## Submodule updates
- **packages/cloudlands-fe** → `11efe422` — picks up the PRSection `prCommitFileCache` typing follow-up ([cloudlands-fe#224](https://github.com/intent-hq/cloudlands-fe/pull/224)), closing the last review thread from [cloudlands-fe#222](https://github.com/intent-hq/cloudlands-fe/pull/222).
- **packages/intentd** — already at `e08a1892` on main (no gitlink change needed); includes the workspace.list enrichment offload ([intentd#314](https://github.com/intent-hq/intentd/pull/314)).

## Docs
- `docs/01_stabilizing/KNOWN_ISSUES.md`: adds **STAB-165** — workspace.list times out on large worktrees or many workspaces — marked fixed by [intentd#314](https://github.com/intent-hq/intentd/pull/314).

## Related PRs (Changes-tab / workspace.list performance effort)
- intentd: [#286](https://github.com/intent-hq/intentd/pull/286), [#288](https://github.com/intent-hq/intentd/pull/288), [#292](https://github.com/intent-hq/intentd/pull/292), [#303](https://github.com/intent-hq/intentd/pull/303), [#310](https://github.com/intent-hq/intentd/pull/310), [#314](https://github.com/intent-hq/intentd/pull/314)
- cloudlands-fe: [#214](https://github.com/intent-hq/cloudlands-fe/pull/214), [#218](https://github.com/intent-hq/cloudlands-fe/pull/218), [#222](https://github.com/intent-hq/cloudlands-fe/pull/222), [#224](https://github.com/intent-hq/cloudlands-fe/pull/224)
- monorepo docs: [#355](https://github.com/intent-hq/monorepo/pull/355), [#367](https://github.com/intent-hq/monorepo/pull/367)

## Verification
- `make check` (cargo fmt --check + clippy -D warnings + build) — pass
- `make test` — pass

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author