### PR TITLE
chore: bump intentd submodule; document 40 MiB transport message limit

### DIFF
--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -77,6 +77,15 @@ When discovery is enabled the server advertises a Bonjour/DNS-SD service so mobi
 
 A client resolves the service, reads `fp` for pinning, and connects to `wss://<resolved-host>:<port>/ws`.
 
+### 1.4 Message size limit
+
+Inbound JSON-RPC messages are capped at **40 MiB** (`MAX_INBOUND_MESSAGE_BYTES = 40 * 1024 * 1024` in `intent-transport`). The limit is the same on both transports; the behavior on violation differs by framing:
+
+- **WSS:** the limit is enforced on the WebSocket message and frame size; an over-limit frame fails fast on the frame header (the payload is not buffered) and the connection is closed.
+- **UDS:** the daemon replies with a `-32600` error (`id: null`, since the request was never parsed) and then closes the connection, without draining the rest of the oversized line.
+
+Outbound (server→client) messages are not subject to this limit.
+
 ## 2. Authentication
 
 ### 2.1 Bearer token on upgrade


### PR DESCRIPTION
Bumps `packages/intentd` to latest `main` and documents the transport-level inbound message size limit in `docs/PROTOCOL.md`.

## Changes

- **Submodule bump**: `packages/intentd` `8058fb5` → `b6f1ef5` (intent-hq/intentd#368 — `fix(transport): enforce 40 MiB inbound message size limit on UDS and WSS`).
- **docs/PROTOCOL.md**: new §1.4 "Message size limit" documenting the 40 MiB inbound cap (`MAX_INBOUND_MESSAGE_BYTES = 40 * 1024 * 1024`), enforced identically on WSS and UDS, and the behavior on violation:
  - WSS: over-limit frame fails fast on the frame header; connection closed.
  - UDS: `-32600` error with `id: null`, then connection closed.

Closes #472
