### PR TITLE
feat: persist New Workspace modal drafts across app restarts

### DIFF
--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -1623,6 +1623,13 @@ save today, and calls `drafts.clear` on send.
 are never returned to a different `clientId`. A future opt-in **shared-draft** (collaborative)
 mode is noted but **out of scope for v1**.
 
+**Opaque keys & reserved sentinels.** `workspaceId` / `agentId` are **opaque draft keys** — the
+daemon never validates them against live workspaces or agents. The FE reserves the sentinel pair
+**`"__new-workspace__"` / `"__initializer__"`** for the New Workspace modal's pre-creation draft
+(no workspace/agent exists yet); it is per-client like any other draft and the FE clears it on
+successful `workspace.create`. The `__…__` form cannot collide with real IDs (daemon-generated
+workspace slugs are lowercase alphanumerics + hyphens).
+
 **`draft:changed` event — no text leakage.** `drafts.set` / `drafts.clear` emit
 `draft:changed { workspaceId, agentId, clientId, hasDraft }` (§6.5). The payload deliberately
 **omits the draft text** — it lets other clients optionally show a "someone is composing"


### PR DESCRIPTION
## Summary

Ships New Workspace modal draft persistence across app restarts.

- **docs: PROTOCOL.md §5.16** — documents the reserved sentinel draft keys (`__new-workspace__` / `__initializer__`) used by the FE to persist the New Workspace modal draft before any workspace or agent exists. Draft keys are opaque to the daemon; the `__…__` sentinel form cannot collide with real workspace IDs.
- **chore: submodule bump** — points `packages/cloudlands-fe` at the merged FE change intent-hq/cloudlands-fe#303 (`c8fca23a`), which persists the modal draft (text + images) via the daemon drafts API with legacy sessionStorage migration, a combined text+attachments size guard, and non-fatal error handling.

## Verification

- `make check` and `make test` green at the monorepo root.
- FE PR intent-hq/cloudlands-fe#303: all CI checks passed; review comments addressed and threads resolved before squash-merge.
