### PR TITLE
fix: bump cloudlands-fe for onboarding repo-config setup script detection (STAB-172)

### DIFF
--- a/docs/01_stabilizing/KNOWN_ISSUES.md
+++ b/docs/01_stabilizing/KNOWN_ISSUES.md
@@ -2,7 +2,7 @@
 
 Live issue tracker for the **01_stabilizing** self-hosting phase.
 
-**Next available ID:** STAB-171 (as of 2026-07-22)
+**Next available ID:** STAB-173 (as of 2026-07-22)
 
 ## Intake Convention
 
@@ -18,6 +18,16 @@ Each issue entry includes:
 ---
 
 ## Fixed Issues
+
+### STAB-172 (2026-07-22, area: cloudlands-fe onboarding / setup scripts, severity: P2)
+
+The onboarding flow's Setup Script dialog did not detect the repo-committed `.intent/config.json` setupScript, unlike the New Workspace dialog — first-run users never saw the "From repo config" entry and got the generic template instead.
+
+**Repro:** On a fresh install, go through onboarding and select a local project whose repo has a committed `.intent/config.json` with a `setupScript`. The Setup Script dialog showed no "From repo config" entry and did not pre-fill the repo's script, while the New Workspace dialog (`CompactWorkspaceInitializer.svelte`) for the same repo detected and pre-filled it.
+
+**Status:** fixed ([intent-hq/cloudlands-fe#235](https://github.com/intent-hq/cloudlands-fe/pull/235), 2026-07-22) — onboarding now probes the selected local repo via `fetchRepoConfigSetupScript` and applies `chooseDefaultSetupScript` with the same priority as the workspace dialog (repo config > last-used script > generic template), forwards the repo-config script to `SetupScriptModal` so "From repo config" renders, discards stale probe results on repo switch, and skips re-saving an unedited repo-config script to the saved-scripts store.
+
+---
 
 ### STAB-170 (2026-07-22, area: intentd/model-discovery, severity: P1)
 

--- a/docs/01_stabilizing/KNOWN_ISSUES.md
+++ b/docs/01_stabilizing/KNOWN_ISSUES.md
@@ -2,7 +2,7 @@
 
 Live issue tracker for the **01_stabilizing** self-hosting phase.
 
-**Next available ID:** STAB-173 (as of 2026-07-22)
+**Next available ID:** STAB-173 (as of 2026-07-22; STAB-171 is reserved by other in-flight work and will be filed separately)
 
 ## Intake Convention
 
@@ -21,7 +21,7 @@ Each issue entry includes:
 
 ### STAB-172 (2026-07-22, area: cloudlands-fe onboarding / setup scripts, severity: P2)
 
-The onboarding flow's Setup Script dialog did not detect the repo-committed `.intent/config.json` setupScript, unlike the New Workspace dialog — first-run users never saw the "From repo config" entry and got the generic template instead.
+The onboarding flow's Setup Script dialog did not detect the repo-committed `.intent/config.json` `setupScript`, unlike the New Workspace dialog — first-run users never saw the "From repo config" entry and got the generic template instead.
 
 **Repro:** On a fresh install, go through onboarding and select a local project whose repo has a committed `.intent/config.json` with a `setupScript`. The Setup Script dialog showed no "From repo config" entry and did not pre-fill the repo's script, while the New Workspace dialog (`CompactWorkspaceInitializer.svelte`) for the same repo detected and pre-filled it.
 


### PR DESCRIPTION
## Summary

Bumps the `packages/cloudlands-fe` submodule to the latest `main` HEAD (`19c85bd5`), which contains intent-hq/cloudlands-fe#235 — porting repo-config setup script detection from the New Workspace dialog to the onboarding flow.

## Changes

- **`packages/cloudlands-fe`** — gitlink `9d3ab1fe` → `19c85bd5` (current `origin/main` HEAD).
- **`docs/01_stabilizing/KNOWN_ISSUES.md`** — files **STAB-172** (area: cloudlands-fe onboarding / setup scripts, severity P2): the onboarding flow's Setup Script dialog did not detect the repo-committed `.intent/config.json` setupScript ("From repo config"), unlike the New Workspace dialog. Marked fixed via [intent-hq/cloudlands-fe#235](https://github.com/intent-hq/cloudlands-fe/pull/235) (2026-07-22). Next available ID advanced to STAB-173 (STAB-171 is reserved by other in-flight work).

## Verification

- `git -C packages/cloudlands-fe rev-parse origin/main` == `19c85bd56b5c1a285a135330518933554ec1f448` == checked-out submodule HEAD.
- Docs + gitlink change only; no Rust changes.
