### PR TITLE
chore: bump cloudlands-fe for CPU/memory status feature and document system.status fields

### DIFF
--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -361,14 +361,15 @@ The `system.status` result includes two **optional** self-process resource field
 ```jsonc
 {
   "cpuPercent": 12.5,        // optional — daemon process CPU usage
-  "memoryBytes": 104857600,  // optional — daemon process resident set size (RSS), in bytes
-  ...
+  "memoryBytes": 104857600   // optional — daemon process resident set size (RSS), in bytes
+  // ...existing status fields (running, listenMode, transports, port, ...)
 }
 ```
 
 - **`cpuPercent`** uses the raw `sysinfo` convention: `100` = one full core, so values **may exceed 100** on multicore systems (not normalized to total capacity). The first sample after daemon startup **may read `0`** before a usage baseline is established.
 - **`memoryBytes`** is the daemon process RSS in bytes.
 - Both fields are **additive and optional**; clients must tolerate their absence and degrade gracefully.
+- **Versioning:** these fields shipped within protocol **v2.0** — the daemon still advertises `protocolVersion: "2.0"`. They add optional response fields to an existing method without changing the method surface (the golden-test-enforced catalog is unchanged), so no version bump was made; clients must detect them by **presence**, not by protocol version.
 
 #### `pairing.getInfo` (local-only)
 

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -354,6 +354,22 @@ browser.exec, client.hello, drafts.clear, drafts.get, drafts.set, events.subscri
 
 **UDS-only method:** `system.shutdown` is only available on the Unix-domain socket transport. `system.status` is available on both UDS and WSS transports.
 
+#### `system.status` — process resource fields (additive, optional)
+
+The `system.status` result includes two **optional** self-process resource fields alongside the existing status payload (`running`, `listenMode`, `transports`, `port`, `clients`, `agents`, `maxAgents`, `version`, `uptimeSeconds`, `fingerprint`, `protocolVersion`, `host`):
+
+```jsonc
+{
+  "cpuPercent": 12.5,        // optional — daemon process CPU usage
+  "memoryBytes": 104857600,  // optional — daemon process resident set size (RSS), in bytes
+  ...
+}
+```
+
+- **`cpuPercent`** uses the raw `sysinfo` convention: `100` = one full core, so values **may exceed 100** on multicore systems (not normalized to total capacity). The first sample after daemon startup **may read `0`** before a usage baseline is established.
+- **`memoryBytes`** is the daemon process RSS in bytes.
+- Both fields are **additive and optional**; clients must tolerate their absence and degrade gracefully.
+
 #### `pairing.getInfo` (local-only)
 
 Returns the structured QR pairing payload so local clients (the `intentd pair` CLI, desktop GUI) can render a QR code for LAN pairing.


### PR DESCRIPTION
Finishes the two-phase workflow for the CPU/memory status feature.

## Submodule PRs

- intent-hq/intentd#321 — `system.status` now reports `cpuPercent` and `memoryBytes` (merged as `3a6f2f5`). **Note:** the intentd gitlink is unchanged in this PR — monorepo main already points at `df55a9d` (via the #322 revert bump), which contains `3a6f2f5`.
- intent-hq/cloudlands-fe#227 — status dropdown CPU/Memory rows with 1s poll while the dropdown is open, optional fields tolerated for graceful degradation (merged as `8cdf5582`). This PR bumps the cloudlands-fe gitlink to that commit.

## Docs

`docs/PROTOCOL.md` documents the new optional `system.status` fields (requested by the FE PR reviewer):

- `cpuPercent` — raw `sysinfo` convention: `100` = one full core, may exceed 100 on multicore (not normalized); first sample after daemon startup may read `0`.
- `memoryBytes` — daemon process RSS in bytes.
- Both fields are additive/optional; clients must degrade gracefully when absent.

The frozen docs under `docs/00_initial_porting/` are untouched.

## Verification

- `make check` and `make test` green at the monorepo root against the bumped submodules.
- `git submodule status`: intentd on main (`df55a9d`, contains `3a6f2f5`), cloudlands-fe on main (`8cdf5582`).
