### PR TITLE
docs: make ACP provider CLI list non-exhaustive (fixes #602)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -19,9 +19,9 @@ The daemon embeds:
 
 - A **JSON-RPC router** serving the full method catalog (see `PROTOCOL.md`),
   reusing one set of **service** implementations across every transport.
-- An **ACP client** that spawns provider CLIs (auggie, claude-code, codex,
-  cortex, droid, opencode) over piped stdio and multiplexes many concurrent
-  agent sessions.
+- An **ACP client** that spawns provider CLIs (auggie, claude-code, codex, … —
+  see the `intent-providers` registry for the full set) over piped stdio and
+  multiplexes many concurrent agent sessions.
 - An **MCP server** exposed *back to* the agents so an agent can call the same
   workspace API the FE uses (`note.*`, `task.*`, `agent.delegate`, …) — the
   agent→BE callback loop.


### PR DESCRIPTION
Fixes #602

The ACP provider CLI enumeration in `docs/ARCHITECTURE.md` (~line 22) was stale: it listed `auggie, claude-code, codex, cortex, droid, opencode` and omitted the registered `grok` and `pi` providers.

Per the issue's suggested fix, the list is now explicitly non-exhaustive and anchored to the provider registry (`packages/intentd/crates/intent-providers/src/config.rs`), so it cannot drift again:

> An **ACP client** that spawns provider CLIs (auggie, claude-code, codex, … — see the `intent-providers` registry for the full set) over piped stdio and multiplexes many concurrent agent sessions.

Docs-only change; no code or submodule impact.
