### PR TITLE
chore: update intentd submodule to latest main (script:output retention sweep)

### DIFF
--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -1235,7 +1235,7 @@ discovery/refresh the daemon's background sweep runs for one workspace, on deman
 These are **historical/aggregate read** helpers — distinct from live streaming (§6). Each requires`workspaceId`.
 
 > **Retention.** Persisted events are pruned by the daemon's retention loop: the high-volume
-> ephemeral families (`agent:stream:*`, `file:*`, `terminal:data`, `host:exec:*`) per the
+> ephemeral families (`agent:stream:*`, `file:*`, `terminal:data`, `script:output`, `host:exec:*`) per the
 > stream-retention window (`events.streamRetentionHours` setting, default **72h**; `0` disables
 > the sweep; `INTENTD_STREAM_RETENTION_HOURS` env override), and `agent:tool:call` rows on a
 > fixed **24h TTL**. Historical reads only see rows within these windows;


### PR DESCRIPTION
Phase 2 monorepo update for intent-hq/intentd#432.

- Bumps `packages/intentd` to latest intentd `main` (`f01ed6f`), which includes the `script:output` ephemeral-retention sweep fix from intent-hq/intentd#432.
- Updates the retention note in `docs/PROTOCOL.md` (§5.10) to list `script:output` alongside the other swept ephemeral families (`agent:stream:*`, `file:*`, `terminal:data`, `host:exec:*`).

Fixes #620
