### PR TITLE
chore: add dependabot config for github-actions and git submodules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+
+  - package-ecosystem: "gitsubmodule"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"


### PR DESCRIPTION
Adds `.github/dependabot.yml` enabling weekly Dependabot updates for:

- `github-actions` (directory `/`) — keeps workflow action versions current
- `gitsubmodule` (directory `/`) — automatic bump PRs for the submodule refs under `packages/`

Both ecosystems use `commit-message.prefix: "chore"` so Dependabot PR titles pass the semantic PR title CI check.

Part of the effort to enable Dependabot across all Intent repos.
