### PR TITLE
docs: rewrite README as the public front door

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ daemon as thin clients.
 ```sh
 brew tap intent-hq/homebrew-tap
 brew install intentd
-brew services start intentd   # start now and at every login
+brew services start intentd   # start now and at login (launchd on macOS, systemd on Linux)
 ```
 
 The Intent desktop app auto-detects and connects to the brew-managed daemon.

--- a/README.md
+++ b/README.md
@@ -1,158 +1,108 @@
-# Intent Monorepo
+# Intent
 
-Monorepo for **Intent**, an agentic coding platform. This repo ties
-the Intent components together via git submodules and provides unified docs, tooling, and
-CI/CD. It mounts the **Rust backend daemon (`intentd`)**, the **Electron + SvelteKit
-desktop frontend (`cloudlands-fe`)**, and the **SwiftUI iOS companion app (`ios`)** as submodules.
+**Intent** is a local-first agentic coding platform. A Rust daemon (`intentd`)
+runs on your machine and owns everything — workspaces, notes, tasks, coding
+agents, git, terminals, and events — exposing it all through a JSON-RPC API.
+A desktop app (Electron + SvelteKit) and an iOS companion app connect to the
+daemon as thin clients.
 
-## Architecture Overview
-
-`intentd` is a local-first Rust daemon that owns the Intent domain model — workspaces, notes,
-tasks, comments, agents, git, pull requests, scripts, terminals, files, and events — and
-exposes it over a JSON-RPC 2.0 API on a Unix-domain socket plus a secure WSS/TLS LAN
-transport. Clients are thin; all business logic lives in the daemon, including the ACP agent
-runtime. The desktop frontend now **exists** and lives in this monorepo as the
-`packages/cloudlands-fe` submodule — an **Electron + SvelteKit + TypeScript** app. It talks
-to `intentd` only through the `AppClient` JSON-RPC boundary (which ships with a mock
-implementation, so the frontend can also run standalone). It was migrated in with full history.
+<!-- TODO: screenshot/demo -->
 
 ```
-┌──────────────────────────────────────────────────────────────┐
-│                       intent-hq/monorepo                     │
-│                                                              │
-│  ┌────────────────────────────────────────────────────────┐  │
-│  │ packages/                                              │  │
-│  │   ├── intentd/        ⇒ submodule → intent-hq/intentd  │  │
-│  │   │     Rust backend daemon (JSON-RPC over UDS)        │  │
-│  │   ├── cloudlands-fe/   ⇒ submodule → intent-hq/cloudlands-fe │
-│  │   │     Electron + SvelteKit desktop UI                │  │
-│  │   └── ios/            ⇒ submodule → intent-hq/ios      │  │
-│  │         SwiftUI iOS companion app                      │  │
-│  ├────────────────────────────────────────────────────────┤  │
-│  │ docs/   ARCHITECTURE.md + PROTOCOL.md                  │  │
-│  │ AGENTS.md   Makefile   cliff.toml   .github/workflows/ │  │
-│  └────────────────────────────────────────────────────────┘  │
-└──────────────────────────────────────────────────────────────┘
+┌────────────────────────┐   ┌────────────────────────┐
+│      Desktop app       │   │   iOS companion app    │
+│  Electron + SvelteKit  │   │        SwiftUI         │
+└───────────┬────────────┘   └───────────┬────────────┘
+            │ JSON-RPC over UDS          │ JSON-RPC over WSS/TLS (LAN)
+            ▼                            ▼
+┌─────────────────────────────────────────────────────────┐
+│                  intentd — Rust daemon                  │
+│  workspaces · notes · tasks · agents · git · terminals  │
+└─────────────────────────────────────────────────────────┘
 ```
 
-Code lives in the submodule repos; the monorepo tracks specific commits of each submodule and
-carries the cross-cutting docs and tooling. See `docs/ARCHITECTURE.md` and `docs/PROTOCOL.md`
-for the full design.
+## Install
 
-## Status
+### Homebrew (macOS & Linux)
 
