### PR TITLE
fix: treat provider-prefixed *:default model ids as explicit selections (cloudlands-fe bump, STAB-181)

### DIFF
--- a/docs/01_stabilizing/KNOWN_ISSUES.md
+++ b/docs/01_stabilizing/KNOWN_ISSUES.md
@@ -2,7 +2,7 @@
 
 Live issue tracker for the **01_stabilizing** self-hosting phase.
 
-**Next available ID:** STAB-181 (as of 2026-07-22)
+**Next available ID:** STAB-182 (as of 2026-07-22)
 
 ## Intake Convention
 
@@ -18,6 +18,20 @@ Each issue entry includes:
 ---
 
 ## Fixed Issues
+
+### STAB-181 (2026-07-22, area: cloudlands-fe model picker, severity: P2)
+
+Selecting a provider's own "Default (recommended)" model in the model picker snapped the trigger label back to the auggie default model instead of showing the chosen provider's default.
+
+**Repro:** New Workspace modal → open the model picker → pick Anthropic Claude Code → choose "Default (recommended)". Observed: the trigger label snaps back to the auggie default (e.g. "Claude Fable 5") while the checkmark stays on the Claude Code row.
+
+**Root cause:** `hasExplicitModel` in `ModelPicker.svelte` treated any parsed `modelId === 'default'` as "no selection", over-matching compound ids like `claude-code:default` — so a provider-prefixed default selection was discarded and the trigger label fell back to the auggie default. The `'default'` sentinel originated in cloudlands-fe PR #6 (`ba7b8255`), before provider-prefixed compound ids existed.
+
+**Expected:** Only the bare `'default'` sentinel means "no explicit selection"; a provider-prefixed `*:default` id is an explicit model choice and the trigger label reflects the selected provider's default.
+
+**Status:** fixed ([intent-hq/cloudlands-fe#248](https://github.com/intent-hq/cloudlands-fe/pull/248), 2026-07-22) — `hasExplicitModel` now treats only the bare `'default'` id as no-selection, so compound `*:default` ids render as explicit selections; regression test covers the trigger label for a provider-prefixed default.
+
+---
 
 ### STAB-180 (2026-07-22, area: settings / providers, severity: P1)
 


### PR DESCRIPTION
Bumps `packages/cloudlands-fe` to `edbf9d41` — the squash commit of [intent-hq/cloudlands-fe#248](https://github.com/intent-hq/cloudlands-fe/pull/248) — and files **STAB-181** in `docs/01_stabilizing/KNOWN_ISSUES.md`.

## What

- **Submodule bump**: `packages/cloudlands-fe` `39afbcbb` → `edbf9d41` (one commit: cloudlands-fe#248).
- **Tracker**: new STAB-181 entry (2026-07-22, area: cloudlands-fe model picker, severity: P2), status fixed via cloudlands-fe#248; next-available ID bumped to STAB-182.

## Bug (STAB-181)

In the New Workspace modal's model picker, choosing Anthropic Claude Code → "Default (recommended)" snapped the trigger label back to the auggie default (e.g. "Claude Fable 5") while the checkmark stayed on the Claude Code row.

**Root cause:** `hasExplicitModel` in `ModelPicker.svelte` treated any parsed `modelId === 'default'` as no-selection, over-matching compound ids like `claude-code:default`. The `'default'` sentinel originated in cloudlands-fe PR #6 (`ba7b8255`), before provider-prefixed compound ids existed.

**Fix (cloudlands-fe#248):** only the bare `'default'` id means no explicit selection; provider-prefixed `*:default` ids render as explicit selections. Regression test included in the submodule PR.

Tracker update rides with the code-fix bump per the AGENTS.md known-issues convention.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author