### PR TITLE
docs: branch-OR-baseRef PR matching in pr.refresh semantics; bump intentd (#459)

### DIFF
--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -1095,10 +1095,11 @@ discovery/refresh the daemon's background sweep runs for one workspace, on deman
 > canonicalisation, §5.1), so review workspaces created *for* a PR link it via `baseRef`.
 > Discovery (and relink-after-merge) queries by the workspace's own branch head first —
 > branch match takes precedence — then falls back to one open-PR query per baseRef
-> candidate; when several PRs match, the highest PR number wins. A stale link is cleared
-> only on a **positive mismatch against both** branch and baseRef: the linked PR's head ref
-> is known, at least one of the workspace's `branch` / `baseRef` is known, and neither
-> matches — unknown inputs never unlink. This intentionally deviates from the FE guard
+> candidate (the raw stored `baseRef` plus, when it differs, its known-remote-prefix-
+> stripped remainder); when several PRs match, the highest PR number wins. A stale link is
+> cleared only on a **positive mismatch**: the linked PR's head ref is known, at least one
+> of the workspace's `branch` / `baseRef` is known, and every known field fails to match —
+> unknown inputs never unlink. This intentionally deviates from the FE guard
 > (which only cleared a stale link when the workspace's own branch was present): a
 > branch-less workspace whose `baseRef` positively mismatches the linked PR's head **does**
 > unlink. Ineligible workspaces (remote, archived, without a repo, or — when no PR is

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -1086,10 +1086,24 @@ discovery/refresh the daemon's background sweep runs for one workspace, on deman
 
 > **`pr.refresh` semantics.** Unlike the rest of `pr.*`, `pr.refresh` does **not** require an
 > active PR — it exists to establish/repair the link. It runs the shared refresh path
-> (discovery by head branch, status update, stale-link clearing, relink-after-merge), so any
+> (discovery, status update, stale-link clearing, relink-after-merge), so any
 > resulting `pr:linked` / `pr:updated` / `pr:unlinked` events (§6.5) are emitted **once** by
-> that path — the RPC adds no duplicate emission. Ineligible workspaces (remote, archived,
-> without a repo, or without a branch) return `outcome: "skipped"` rather than erroring.
+> that path — the RPC adds no duplicate emission. The matching rule is **branch OR baseRef**:
+> a PR matches a workspace when its head ref equals the workspace's own `branch`, or when it
+> matches the workspace's `baseRef` (raw equality, plus the known-remote-prefix-stripped
+> remainder for legacy rows persisted before write-side canonicalisation — see `baseRef`
+> canonicalisation, §5.1), so review workspaces created *for* a PR link it via `baseRef`.
+> Discovery (and relink-after-merge) queries by the workspace's own branch head first —
+> branch match takes precedence — then falls back to one open-PR query per baseRef
+> candidate; when several PRs match, the highest PR number wins. A stale link is cleared
+> only on a **positive mismatch against both** branch and baseRef: the linked PR's head ref
+> is known, at least one of the workspace's `branch` / `baseRef` is known, and neither
+> matches — unknown inputs never unlink. This intentionally deviates from the FE guard
+> (which only cleared a stale link when the workspace's own branch was present): a
+> branch-less workspace whose `baseRef` positively mismatches the linked PR's head **does**
+> unlink. Ineligible workspaces (remote, archived, without a repo, or — when no PR is
+> linked — with neither a branch nor a baseRef) return `outcome: "skipped"` rather than
+> erroring.
 > Unlike the usual omitted-when-absent (`skip_serializing_if`) convention, `prNumber` /
 > `prUrl` / `prStatus` are always present and serialize as literal `null` when no PR is
 > linked after the refresh; `pullRequests` is always an array (possibly empty). An unknown


### PR DESCRIPTION
## Summary

Follow-up to intent-hq/intentd#461 (baseRef-aware PR-workspace matching, merged as `e4d6e5c`).

Closes #459

## Changes

### `docs/PROTOCOL.md`

Rewrites the `pr.refresh` semantics note (§5.7) to describe the shipped **branch-OR-baseRef** matching rule, verified against the merged intentd code (`intent-services/src/pr_ops.rs`, `lib.rs::refresh_workspace_pr_with_sc`):

- **Matching rule**: a PR matches a workspace when its head ref equals the workspace's own `branch` OR matches its `baseRef` (raw equality plus the known-remote-prefix-stripped remainder for legacy rows — cross-referenced to the §5.1 `baseRef` canonicalisation note), so review workspaces created *for* a PR link it via `baseRef`.
- **Discovery / relink-after-merge**: branch head-query first (branch match takes precedence), then one open-PR query per baseRef candidate; highest PR number wins.
- **Stale-link clearing**: only on a positive mismatch against **both** branch and baseRef; unknown inputs never unlink.
- **Intentional deviation** (intentd#461 reviewer request): unlike the FE guard, a branch-less workspace whose `baseRef` positively mismatches the linked PR's head **does** unlink.
- **Eligibility**: the "skipped" list updated — an unlinked workspace is skipped only when it has *neither* a branch *nor* a baseRef (previously "without a branch").

### `packages/intentd`

Bumps the gitlink `31fefb2` → `e4d6e5c` (`feat: baseRef-aware PR-workspace matching (intent-hq/monorepo#459)`), the merge commit of intent-hq/intentd#461.

## Verification

- `make check` — pass (fmt + clippy + build)
- `make test` — pass (full workspace)
