### PR TITLE
chore: update intentd submodule to latest main (comment.* -32602 alignment)

### DIFF
--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -798,6 +798,15 @@ optional `authorType` param on `comment.add` **and** `comment.respond` sets
 the persisted comment's `authorType` (defaulting `author` to `"User"` /
 `"Agent"` accordingly when absent); omitting it keeps the backward-compatible
 `agent` default, and an invalid value is rejected with `-32602`.
+`comment.getThread` and `comment.resolveThread` apply the same missing-id
+validation: providing neither `threadId` nor `commentId` is rejected with
+`-32602` ("Either threadId or commentId must be provided"), and
+`comment.list`'s filter validations — a non-ISO-8601 `since`, an `authorType`
+other than `user`/`agent`, and a `status` other than `open`/`resolved`/
+`pending` — are likewise `-32602` (monorepo#649). Lookup failures are **not**
+caller-input errors and stay `-32603`: an unknown `commentId` ("Comment not
+found: …") or unknown `threadId` ("Thread not found: …") on
+`comment.getThread`/`comment.resolveThread` returns `-32603 Internal error`.
 
 **Thread resolution.** One additional method addresses an entire thread by `threadId` **or** `commentId`. Emits the `comment:resolved` event (§6.5).
 


### PR DESCRIPTION
Closes #649.

Bumps `packages/intentd` to latest main, picking up intent-hq/intentd#455:
`comment.getThread` / `comment.resolveThread` now return `-32602 Invalid params`
(was `-32603 Internal`) for the "Either threadId or commentId must be provided"
caller-input validation, matching `comment.respond` after intent-hq/intentd#445.
The in-pattern sweep the issue asked for also flipped `comment.list`'s three
filter validations (invalid `since` / `authorType` / `status`) to `-32602`.
Lookup failures ("Comment not found", "Thread not found") intentionally keep
`-32603`, now pinned by unit tests on both arms.

Also extends the `docs/PROTOCOL.md` §5.3 error-code paragraph (as required on
the intentd PR review) to document:

- the `-32602` missing-id validation on `comment.getThread` / `comment.resolveThread`
- the three `-32602` `comment.list` filter validations
- the explicit boundary: lookup failures (unknown `commentId`/`threadId`) remain `-32603`

Submodule PR: intent-hq/intentd#455 (merged, squash `f965ad6`).
