### PR TITLE
chore: update intentd submodule for comment.respond -32602 alignment

### DIFF
--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -777,7 +777,11 @@ Uniqueness rules are identical on both paths: an ambiguous `searchContext` or
 `commentTarget` is rejected. All anchoring failures (context not found /
 ambiguous, target not in context / ambiguous) and the empty-field validations
 (`comment`, `searchContext`, `commentTarget`, invalid `authorType`) return
-`-32602` with a descriptive message, **not** `-32603 "Internal error"`. The
+`-32602` with a descriptive message, **not** `-32603 "Internal error"`.
+`comment.respond`'s caller-input checks follow the same rule: missing
+`threadId`/`commentId` (at least one is required), an empty/whitespace-only
+`comment`, and `type: "suggestion"` without both `suggestionOriginal` and
+`suggestionProposed` are all rejected with `-32602`. The
 optional `authorType` param on `comment.add` **and** `comment.respond` sets
 the persisted comment's `authorType` (defaulting `author` to `"User"` /
 `"Agent"` accordingly when absent); omitting it keeps the backward-compatible


### PR DESCRIPTION
Fixes intent-hq/monorepo#632

Bumps the `packages/intentd` gitlink to latest main, which includes intent-hq/intentd#445: `comment.respond`'s pre-existing caller-input validations (missing `threadId`/`commentId`, empty/whitespace-only `comment`, `type: "suggestion"` without both `suggestionOriginal`/`suggestionProposed`) now return `-32602 InvalidParams` instead of `-32603 Internal`, matching `comment.add` and the intentd#434 `authorType` validation.

Also extends `docs/PROTOCOL.md` §5.3 so the "-32602, not -32603" wording explicitly covers `comment.respond`'s caller-input checks.

Submodule PR: intent-hq/intentd#445 (merged; unit + WSS e2e coverage asserting the -32602 envelopes; fmt/clippy `--workspace --all-targets`/test all green).

Related follow-up filed during review: intent-hq/monorepo#649 (`comment.getThread`/`comment.resolveThread` have the same validation still returning -32603).
