### PR TITLE
docs: file STAB-176 (interrupted partial-turn wipe) and document the interrupt flush convention

### DIFF
--- a/docs/01_stabilizing/KNOWN_ISSUES.md
+++ b/docs/01_stabilizing/KNOWN_ISSUES.md
@@ -2,7 +2,7 @@
 
 Live issue tracker for the **01_stabilizing** self-hosting phase.
 
-**Next available ID:** STAB-176 (as of 2026-07-22)
+**Next available ID:** STAB-177 (as of 2026-07-22)
 
 ## Intake Convention
 
@@ -18,6 +18,16 @@ Each issue entry includes:
 ---
 
 ## Fixed Issues
+
+### STAB-176 (2026-07-22, area: agent streaming / chat.subscribe, severity: P1)
+
+Interrupting a streaming agent (Stop button or ⌘Enter interrupt send) immediately hid all in-flight deltas — the partial assistant output vanished from the chat.
+
+**Repro:** While an agent is streaming a turn, interrupt it via Stop or ⌘Enter. Observed: every streamed-so-far block disappears the moment the interrupt lands. Root cause: the daemon aborted the turn worker without flushing the live-turn slot, so no partial assistant row was persisted; the `chat.subscribe` terminal reconcile after `agent:stream:end` re-read a transcript without the streamed message and wiped the live blocks via `removedIds`.
+
+**Status:** fixed ([intent-hq/intentd#336](https://github.com/intent-hq/intentd/pull/336), [intent-hq/cloudlands-fe#242](https://github.com/intent-hq/cloudlands-fe/pull/242), [intent-hq/cloudlands-fe#243](https://github.com/intent-hq/cloudlands-fe/pull/243), 2026-07-22) — intentd#336 snapshots the live-turn slot before aborting the turn worker and flushes the partial assistant message under the turn's minted `messageId` with `metadata.interrupted = true` + `metadata.stopReason = "interrupted"` **before** emitting `agent:stream:end` (same convention as the graceful-shutdown flush; no-op for empty partials), so the terminal reconcile keeps the streamed blocks instead of erasing them. cloudlands-fe#242/#243 add regression tests: interrupted deltas stay visible with the Stopped indicator, and stop-button state dispatches don't erase the in-flight partial. The convention is documented in `docs/PROTOCOL.md` §7.5.
+
+---
 
 ### STAB-175 (2026-07-22, area: cloudlands-fe overlays/keyboard, severity: P2)
 

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -687,14 +687,14 @@ Event types follow the pattern `<category>:<action>`. Common categories:
 
 ### 7.5 Interrupted Partial-Turn Persistence
 
-On a **user interrupt** of an in-flight turn — `agent.stop`, `agent.forceMessage`, or `agent.sendMessage` / `agent.sendToTask` with `priority: "interrupt"` — the daemon persists the streamed-so-far partial assistant message **before** emitting the terminal `agent:stream:end`. The partial turn's content blocks are written to the transcript under the assistant `messageId` minted at turn start (the same id carried by the live `agent:stream:chunk` events, and from which the `chat.subscribe` synthetic block ids are derived as `{messageId}:{blockIndex}` — §7.1 of the porting-era protocol), tagged on the message row with:
+On a **user interrupt** of an in-flight turn — `agent.stop`, `agent.forceMessage`, or `agent.sendMessage` / `agent.sendToTask` called with the request parameter `priority: "interrupt"` — the daemon persists the streamed-so-far partial assistant message **before** emitting the terminal `agent:stream:end`. The partial turn's content blocks are written to the transcript under the assistant `messageId` minted at turn start (the same id carried by the live `agent:stream:chunk` events, and from which the `chat.subscribe` synthetic block ids are derived as `{messageId}:{blockIndex}` — see `docs/00_initial_porting/PROTOCOL.md` §7.1), tagged on the message row with:
 
 - `metadata.interrupted: true`
 - `metadata.stopReason: "interrupted"`
 
 This is the same convention as the graceful-shutdown flush of an in-flight turn. The flush is a no-op when the partial has no content blocks (nothing streamed yet).
 
-**Consequence for `chat.subscribe` (the terminal reconcile of §7.1 in the porting-era protocol, `docs/00_initial_porting/PROTOCOL.md`):** because the partial assistant row is persisted before `agent:stream:end`, the channel's terminal reconcile re-reads a transcript that **contains** the streamed message — the streamed blocks are re-emitted as authoritative `updated` entries and are **not** wiped via `removedIds`. Clients keep the partial output visible and may render an interrupted/"Stopped" indicator from `metadata.interrupted` / `metadata.stopReason` on the persisted row (also visible via `agent.getConversation`). On an interrupt-priority send, the interrupted partial row precedes the new user message in the transcript.
+**Consequence for `chat.subscribe` (the terminal reconcile of `docs/00_initial_porting/PROTOCOL.md` §7.1):** because the partial assistant row is persisted before `agent:stream:end`, the channel's terminal reconcile re-reads a transcript that **contains** the streamed message — the streamed blocks are re-emitted as authoritative `updated` entries and are **not** wiped via `removedIds`. Clients keep the partial output visible and may render an interrupted/"Stopped" indicator from `metadata.interrupted` / `metadata.stopReason` on the persisted row (also visible via `agent.getConversation`). On an interrupt-priority send, the interrupted partial row precedes the new user message in the transcript.
 
 Added in [intent-hq/intentd#336](https://github.com/intent-hq/intentd/pull/336); no method-surface change (additive persistence semantics within protocol v2.0).
 

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -685,6 +685,19 @@ Event types follow the pattern `<category>:<action>`. Common categories:
 - **`goal:*`** — goal tracking events
 - **`github:*`** — GitHub auth surface: `github:auth-changed` carries `data = { status: "authorized" | "expired" | "denied" | "error" | "revoked" }` on device-flow terminal transitions and `github.revoke`; global (empty `workspaceId`), never carries a token or code
 
+### 7.5 Interrupted Partial-Turn Persistence
+
+On a **user interrupt** of an in-flight turn — `agent.stop`, `agent.forceMessage`, or `agent.sendMessage` / `agent.sendToTask` with `priority: "interrupt"` — the daemon persists the streamed-so-far partial assistant message **before** emitting the terminal `agent:stream:end`. The partial turn's content blocks are written to the transcript under the assistant `messageId` minted at turn start (the same id carried by the live `agent:stream:chunk` events, and from which the `chat.subscribe` synthetic block ids are derived as `{messageId}:{blockIndex}` — §7.1 of the porting-era protocol), tagged on the message row with:
+
+- `metadata.interrupted: true`
+- `metadata.stopReason: "interrupted"`
+
+This is the same convention as the graceful-shutdown flush of an in-flight turn. The flush is a no-op when the partial has no content blocks (nothing streamed yet).
+
+**Consequence for `chat.subscribe` (the terminal reconcile of §7.1 in the porting-era protocol, `docs/00_initial_porting/PROTOCOL.md`):** because the partial assistant row is persisted before `agent:stream:end`, the channel's terminal reconcile re-reads a transcript that **contains** the streamed message — the streamed blocks are re-emitted as authoritative `updated` entries and are **not** wiped via `removedIds`. Clients keep the partial output visible and may render an interrupted/"Stopped" indicator from `metadata.interrupted` / `metadata.stopReason` on the persisted row (also visible via `agent.getConversation`). On an interrupt-priority send, the interrupted partial row precedes the new user message in the transcript.
+
+Added in [intent-hq/intentd#336](https://github.com/intent-hq/intentd/pull/336); no method-surface change (additive persistence semantics within protocol v2.0).
+
 ---
 
 ## 8. Error Codes


### PR DESCRIPTION
Closes out the interrupted-stream wipe bug: interrupting a streaming agent (Stop or ⌘Enter) immediately hid all in-flight deltas because the daemon never persisted the partial assistant message, so the `chat.subscribe` terminal reconcile wiped the streamed blocks via `removedIds`.

**Now docs-only after rebase:** the submodule state this PR originally carried has already landed on main — `packages/intentd` at `3b88ba9` contains the daemon fix [intent-hq/intentd#336](https://github.com/intent-hq/intentd/pull/336) (`72e12b9`, via #435/#436), and `packages/cloudlands-fe` at `10b0990f` contains the regression tests [intent-hq/cloudlands-fe#242](https://github.com/intent-hq/cloudlands-fe/pull/242)/[#243](https://github.com/intent-hq/cloudlands-fe/pull/243) (via #442). The issue entry was renumbered STAB-175 → **STAB-176** because #442 claimed STAB-175 for the RepoSelector Escape bug while this PR was in review.

## Changes

- **`docs/01_stabilizing/KNOWN_ISSUES.md`**: files **STAB-176** (2026-07-22, area: agent streaming / chat.subscribe, P1) as fixed, linking intentd#336 and cloudlands-fe#242/#243; bumps the next-available ID to STAB-177.
- **`docs/PROTOCOL.md`**: new **§7.5 Interrupted Partial-Turn Persistence** documenting the convention flagged in the cloudlands-fe#242 review — on user interrupt the daemon persists the partial assistant message under the minted `messageId` with `metadata.interrupted = true` + `metadata.stopReason = "interrupted"` **before** emitting `agent:stream:end`, so the `chat.subscribe` terminal reconcile keeps streamed blocks (no `removedIds` wipe). Additive semantics only; no method-surface change.

## Review

- Verifier review passed (evidence-checked against intentd `72e12b9`); its one deviation (stale gitlink) is now moot post-rebase.
- Both Copilot inline comments addressed (grammar nit; block-id derivation wording).

## Verification

- `make check` — pass (fmt, clippy `-D warnings`, build)
- `make test` — pass (full `cargo test` in `packages/intentd`)
- Post-rebase the diff is docs-only; `packages/intentd` is byte-identical to main, so the gates are unaffected.
