### PR TITLE
fix: restore submodule init in workspace setupScript

### DIFF
--- a/.intent/config.json
+++ b/.intent/config.json
@@ -1,5 +1,5 @@
 {
-  "setupScript": "#!/bin/bash\n# Generic setup script\n# Available variables: $MAIN_CHECKOUT, $WORKTREE_PATH, $BRANCH_NAME, $SOURCE_BRANCH\n\n# Copy environment and config files\nfor file in .env .env.local .envrc .tool-versions; do\n  if [ -f \"$MAIN_CHECKOUT/$file\" ]; then\n    cp \"$MAIN_CHECKOUT/$file\" \"./$file\"\n    echo \"Copied $file\"\n  fi\ndone\n\necho \"Config files copied\"",
+  "setupScript": "#!/bin/bash\n# Generic setup script\n# Available variables: $MAIN_CHECKOUT, $WORKTREE_PATH, $BRANCH_NAME, $SOURCE_BRANCH\n\n# Copy environment and config files\nfor file in .env .env.local .envrc .tool-versions; do\n  if [ -f \"$MAIN_CHECKOUT/$file\" ]; then\n    cp \"$MAIN_CHECKOUT/$file\" \"./$file\"\n    echo \"Copied $file\"\n  fi\ndone\n\necho \"Config files copied\"\n\n# Initialize git submodules\necho \"Initializing submodules\"\ngit submodule update --init --recursive",
   "scripts": [
     {
       "name": "all",


### PR DESCRIPTION
## Summary

Re-adds the submodule-initialization tail to the `setupScript` value in `.intent/config.json`, restoring it to the state introduced by PR #340 (commit b14f927).

The tail was accidentally dropped by commit c5974561, which reverted the `setupScript` to a version without the `git submodule update --init --recursive` step. Without it, new worktrees are created with uninitialized submodules.

## Changes

- `.intent/config.json`: appended the submodule init block (`echo "Initializing submodules"` + `git submodule update --init --recursive`) back to `setupScript`.

## Verification

- `git diff b14f927 -- .intent/config.json` is empty (file matches the PR #340 state exactly)
- `python3 -c "import json; json.load(open('.intent/config.json'))"` exits 0 (valid JSON)

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author