### PR TITLE
docs: add CONTRIBUTING.md and SECURITY.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,8 +65,8 @@ conventional commit before pushing.
 Keep the relevant checks green before opening a PR:
 
 - **intentd**: `cargo fmt --check`, `cargo clippy -- -D warnings`, and
-  `cargo build` — the monorepo-root `Makefile` wraps these as `make check` and
-  `make test`.
+  `cargo build` — the monorepo-root `Makefile` wraps these as `make check`
+  (fmt + clippy) and `make build`; run `make test` for the test suite.
 - **cloudlands-fe**: `pnpm run check` and `pnpm vitest run`.
 - **ios**: build + test targets passing.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,99 @@
+# Contributing to Intent
+
+Thanks for your interest in Intent!
+
+## Contribution posture
+
+Intent is developed in the open, but active development currently happens at high
+velocity inside this repository and its component repositories, largely driven by
+AI agents working against a shared workflow. To keep review overhead manageable:
+
+- **Issues are welcome.** Bug reports and feature requests are the most valuable
+  way to contribute right now — please file them on
+  [intent-hq/monorepo](https://github.com/intent-hq/monorepo/issues), the single
+  tracker for all components.
+- **External pull requests are deferred for now.** Unsolicited PRs may be closed
+  with thanks. If you want to work on something, open an issue first so we can
+  discuss it — we expect to open up to external PRs as the project matures.
+
+The rest of this document describes how changes flow through the repositories, so
+that issue discussions and any future contributions match the project's workflow.
+
+## Repository structure
+
+This monorepo tracks the Intent component repositories as git submodules; the code
+lives in the submodule repos:
+
+| Path | Repository | Component |
+|------|------------|-----------|
+| `packages/intentd` | [intent-hq/intentd](https://github.com/intent-hq/intentd) | Rust backend daemon |
+| `packages/cloudlands-fe` | [intent-hq/cloudlands-fe](https://github.com/intent-hq/cloudlands-fe) | Electron + SvelteKit desktop frontend |
+| `packages/ios` | [intent-hq/ios](https://github.com/intent-hq/ios) | SwiftUI iOS companion app |
+
+The durable engineering docs live in [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)
+(backend architecture) and [docs/PROTOCOL.md](docs/PROTOCOL.md) (the canonical
+wire contract); see [docs/README.md](docs/README.md) for the docs index.
+
+## Two-phase change workflow
+
+Changes that touch a submodule land in two phases:
+
+1. **Phase 1 — submodule PR.** Make scoped, conventional commits on a feature
+   branch in the submodule repo (e.g. `intent-hq/intentd`), open a PR there, and
+   merge it (squash merge preferred).
+2. **Phase 2 — monorepo gitlink bump.** Point the submodule at the newly merged
+   commit, commit the pointer change in the monorepo (e.g.
+   `chore: update intentd submodule to latest main`), and open a monorepo PR that
+   references the submodule PR.
+
+Monorepo-only changes (docs, CI, templates) need only a single monorepo PR.
+
+## Conventional commits
+
+Commit messages and PR titles follow
+[Conventional Commits](https://www.conventionalcommits.org/). CI validates PR
+titles against these types: `feat`, `fix`, `chore`, `docs`, `refactor`, `test`,
+`ci`, `perf`.
+
+PRs are squash-merged (rebase is also allowed). On squash, the commit title
+defaults to the commit message (or the PR title as fallback), so on
+single-commit PRs make sure the branch commit message is itself a valid
+conventional commit before pushing.
+
+## CI expectations
+
+Keep the relevant checks green before opening a PR:
+
+- **intentd**: `cargo fmt --check`, `cargo clippy -- -D warnings`, and
+  `cargo build` — the monorepo-root `Makefile` wraps these as `make check` and
+  `make test`.
+- **cloudlands-fe**: `pnpm run check` and `pnpm vitest run`.
+- **ios**: build + test targets passing.
+
+## Filing issues
+
+- Use the [issue forms](https://github.com/intent-hq/monorepo/issues/new/choose)
+  (bug report / feature request) and pick the affected component(s).
+- **Search first** — check existing open *and* closed issues and comment on or
+  link an existing issue instead of filing a duplicate.
+- Issues are triaged with `component:*` labels and a severity taxonomy
+  (P0 crash/data-loss, P1 broken feature, P2 papercut) described in
+  [docs/README.md](docs/README.md).
+
+## Local setup
+
+```bash
+git submodule update --init --recursive
+make check
+make test
+```
+
+## Security issues
+
+Please do not report security vulnerabilities through public issues — see
+[SECURITY.md](SECURITY.md).
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the
+[Apache License 2.0](LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,30 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please report security vulnerabilities **privately** through
+[GitHub Security Advisories on intent-hq/monorepo](https://github.com/intent-hq/monorepo/security/advisories/new)
+— the single tracker for all Intent components. Do **not** open a public issue
+or pull request for a security problem.
+
+This applies to all three components:
+
+- `intentd` — Rust backend daemon
+- `cloudlands-fe` — Electron + SvelteKit desktop frontend
+- `ios` — SwiftUI iOS companion app
+
+When reporting, please include the affected component, a description of the
+issue and its impact, and reproduction steps or a proof of concept if you have
+one.
+
+## What to expect
+
+We aim to acknowledge new reports within a few business days. Intent is a small
+project without a dedicated security team, so we cannot promise a hard SLA, but
+we will keep you informed as we triage and fix confirmed issues, and credit
+reporters in the advisory unless they prefer otherwise.
+
+## Supported versions
+
+Intent is pre-1.0 software. Only the latest code on the `main` branch of each
+repository is supported; fixes are not backported to earlier snapshots or tags.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,6 +7,10 @@ Please report security vulnerabilities **privately** through
 — the single tracker for all Intent components. Do **not** open a public issue
 or pull request for a security problem.
 
+If the advisory form is not available (for example, private vulnerability
+reporting has not yet been enabled on the repository), contact the maintainers
+privately rather than disclosing publicly.
+
 This applies to all three components:
 
 - `intentd` — Rust backend daemon


### PR DESCRIPTION
Closes #425.

Adds the two community files at the monorepo root, reflecting the decided contribution posture (snapshot-mirror-first: issues welcome, external PRs deferred for now).

## CONTRIBUTING.md
- Contribution posture statement (issues welcome; external PRs deferred/closed-with-thanks until the team opens up)
- Repo structure: monorepo + 3 submodules, code lives in the submodule repos; links to `docs/ARCHITECTURE.md`, `docs/PROTOCOL.md`, `docs/README.md`
- Two-phase workflow (Phase 1 submodule PR -> Phase 2 gitlink bump PR, per AGENTS.md)
- Conventional commits: CI-validated types (`feat`/`fix`/`chore`/`docs`/`refactor`/`test`/`ci`/`perf`) + squash-merge title rules
- CI expectations per repo (intentd: fmt/clippy `-D warnings`/build via `make check`/`make test`; cloudlands-fe: `pnpm run check` + `pnpm vitest run`; ios: build+test) sourced from `docs/README.md`
- Issue filing: issue forms, `component:*` labels + P0/P1/P2 severity, dedup-first
- Local setup + pointer to SECURITY.md; Apache-2.0 license note

## SECURITY.md
- Private reporting via GitHub Security Advisories on `intent-hq/monorepo` (single tracker; no email invented). Note: the "Report a vulnerability" flow becomes available once the repo is public (#417) and private vulnerability reporting is enabled in repo settings.
- Scope covers all three components; modest response expectation (acknowledgment target, no hard SLA)
- Supported versions: pre-1.0, latest `main` only

No submodule changes; no CODE_OF_CONDUCT.md (out of scope for #425).

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author