### PR TITLE
docs: clarify WSS fragmented-message behavior for the 40 MiB inbound limit

### DIFF
--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -81,7 +81,7 @@ A client resolves the service, reads `fp` for pinning, and connects to `wss://<r
 
 Inbound JSON-RPC messages are capped at **40 MiB** (`MAX_INBOUND_MESSAGE_BYTES = 40 * 1024 * 1024` in `intent-transport`). The limit is the same on both transports; the behavior on violation differs by framing:
 
-- **WSS:** the limit is enforced on the WebSocket message and frame size; an over-limit frame fails fast on the frame header (the payload is not buffered) and the connection is closed.
+- **WSS:** the limit is enforced on both the WebSocket frame size and the total message size, and the connection is closed on violation. A single over-limit frame fails fast on the frame header (its payload is not buffered); a fragmented message is rejected once its accumulated fragments exceed the cap, so up to the limit may be buffered before rejection.
 - **UDS:** the daemon replies with a `-32600` error (`id: null`, since the request was never parsed) and then closes the connection, without draining the rest of the oversized line.
 
 Outbound (server→client) messages are not subject to this limit.


### PR DESCRIPTION
Follow-up to #496, addressing the Copilot review comment posted after merge: the WSS bullet in §1.4 described only the single-frame fail-fast path. A fragmented WebSocket message can exceed the message-size cap without any single frame exceeding the frame cap; in that case fragments accumulate up to the 40 MiB limit before rejection.

This clarifies the WSS bullet to describe both cases explicitly, matching tungstenite's `max_frame_size` / `max_message_size` semantics in `intent-transport/src/ws.rs`.

Refs #496, comment: https://github.com/intent-hq/monorepo/pull/496#discussion_r3633201408