-| Component | Status |
-| --- | --- |
-| `packages/intentd` | **Backend port — canonical persistence landed.** The full JSON-RPC method catalog (see [docs/PROTOCOL.md](./docs/PROTOCOL.md)) + a server-initiated `events.event` notification over SQLite, spanning workspace/repo/note/task/comment, events, git/PR/file-tracking/metrics/accept-changes, search/terminal/script, workspace-file/note-primitive/cross-workspace, the settings/rules/specialist/`mcp.servers`/MCP-OAuth agent ecosystem, GitHub-browse/Linear/Sentry integrations, and the ACP agent runtime (`agent.*`). The daemon owns all persistent user-facing state (notes/comments/assets/settings/agent sessions). Transports: UDS (default, `0600`) + WSS/TLS (bearer auth, origin allow-list, fingerprint pinning). CLI: `serve`/`call`/`status`/`stop`/`doctor`/`import`/`service`/`token`/`mcp-bridge`. |
-| `packages/cloudlands-fe` | **Desktop frontend — daemon-canonical.** Electron + SvelteKit + TypeScript app, mounted at `packages/cloudlands-fe`. Reaches the backend only through the `AppClient` JSON-RPC boundary (live `intentd` + a mock implementation for standalone runs); local persistence, execution spawns, the legacy agent transport, and the remote-backend stack are all retired onto daemon RPCs. |
-| `packages/ios` | **iOS companion app — submodule mounted.** SwiftUI iOS app, mounted at `packages/ios`. Early-stage development. |
-
-## Repository Layout
-
-```
-monorepo/
-├── .github/
-│   └── workflows/
-│       └── ci.yml                 # fmt/clippy/test + build matrix + PR-title check
-├── .gitmodules                    # Submodule definitions (intentd, cloudlands-fe, ios)
-├── cliff.toml                     # git-cliff changelog config (conventional commits)
-├── docs/
-│   ├── ARCHITECTURE.md            # Durable backend architecture
-│   └── PROTOCOL.md                # Canonical wire contract (protocol v2.0)
-├── packages/
-│   ├── intentd/                   # ⇒ submodule → intent-hq/intentd (Rust backend)
-│   ├── cloudlands-fe/             # ⇒ submodule → intent-hq/cloudlands-fe (Electron + SvelteKit frontend)
-│   └── ios/                       # ⇒ submodule → intent-hq/ios (SwiftUI iOS companion app)
-├── AGENTS.md                      # AI agent workflow guide (commit/PR conventions)
-├── Makefile                       # Cross-package task orchestration
-└── README.md                      # ← you are here
+```sh
+brew tap intent-hq/homebrew-tap
+brew install intentd
+brew services start intentd   # start now and at every login
 ```
 
-## Submodules
+The Intent desktop app auto-detects and connects to the brew-managed daemon.
 
-| Path                     | Repository                                                                    |
-| ------------------------ | ----------------------------------------------------------------------------- |
-| `packages/intentd`       | [intent-hq/intentd](https://github.com/intent-hq/intentd)                     |
-| `packages/cloudlands-fe` | [intent-hq/cloudlands-fe](https://github.com/intent-hq/cloudlands-fe)         |
-| `packages/ios`           | [intent-hq/ios](https://github.com/intent-hq/ios)                             |
+### GitHub Releases
 
-## Getting Started
+Prebuilt `intentd` binaries — macOS, Linux, and Windows archives, `.deb`
+packages, and shell/PowerShell installers — are published on the
+[intentd releases page](https://github.com/intent-hq/intentd/releases).
 
-```bash
-# Clone with submodules
-git clone --recursive git@github.com:intent-hq/monorepo.git
+The desktop app is not yet packaged for download; it will ship via GitHub
+Releases. Until then, you can [build it from source](#build-from-source).
+
+## Build from source
+
+```sh
+git clone --recursive https://github.com/intent-hq/monorepo.git
 cd monorepo
-
-# Or, if already cloned without --recursive:
+# If already cloned without --recursive:
 git submodule update --init --recursive
 
-# Verify and test (delegates into packages/intentd)
-make check      # cargo fmt --check + cargo clippy -- -D warnings
-make test       # cargo test --workspace
-make build      # cargo build --workspace
-make clean      # remove build artifacts
-
-# Local dev: choose one of two workflows
-#
-# Option 1 — One-command sidecar mode (recommended):
-#   The FE spawns and supervises its own intentd binary (like the packaged app).
-#
-#   make dev
-#
-# Option 2 — Two-terminal mode (daemon + FE separate):
-#   Run the daemon and FE in separate terminals. Useful for daemon debugging.
-#
-#   # Terminal 1 — dev daemon: isolated data dir under .dev/intentd, UDS + insecure TCP (--insecure)
-#   make dev-daemon
-#
-#   # Terminal 2 — Electron + SvelteKit frontend (packages/cloudlands-fe);
-#   # connects to ws://127.0.0.1:5181/ws out of the box.
-#   make run-fe
-#
-# Occasional "debug the release app with its own state" variant: run intentd
-# against its default (real) data dir (UDS always on; the secure WSS listener
-# starts only if the persisted `server.wsApi.enabled` setting is true):
-#
-#   make release-daemon                                      # real data dir, no --insecure
-#   INTENTD_SOCKET=~/Library/Application\ Support/intentd/intentd.sock make run-fe
-#
-# `make run-intentd` is a deprecated alias for `make release-daemon`.
-# `make ios-info` prints the host/port for the iOS simulator and hardware, and
-# `make ios-open` opens the Xcode project (`packages/ios/Intent.xcodeproj`).
-# `make help` lists every documented target.
+make check   # cargo fmt --check + cargo clippy -- -D warnings
+make test    # cargo test --workspace
+make build   # cargo build --workspace
 ```
 
-## Contributing & Workflow
+Run the stack locally in one of two ways:
 
-Changes that span a submodule and the monorepo follow a two-phase flow (see `AGENTS.md` for
-the full guide):
+```sh
+# One-command sidecar mode (recommended): the desktop app spawns and
+# supervises its own intentd binary, like the packaged app.
+make dev
 
-**Phase 1 — Submodule PR.** Make scoped, conventional commits on a feature branch in the
-submodule (e.g. `intent-hq/intentd`), push, open a PR, and merge (squash preferred).
+# Two-terminal mode, useful for daemon debugging:
+make dev-daemon   # terminal 1 — dev daemon with an isolated data dir
+make run-fe       # terminal 2 — desktop app, connects to the dev daemon
+```
 
-**Phase 2 — Monorepo update.** Pull the submodule's latest `main`, stage the updated gitlink
-(`git add packages/intentd`), commit (`chore: update intentd submodule to latest main`), push,
-and open a monorepo PR referencing the submodule PR.
+`make help` lists every documented target.
 
-Conventions:
+## Architecture
 
-- **Conventional commits** are required and PR titles are validated in CI against `feat`,
-  `fix`, `chore`, `docs`, `refactor`, `test`, `ci`, `perf`.
-- **Changelogs** are generated with `git-cliff` (see `cliff.toml`).
-- For Rust changes, keep `cargo fmt --check`, `cargo clippy -- -D warnings`, and
-  `cargo build` green in `packages/intentd` before opening a PR.
+Clients are thin: all state and business logic — including the agent runtime —
+live in `intentd`, which persists to SQLite and serves JSON-RPC 2.0 over a
+Unix-domain socket (local clients) and WSS/TLS (LAN clients such as the iOS
+app). See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for the backend design
+and [docs/PROTOCOL.md](docs/PROTOCOL.md) for the canonical wire contract.
 
-## Documentation
+This monorepo ties the components together as git submodules and carries the
+cross-cutting docs, tooling, and CI; the code lives in the component repos:
 
-- [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) — the durable backend architecture:
-  system overview, crate layout, dependency rules, persistence, and transports.
-- [`docs/PROTOCOL.md`](docs/PROTOCOL.md) — the canonical wire contract (protocol v2.0):
-  transport, JSON-RPC envelope, full method catalog, events, and error codes.
+| Path | Repository | Component |
+|------|------------|-----------|
+| `packages/intentd` | [intent-hq/intentd](https://github.com/intent-hq/intentd) | Rust backend daemon |
+| `packages/cloudlands-fe` | [intent-hq/cloudlands-fe](https://github.com/intent-hq/cloudlands-fe) | Electron + SvelteKit desktop app |
+| `packages/ios` | [intent-hq/ios](https://github.com/intent-hq/ios) | SwiftUI iOS companion app (private) |
 
-## Related Repositories
+## Community
 
-| Repository | Description |
-| --- | --- |
-| [intent-hq/intentd](https://github.com/intent-hq/intentd) | Rust backend daemon — JSON-RPC over UDS, mounted at `packages/intentd`. |
-| [intent-hq/cloudlands-fe](https://github.com/intent-hq/cloudlands-fe) | Electron + SvelteKit desktop frontend — mounted at `packages/cloudlands-fe`. |
-| [intent-hq/ios](https://github.com/intent-hq/ios) | SwiftUI iOS companion app — mounted at `packages/ios`. |
+- [CONTRIBUTING.md](CONTRIBUTING.md) — bug reports and feature requests are
+  very welcome via the
+  [issue forms](https://github.com/intent-hq/monorepo/issues/new/choose);
+  external pull requests are deferred for now while the public repository is a
+  read-only snapshot mirror.
+- [SECURITY.md](SECURITY.md) — report security vulnerabilities privately, not
+  through public issues.
+- [Issue tracker](https://github.com/intent-hq/monorepo/issues) — the single
+  tracker for all Intent components.
+
+## iOS companion app
+
+The SwiftUI iOS companion app is in early development; its repository is
+currently private and will open up later.
+
+## License
+
+Intent is licensed under the [Apache License 2.0](LICENSE).

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ daemon as thin clients.
 ```sh
 brew tap intent-hq/homebrew-tap
 brew install intentd
-brew services start intentd   # start now and at login (launchd on macOS, systemd on Linux)
+brew services start intentd   # start now and on startup (launchd on macOS, systemd on Linux)
 ```
 
 The Intent desktop app auto-detects and connects to the brew-managed daemon.

--- a/README.md
+++ b/README.md
@@ -45,10 +45,10 @@ Releases. Until then, you can [build it from source](#build-from-source).
 ## Build from source
 
 ```sh
-git clone --recursive https://github.com/intent-hq/monorepo.git
+git clone https://github.com/intent-hq/monorepo.git
 cd monorepo
-# If already cloned without --recursive:
-git submodule update --init --recursive
+# Init the public submodules (packages/ios is currently private):
+git submodule update --init --recursive packages/intentd packages/cloudlands-fe
 
 make check   # cargo fmt --check + cargo clippy -- -D warnings
 make test    # cargo test --workspace

--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ brew install intentd
 brew services start intentd   # start now and on startup (launchd on macOS, systemd on Linux)
 ```
 
-The Intent desktop app auto-detects and connects to the brew-managed daemon.
+The Intent desktop app connects to an already-running daemon such as this
+brew-managed one when configured to; it can also spawn its own bundled
+`intentd` (sidecar mode).
 
 ### GitHub Releases
 


### PR DESCRIPTION
Closes #428.

Rewrites the root README as the public landing page for Intent:

- **Intro** — what Intent is in user-facing terms (local-first agentic coding platform: `intentd` Rust daemon + Electron/SvelteKit desktop app + iOS companion), with a simplified component diagram and an explicit `<!-- TODO: screenshot/demo -->` placeholder (no assets exist yet).
- **Install** — Homebrew tap first (`brew tap intent-hq/homebrew-tap && brew install intentd`, `brew services start intentd`; desktop app auto-detects the brew daemon), then a link to intentd GitHub Releases. Honestly states the desktop app is not yet packaged for download and will ship via Releases.
- **Build from source** — non-recursive clone + explicit init of the public submodules (`git submodule update --init --recursive packages/intentd packages/cloudlands-fe`; `packages/ios` is private, so `--recursive` would fail for the public), `make check/test/build`, and the two dev workflows condensed (`make dev` sidecar mode; `make dev-daemon` + `make run-fe`), pointing at `make help` for the rest.
- **Architecture** — thin clients, daemon owns all state, UDS + WSS transports; links `docs/ARCHITECTURE.md` and `docs/PROTOCOL.md`; compact submodule table (ios marked private).
- **Community** — CONTRIBUTING.md (issues welcome, external PRs deferred while the public repo is a read-only snapshot mirror), SECURITY.md, issue forms.
- **iOS** — one line: early development, repo currently private.

Removed: porting-era Status table, method-catalog dumps, "migrated in with full history" framing, and the Contributing & Workflow section that duplicated CONTRIBUTING.md/AGENTS.md.

Diff touches only `README.md`; no submodule gitlink changes.
