### PR TITLE
chore: update intentd submodule and add --all-targets to clippy gate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,8 +113,8 @@ build-intentd: ensure-intentd-submodule
 fmt: ensure-intentd-submodule ## cargo fmt --check
 	cd $(INTENTD_DIR) && cargo fmt --check
 
-clippy: ensure-intentd-submodule ## cargo clippy -- -D warnings
-	cd $(INTENTD_DIR) && cargo clippy --workspace -- -D warnings
+clippy: ensure-intentd-submodule ## cargo clippy --all-targets -- -D warnings
+	cd $(INTENTD_DIR) && cargo clippy --workspace --all-targets -- -D warnings
 
 check: fmt clippy ## fmt + clippy
 


### PR DESCRIPTION
Closes #640.

Monorepo half of the fix for #640, following intent-hq/intentd#444 (merged):

## Changes
- Bump `packages/intentd` to latest main (`bb3d847`), which includes intent-hq/intentd#444 (CI clippy gate now runs with `--all-targets`) and intent-hq/intentd#445. The `clippy::cmp_owned` lint from the issue was already fixed on intentd main by intent-hq/intentd#442.
- `Makefile`: the `clippy` target now runs `cargo clippy --workspace --all-targets -- -D warnings` (help comment updated to match), so test-target lint regressions can no longer land silently via the local gate either.

## Verification
- `make check` and `make test` green at monorepo root with the updated gate and the submodule at `bb3d847`.