### PR TITLE
fix: dismiss only the topmost overlay on Escape (STAB-171); bump cloudlands-fe

### DIFF
--- a/docs/01_stabilizing/KNOWN_ISSUES.md
+++ b/docs/01_stabilizing/KNOWN_ISSUES.md
@@ -2,7 +2,7 @@
 
 Live issue tracker for the **01_stabilizing** self-hosting phase.
 
-**Next available ID:** STAB-173 (as of 2026-07-22; STAB-171 is reserved by other in-flight work and will be filed separately)
+**Next available ID:** STAB-173 (as of 2026-07-22)
 
 ## Intake Convention
 
@@ -18,6 +18,16 @@ Each issue entry includes:
 ---
 
 ## Fixed Issues
+
+### STAB-171 (2026-07-22, area: cloudlands-fe overlays/keyboard, severity: P2)
+
+Pressing Escape with the image lightbox open on top of the New Workspace dialog closed the dialog instead of the lightbox.
+
+**Repro:** Open the New Workspace dialog, attach an image, open the lightbox, press Escape. Observed: the dialog closed instead of the lightbox. Root cause: both overlays registered window capture-phase Escape `keydown` listeners; for listeners on the same target and phase, dispatch order is registration order, so the modal's older listener won.
+
+**Status:** fixed ([intent-hq/cloudlands-fe#234](https://github.com/intent-hq/cloudlands-fe/pull/234), 2026-07-22) — introduced an escape-layer stack (`src/lib/utils/escapeLayers.ts`): overlays register a layer while open and a single shared capture-phase listener dispatches Escape only to the topmost layer (calling `stopImmediatePropagation()` to suppress unmigrated same-target listeners); `NewSpaceModal` and `ImageLightbox` migrated, with unit + regression tests. Follow-up: `Modal.svelte` still has its own legacy capture-phase Escape listener and should be migrated to the layer stack.
+
+---
 
 ### STAB-172 (2026-07-22, area: cloudlands-fe onboarding / setup scripts, severity: P2)
 


### PR DESCRIPTION
## Summary

Bumps `packages/cloudlands-fe` to latest main (`e693220d`), which lands the Escape-layer fix from intent-hq/cloudlands-fe#234, and files the bug as **STAB-171** in `docs/01_stabilizing/KNOWN_ISSUES.md` (marked fixed).

**Bug (STAB-171, P2, cloudlands-fe overlays/keyboard):** pressing Escape with the image lightbox open on top of the New Workspace dialog closed the dialog instead of the lightbox. Both overlays registered window capture-phase Escape listeners; same-target listeners fire in registration order, so the modal's older listener won.

**Fix:** escape-layer stack — a single shared capture-phase listener dispatches Escape only to the topmost registered overlay layer.

## Changes

- `packages/cloudlands-fe` gitlink → `e693220d` (merge of intent-hq/cloudlands-fe#234)
- `docs/01_stabilizing/KNOWN_ISSUES.md` — STAB-171 entry (status: fixed), noted `Modal.svelte` legacy-listener migration as a follow-up

## References

- Submodule PR: intent-hq/cloudlands-fe#234
