### PR TITLE
fix: comment.add tolerant anchoring + actionable errors (intentd bump)

### DIFF
--- a/.intent/config.json
+++ b/.intent/config.json
@@ -1,5 +1,5 @@
 {
-  "setupScript": "#!/bin/bash\n# Generic setup script\n# Available variables: $MAIN_CHECKOUT, $WORKTREE_PATH, $BRANCH_NAME, $SOURCE_BRANCH\n\n# Copy environment and config files\nfor file in .env .env.local .envrc .tool-versions; do\n  if [ -f \"$MAIN_CHECKOUT/$file\" ]; then\n    cp \"$MAIN_CHECKOUT/$file\" \"./$file\"\n    echo \"Copied $file\"\n  fi\ndone\n\necho \"Config files copied\"\n\n# Initialize required submodules (idempotent; Rust-workflow only)\nmake ensure-submodules",
+  "setupScript": "#!/bin/bash\n# Generic setup script\n# Available variables: $MAIN_CHECKOUT, $WORKTREE_PATH, $BRANCH_NAME, $SOURCE_BRANCH\n\n# Copy environment and config files\nfor file in .env .env.local .envrc .tool-versions; do\n  if [ -f \"$MAIN_CHECKOUT/$file\" ]; then\n    cp \"$MAIN_CHECKOUT/$file\" \"./$file\"\n    echo \"Copied $file\"\n  fi\ndone\n\necho \"Config files copied\"",
   "scripts": [
     {
       "name": "all",

--- a/.intent/config.json
+++ b/.intent/config.json
@@ -1,5 +1,5 @@
 {
-  "setupScript": "#!/bin/bash\n# Generic setup script\n# Available variables: $MAIN_CHECKOUT, $WORKTREE_PATH, $BRANCH_NAME, $SOURCE_BRANCH\n\n# Copy environment and config files\nfor file in .env .env.local .envrc .tool-versions; do\n  if [ -f \"$MAIN_CHECKOUT/$file\" ]; then\n    cp \"$MAIN_CHECKOUT/$file\" \"./$file\"\n    echo \"Copied $file\"\n  fi\ndone\n\necho \"Config files copied\"",
+  "setupScript": "#!/bin/bash\n# Generic setup script\n# Available variables: $MAIN_CHECKOUT, $WORKTREE_PATH, $BRANCH_NAME, $SOURCE_BRANCH\n\n# Copy environment and config files\nfor file in .env .env.local .envrc .tool-versions; do\n  if [ -f \"$MAIN_CHECKOUT/$file\" ]; then\n    cp \"$MAIN_CHECKOUT/$file\" \"./$file\"\n    echo \"Copied $file\"\n  fi\ndone\n\necho \"Config files copied\"\n\n# Initialize required submodules (idempotent; Rust-workflow only)\nmake ensure-submodules",
   "scripts": [
     {
       "name": "all",

--- a/docs/00_initial_porting/PROTOCOL.md
+++ b/docs/00_initial_porting/PROTOCOL.md
@@ -566,7 +566,7 @@ each recompute so the read path is O(1) and survives restart. `note.delete` casc
 
 | Method | Params | Result |
 | --- | --- | --- |
-| comment.add | noteId (req), searchContext (req), commentTarget (req), comment (req), type?, author?, idempotencyKey? | { ok, ... } (anchors by text search). A replay with the same `(workspaceId, idempotencyKey)` returns the stored result without re-executing (no duplicate comment, no second `comment:added`); empty/whitespace-only keys are treated as absent. |
+| comment.add | noteId (req), searchContext (req), commentTarget (req), comment (req), type?, author?, authorType? ("user" \| "agent", default "agent"), idempotencyKey? | { ok, ... } (anchors by text search). A replay with the same `(workspaceId, idempotencyKey)` returns the stored result without re-executing (no duplicate comment, no second `comment:added`); empty/whitespace-only keys are treated as absent. |
 | comment.list | noteId (req), since?, authorType?, status?, includeComments? | { threads: [...] } |
 | comment.getThread | noteId (req), threadId? or commentId? | { thread } |
 | comment.respond | noteId (req), comment (req), threadId?/commentId?, type?, author?, suggestionOriginal?, suggestionProposed? | { ok, ... } |
@@ -586,6 +586,23 @@ markers scrubbed from the persisted content and the comment is flipped to
 `isOrphaned: true`. Comments in the wire `Comment` shape carry an optional
 `isOrphaned: bool` field (omitted when unset, `true` for orphaned comments,
 `false` explicitly when a previously-orphaned comment heals).
+
+**Tolerant anchoring + actionable errors.** `comment.add` first attempts an
+exact substring match of `searchContext` against the note markdown. When no
+exact occurrence exists, it retries against a *plaintext projection* of the
+markdown (heading/list/blockquote markers, emphasis/code delimiters, link
+syntax — keeping link text — HTML comments including existing anchor markers,
+and all whitespace stripped, with a byte map back to the source), so anchors
+derived from an editor's rendered plain text (e.g. tiptap `textBetween`, which
+joins blocks with no separator) anchor correctly onto the formatted source.
+Uniqueness rules are identical on both paths: an ambiguous `searchContext` or
+`commentTarget` is rejected. All anchoring failures (context not found /
+ambiguous, target not in context / ambiguous) and the empty-field validations
+(`comment`, `searchContext`, `commentTarget`, invalid `authorType`) return
+`-32602` with a descriptive message, **not** `-32603 "Internal error"`. The
+optional `authorType` param sets the persisted comment's `authorType`
+(defaulting `author` to `"User"` / `"Agent"` accordingly when absent);
+omitting it keeps the backward-compatible `agent` default.
 
 **`comment.*` extensions (new in intentd — additive; do not change the ported count of 5).** One additional method addresses an entire thread by `threadId` **or** `commentId`. Emits the `comment:resolved` event (§6.5).
 


### PR DESCRIPTION
# Summary

Bumps `packages/intentd` to latest main, picking up [intent-hq/intentd#341](https://github.com/intent-hq/intentd/pull/341): tolerant `comment.add` anchoring for plain-text-derived anchors, actionable `-32602` anchoring errors (instead of opaque `-32603 "Internal error"`), a `tracing::warn!` on failure, and the new optional `authorType` param.

Also updates `docs/00_initial_porting/PROTOCOL.md` §5.3:

- `comment.add` params row gains `authorType?` (`"user"` | `"agent"`, default `"agent"`).
- New "Tolerant anchoring + actionable errors" note documenting the plaintext-projection fallback, the preserved uniqueness rules, and the `-32602` error behavior.

## Verification

In `packages/intentd` at the bumped commit: `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test` all green; intentd PR CI (check, coverage-all, coverage-e2e, CodeQL) passed before squash-merge.
