### PR TITLE
chore: update intentd submodule for system.shutdown UDS-only guard

### DIFF
--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -3711,7 +3711,7 @@ Errors use the standard JSON-RPC 2.0 `error` object `{ code, message, data? }`.
 | -32602 | Invalid params | Missing required param ("Missing required parameter: <name>"), bad workspaceId ("workspaceId is required"), non-array where an array is required, "not found" lookups, unauthorized repoPath, etc. |
 | -32603 | Internal error | Underlying service threw. message is "Internal error" with the original message in data for unexpected throws; many shims pass the underlying message through as message directly. |
 | -32005 | Conflict | Optimistic-concurrency failure: a conditional write's `expectedVersion` did not match the entity's current `rev`. `error.data = { code: "conflict", current }` carries the current entity so the client can reconcile (note conditional writes; §4, §5.6). |
-| -32001 | Unauthorized | Local-only guard: a remote (TCP/WSS) caller invoked a local-only fast-path method (e.g. `pairing.getInfo` or `system.importLegacy`, §5). |
+| -32001 | Unauthorized | Local-only guard: a remote (TCP/WSS) caller invoked a local-only fast-path method (e.g. `pairing.getInfo`, `system.shutdown`, or `system.importLegacy`, §5). |
 
 The only custom numeric codes outside the standard `-327xx` range are `-32005` (Conflict) and `-32001` (Unauthorized, local-only guard); other server-specific conditions (e.g. "not a delegated agent", "path outside workspace", "staging `.` is blocked") are reported as `-32602`/`-32603` with a descriptive `message`. Notification-shaped requests (no `id`) never receive an error response except for parse/invalid-request failures detected before the notification status is known.
 


### PR DESCRIPTION
Closes #630.

## What

- Bumps `packages/intentd` to latest main (`13aa3da`), which includes intent-hq/intentd#436: `system.shutdown` now enforces the documented UDS-only contract — remote (TCP/WSS) callers get `-32001 "system.shutdown is available over UDS only"` instead of tearing the daemon down, and remote shutdown notifications are ignored. Mirrors the `system.importLegacy` guard from intent-hq/intentd#423.
- `docs/PROTOCOL.md`: adds `system.shutdown` to the §9 `-32001` error-table row's examples (previously cited only `pairing.getInfo` and `system.importLegacy`). §5 already documented `system.shutdown` as UDS-only, so no protocol version bump and no catalog count changes.

## Refs

- Submodule PR: intent-hq/intentd#436 (squash-merged; CI green; reviewer findings addressed)
- Issue: #630

## Verification

In `packages/intentd` @ `13aa3da`: `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo build`, `cargo test -p intent-transport control`, `cargo test -p intentd --test e2e_wss_server_pairing`, `cargo test -p intentd --test uds_control` — all green (also enforced by intentd CI on the merged PR).
