### PR TITLE
chore: add issue forms and PR template (#424)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,56 @@
+name: Bug report
+description: Report a bug in intentd, cloudlands-fe, ios, or docs/tooling
+labels: ["bug"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What happened?
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Reproduction steps
+      placeholder: |
+        1. ...
+        2. ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected-actual
+    attributes:
+      label: Expected vs actual
+      description: What did you expect to happen, and what happened instead?
+    validations:
+      required: true
+  - type: checkboxes
+    id: component
+    attributes:
+      label: Component
+      description: >
+        Check all that apply. Triage applies the matching label
+        (`component:intentd`, `component:fe`, `component:ios`, `docs`).
+      options:
+        - label: intentd (Rust backend daemon)
+        - label: cloudlands-fe (Electron + SvelteKit desktop frontend)
+        - label: ios (SwiftUI companion app)
+        - label: docs / tooling
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      description: Per the taxonomy in docs/README.md
+      options:
+        - P0 — crash, data-loss, or corruption; blocks shipping to external users
+        - P1 — broken feature; app still usable but with significant workaround required
+        - P2 — papercut; annoying but does not block workflows
+    validations:
+      required: true
+  - type: checkboxes
+    id: agent-filed
+    attributes:
+      label: Agent-filed
+      options:
+        - label: This issue was filed by an AI agent (triage applies the `agent-filed` label)

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -30,8 +30,9 @@ body:
     attributes:
       label: Component
       description: >
-        Check all that apply. Triage applies the matching label
-        (`component:intentd`, `component:fe`, `component:ios`, `docs`).
+        Check all that apply. Checkboxes do not apply labels automatically —
+        a triager will add the matching label (`component:intentd`,
+        `component:fe`, `component:ios`, `docs`).
       options:
         - label: intentd (Rust backend daemon)
         - label: cloudlands-fe (Electron + SvelteKit desktop frontend)
@@ -53,4 +54,4 @@ body:
     attributes:
       label: Agent-filed
       options:
-        - label: This issue was filed by an AI agent (triage applies the `agent-filed` label)
+        - label: This issue was filed by an AI agent (a triager will add the `agent-filed` label)

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -21,8 +21,9 @@ body:
     attributes:
       label: Component
       description: >
-        Check all that apply. Triage applies the matching label
-        (`component:intentd`, `component:fe`, `component:ios`, `docs`).
+        Check all that apply. Checkboxes do not apply labels automatically —
+        a triager will add the matching label (`component:intentd`,
+        `component:fe`, `component:ios`, `docs`).
       options:
         - label: intentd (Rust backend daemon)
         - label: cloudlands-fe (Electron + SvelteKit desktop frontend)

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,35 @@
+name: Feature request
+description: Propose an enhancement or new capability
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem statement
+      description: What problem does this solve? Why is it needed?
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: What should happen?
+    validations:
+      required: true
+  - type: checkboxes
+    id: component
+    attributes:
+      label: Component
+      description: >
+        Check all that apply. Triage applies the matching label
+        (`component:intentd`, `component:fe`, `component:ios`, `docs`).
+      options:
+        - label: intentd (Rust backend daemon)
+        - label: cloudlands-fe (Electron + SvelteKit desktop frontend)
+        - label: ios (SwiftUI companion app)
+        - label: docs / tooling
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you considered, and why they were rejected.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,8 @@
+<!-- Brief summary of the change. -->
+
+## Checklist
+
+- [ ] PR title is a conventional commit (`feat` / `fix` / `chore` / `docs` / `refactor` / `test` / `ci` / `perf`) — validated by CI
+- [ ] Linked issue referenced (e.g. `Closes #123`)
+- [ ] Tests/checks green (`make check` + `make test` for intentd changes)
+- [ ] If this PR bumps a submodule pointer: the submodule PR was merged first (Phase 1 → Phase 2 workflow in AGENTS.md)


### PR DESCRIPTION
Closes #424.

Adds structured issue/PR intake to the monorepo:

- `.github/ISSUE_TEMPLATE/bug_report.yml` — issue form with description, reproduction steps, expected vs actual, component checkboxes (intentd / cloudlands-fe / ios / docs-tooling), severity dropdown aligned with the P0/P1/P2 taxonomy in `docs/README.md`, and an agent-filed checkbox; auto-applies the `bug` label.
- `.github/ISSUE_TEMPLATE/feature_request.yml` — problem statement, proposed solution, component checkboxes, alternatives considered; auto-applies the `enhancement` label.
- `.github/ISSUE_TEMPLATE/config.yml` — `blank_issues_enabled: true` so agents can keep filing free-form issues per AGENTS.md policy.
- `.github/pull_request_template.md` — brief checklist: conventional-commit PR title (CI-validated), linked issue, green checks, and the Phase 1 → Phase 2 submodule workflow reminder.

### Label normalization (repo-settings sibling task, no file changes)

The label taxonomy from #424 was normalized directly via the GitHub API:

- Descriptions + colors added to all 8 taxonomy labels.
- `documentation` label deleted (0 issues used it; `docs` had 6, all already correctly labeled). No migration needed.
- `agent-filed` kept as-is (#E99695); GitHub defaults (`bug`, `enhancement`, etc.) untouched.

| Label | Description | Color |
|---|---|---|
| component:intentd | Rust backend daemon (packages/intentd) | #0e5a8a |
| component:fe | Electron + SvelteKit desktop frontend (packages/cloudlands-fe) | #1d76db |
| component:ios | SwiftUI iOS companion app (packages/ios) | #54aeff |
| oss-launch | Work toward the open-source launch | #d93f0b |
| launch-blocker | Urgent: must be resolved before the OSS launch | #b60205 |
| docs | Improvements or additions to documentation | #0075ca |
| agent-workflow | Agent workflow conventions, delegation, and automation | #0e8a16 |
| design | Design, UX, and visual polish | #d4c5f9 |
| agent-filed | Filed by an agent (unchanged) | #E99695 |

All labels referenced by the templates (`bug`, `enhancement`, `component:*`, `docs`, `agent-filed`) exist on the repo.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author