### PR TITLE
fix: update cloudlands-fe submodule for specialist picker specialistId fix

### DIFF
--- a/.intent/config.json
+++ b/.intent/config.json
@@ -1,5 +1,5 @@
 {
-  "setupScript": "#!/bin/bash\n# Generic setup script\n# Available variables: $MAIN_CHECKOUT, $WORKTREE_PATH, $BRANCH_NAME, $SOURCE_BRANCH\n\n# Copy environment and config files\nfor file in .env .env.local .envrc .tool-versions; do\n  if [ -f \"$MAIN_CHECKOUT/$file\" ]; then\n    cp \"$MAIN_CHECKOUT/$file\" \"./$file\"\n    echo \"Copied $file\"\n  fi\ndone\n\necho \"Config files copied\"\n\n# Initialize git submodules\necho \"Initializing submodules\"\ngit submodule update --init --recursive",
+  "setupScript": "#!/bin/bash\n# Generic setup script\n# Available variables: $MAIN_CHECKOUT, $WORKTREE_PATH, $BRANCH_NAME, $SOURCE_BRANCH\n\n# Copy environment and config files\nfor file in .env .env.local .envrc .tool-versions; do\n  if [ -f \"$MAIN_CHECKOUT/$file\" ]; then\n    cp \"$MAIN_CHECKOUT/$file\" \"./$file\"\n    echo \"Copied $file\"\n  fi\ndone\n\necho \"Config files copied\"",
   "scripts": [
     {
       "name": "all",

--- a/.intent/config.json
+++ b/.intent/config.json
@@ -1,5 +1,5 @@
 {
-  "setupScript": "#!/bin/bash\n# Generic setup script\n# Available variables: $MAIN_CHECKOUT, $WORKTREE_PATH, $BRANCH_NAME, $SOURCE_BRANCH\n\n# Copy environment and config files\nfor file in .env .env.local .envrc .tool-versions; do\n  if [ -f \"$MAIN_CHECKOUT/$file\" ]; then\n    cp \"$MAIN_CHECKOUT/$file\" \"./$file\"\n    echo \"Copied $file\"\n  fi\ndone\n\necho \"Config files copied\"",
+  "setupScript": "#!/bin/bash\n# Generic setup script\n# Available variables: $MAIN_CHECKOUT, $WORKTREE_PATH, $BRANCH_NAME, $SOURCE_BRANCH\n\n# Copy environment and config files\nfor file in .env .env.local .envrc .tool-versions; do\n  if [ -f \"$MAIN_CHECKOUT/$file\" ]; then\n    cp \"$MAIN_CHECKOUT/$file\" \"./$file\"\n    echo \"Copied $file\"\n  fi\ndone\n\necho \"Config files copied\"\n\n# Initialize required submodules (idempotent; Rust-workflow only)\nmake ensure-submodules",
   "scripts": [
     {
       "name": "all",

--- a/docs/01_stabilizing/KNOWN_ISSUES.md
+++ b/docs/01_stabilizing/KNOWN_ISSUES.md
@@ -2,7 +2,7 @@
 
 Live issue tracker for the **01_stabilizing** self-hosting phase.
 
-**Next available ID:** STAB-173 (as of 2026-07-22)
+**Next available ID:** STAB-174 (as of 2026-07-22)
 
 ## Intake Convention
 
@@ -19,6 +19,18 @@ Each issue entry includes:
 
 ## Fixed Issues
 
+### STAB-173 (2026-07-22, area: cloudlands-fe agent creation / specialist picker, severity: P1)
+
+Creating an agent from the + tab specialist picker (e.g. "PR Shepherd") produced a session whose specialist never persisted — the chat header/welcome fell back to "General" after the daemon-canonical refetch, even though the tab name was correct.
+
+**Repro:** Click the + tab, pick a specialist (e.g. PR Shepherd), and create the agent. Observed: the optimistic session initially shows the specialist, but once the canonical `AgentLite` refetch replaces it, the chat welcome shows "General" — the daemon persisted the session with no specialist.
+
+**Root cause:** The picker path only carried the specialist inside `agent.create` `metadata` (`handleCreateAgentWithSpecialist` → `metadata: { specialist }`), and `agent-factory.ts#createInBackend` never set the request's top-level `specialist` field — so `LiveAgentsClient` never emitted the wire `specialistId` param. Per PROTOCOL §5.5, the daemon reads `specialistId` from top-level params only; `metadata.specialist` is not harvested.
+
+**Status:** fixed ([intent-hq/cloudlands-fe#239](https://github.com/intent-hq/cloudlands-fe/pull/239), 2026-07-22) — `createInBackend` lifts `agent.metadata?.specialist` onto `AgentCreateRequest.specialist`, which `LiveAgentsClient` maps to wire `specialistId` (omitted when absent, so the no-specialist path is unchanged); also covers `handleRunAgentForNote`. Regression tests upgraded to the wire-level `MockBackendTransport` fixture, asserting `agent.create` params include `specialistId` when a specialist is chosen and omit it when not.
+
+---
+
 ### STAB-171 (2026-07-22, area: cloudlands-fe overlays/keyboard, severity: P2)
 
 Pressing Escape with the image lightbox open on top of the New Workspace dialog closed the dialog instead of the lightbox.
@@ -26,7 +38,6 @@ Pressing Escape with the image lightbox open on top of the New Workspace dialog 
 **Repro:** Open the New Workspace dialog, attach an image, open the lightbox, press Escape. Observed: the dialog closed instead of the lightbox. Root cause: both overlays registered window capture-phase Escape `keydown` listeners; for listeners on the same target and phase, dispatch order is registration order, so the modal's older listener won.
 
 **Status:** fixed ([intent-hq/cloudlands-fe#234](https://github.com/intent-hq/cloudlands-fe/pull/234), 2026-07-22) — introduced an escape-layer stack (`src/lib/utils/escapeLayers.ts`): overlays register a layer while open and a single shared capture-phase listener dispatches Escape only to the topmost layer (calling `stopImmediatePropagation()` to suppress unmigrated same-target listeners); `NewSpaceModal` and `ImageLightbox` migrated, with unit + regression tests. Follow-up: `Modal.svelte` still has its own legacy capture-phase Escape listener and should be migrated to the layer stack.
-
 ---
 
 ### STAB-172 (2026-07-22, area: cloudlands-fe onboarding / setup scripts, severity: P2)


### PR DESCRIPTION
Bumps `packages/cloudlands-fe` to `79d4188e` — [intent-hq/cloudlands-fe#239](https://github.com/intent-hq/cloudlands-fe/pull/239): fix: send top-level `specialistId` on `agent.create` from the specialist picker path.

## Summary

Creating an agent from the + tab specialist picker produced a session whose specialist never persisted — the FE only carried the specialist inside `agent.create` `metadata`, which the daemon does not harvest (PROTOCOL §5.5 reads top-level `specialistId` only). The chat welcome fell back to "General" after the daemon-canonical refetch.

The submodule fix lifts `agent.metadata?.specialist` onto `AgentCreateRequest.specialist` in `agent-factory.ts#createInBackend`; `LiveAgentsClient` already maps it to wire `specialistId` and omits it when absent. Wire-level regression tests (MockBackendTransport) assert `specialistId` is included when a specialist is chosen and omitted when not.

## Included in this PR

- Submodule bump `packages/cloudlands-fe` → `79d4188e` (PR #239, merged with all CI green + verifier approval)
- `docs/01_stabilizing/KNOWN_ISSUES.md`: files **STAB-173** as fixed with the PR link (next available ID advanced to STAB-174)
- Ride-along from this workspace branch: `chore: set default workspace to monorepo in config` (`.intent/config.json` setup-script tweak, committed by a sibling agent)
