### PR TITLE
docs: add Network & privacy section to root README and bump cloudlands-fe

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,35 @@ cross-cutting docs, tooling, and CI; the code lives in the component repos:
 | `packages/cloudlands-fe` | [intent-hq/cloudlands-fe](https://github.com/intent-hq/cloudlands-fe) | Electron + SvelteKit desktop app |
 | `packages/ios` | [intent-hq/ios](https://github.com/intent-hq/ios) | SwiftUI iOS companion app (private) |
 
+## Network & privacy
+
+Intent is local-first: all state lives on your machine, and the stack ships
+**no telemetry, analytics, or crash reporting**. Network access is limited to
+update checks against public GitHub Releases and actions you take yourself:
+
+- **Desktop app auto-updates** — the packaged app checks for and downloads
+  updates from GitHub Releases on
+  [intent-hq/cloudlands-releases](https://github.com/intent-hq/cloudlands-releases).
+- **intentd sitter self-update** — the sitter (see [Install](#install))
+  downloads the daemon and checks the channel manifests published on the
+  [intentd releases page](https://github.com/intent-hq/intentd/releases).
+- **Auggie binary download (on demand)** — installing the Auggie CLI from the
+  desktop app downloads the pre-built binary from the latest public release of
+  [augmentcode/auggie](https://github.com/augmentcode/auggie).
+- **Provider sign-ins (user-initiated)** — signing in to a coding-agent
+  provider (Auggie, Claude Code, Codex, OpenCode, Droid, Grok) runs that
+  provider's own CLI sign-in flow; each provider CLI talks to its own vendor
+  service when you sign in.
+- **User-configured integrations** — connecting GitHub (OAuth device flow or
+  personal access token), Linear (API key), or Sentry calls the respective
+  service's API with credentials you provide. Sentry is opt-in in two places:
+  the desktop app talks to the sentry.io API when you connect a Sentry
+  account, and the daemon's Sentry integration uses an API token you
+  configure. Nothing is sent to any of these services unless you connect them.
+
+Coding agents you run are external programs and may access the network
+according to their own provider's behavior.
+
 ## Community
 
 - [CONTRIBUTING.md](CONTRIBUTING.md) — bug reports and feature requests are

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ update checks against public GitHub Releases and actions you take yourself:
   desktop app downloads the pre-built binary from the latest public release of
   [augmentcode/auggie](https://github.com/augmentcode/auggie).
 - **Provider sign-ins (user-initiated)** — signing in to a coding-agent
-  provider (Auggie, Claude Code, Codex, OpenCode, Droid, Grok) runs that
+  provider (Auggie, Claude Code, Codex, OpenCode, Droid, Grok, Pi) runs that
   provider's own CLI sign-in flow; each provider CLI talks to its own vendor
   service when you sign in.
 - **User-configured integrations** — connecting GitHub (OAuth device flow or


### PR DESCRIPTION
Adds the stack-wide **Network & privacy** section to the root README, documenting every remaining network call the OSS build makes, and bumps the `packages/cloudlands-fe` submodule to latest main.

Closes #426

## What's disclosed

- Desktop app auto-updates → GitHub Releases on [intent-hq/cloudlands-releases](https://github.com/intent-hq/cloudlands-releases)
- intentd sitter self-update → channel manifests on the [intentd releases page](https://github.com/intent-hq/intentd/releases) (cross-referenced from the existing Install section)
- On-demand Auggie binary download → latest public release of [augmentcode/auggie](https://github.com/augmentcode/auggie)
- User-initiated provider sign-ins (Auggie, Claude Code, Codex, OpenCode, Droid, Grok) — each provider CLI talks to its own vendor service
- User-configured integrations: GitHub (OAuth device flow / PAT), Linear (API key), Sentry (API token) — with Sentry noted as opt-in both app-side (desktop app calls the sentry.io API when connected) and daemon-side (API token)
- Explicit statement: no telemetry, analytics, or crash reporting; agents you run may access the network per their own provider behavior

The section heading is exactly `## Network & privacy` so the `#network--privacy` anchor resolves — the cloudlands-fe README (merged in intent-hq/cloudlands-fe#344) links to it for daemon-side calls.

## Submodule bump

`packages/cloudlands-fe` → `70b2d744` (current origin/main), which includes the app-side Network & privacy section from intent-hq/cloudlands-fe#344.
