### PR TITLE
fix: inherit hidden flag across specialist tiers

### DIFF
--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -1287,9 +1287,14 @@ resolved view; `create`/`edit` take a full `spec` body. Malformed params → `-3
 non-existent or `bundled` definition → `-32602`.
 
 - **SpecialistDef** — `{ id, name, description, modelTier?: "low"|"medium"|"high", prompt?,
-  source: "project"|"user"|"bundled", path? }`. On `list`/`get`, `source` is the **winning** tier
-  and `path?` the file it resolved from (omitted for `bundled`); on `create`/`edit` the body
-  carries the authored fields and `scope` chooses the target tier.
+  hidden?: boolean, source: "project"|"user"|"bundled", path? }`. On `list`/`get`, `source` is the
+  **winning** tier and `path?` the file it resolved from (omitted for `bundled`); on `create`/`edit`
+  the body carries the authored fields and `scope` chooses the target tier.
+- **`hidden?`** — optional boolean sourced from `hidden: true` in the specialist file's
+  frontmatter; emitted only when true (absent ⇒ not hidden) and round-tripped by
+  `create`/`edit`. Hidden specialists stay in `list`/`get` results — clients filter them out of
+  specialist pickers while keeping them visible on editing surfaces (e.g. Settings → AI
+  Behavior). The bundled `chief-of-staff` is flagged hidden.
 - The daemon watches the user (`~/.intent/specialists/`) and project
   (`<workspace>/.intent/specialists/`) tiers (using `notify` watchers, the same infrastructure as
   workspace `file:changed` events); when a specialist file is created/modified/deleted under a

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -1290,10 +1290,14 @@ non-existent or `bundled` definition → `-32602`.
   hidden?: boolean, source: "project"|"user"|"bundled", path? }`. On `list`/`get`, `source` is the
   **winning** tier and `path?` the file it resolved from (omitted for `bundled`); on `create`/`edit`
   the body carries the authored fields and `scope` chooses the target tier.
-- **`hidden?`** — optional boolean sourced from `hidden: true` in the specialist file's
-  frontmatter; emitted only when true (absent ⇒ not hidden) and round-tripped by
-  `create`/`edit`. On `create`/`edit` the spec's `hidden` is authoritative: omitting it (or
-  sending `hidden: false`) clears the flag — both are accepted and normalized to not-hidden.
+- **`hidden?`** — optional boolean sourced from `hidden:` in the specialist file's
+  frontmatter and **inherited across tiers**: a definition resolves `hidden: true` when any
+  lower tier (down to the embedded bundled floor) sets `hidden: true`, unless a higher tier
+  **explicitly** sets `hidden: false` — a file that omits the key inherits the lower tiers'
+  effective value. Emitted on `list`/`get` only when the resolved value is true (absent ⇒ not
+  hidden). On `create`/`edit` an explicit `hidden: true`/`false` is written verbatim and an
+  omitted `hidden` writes no key (the resolved value then inherits); explicit `hidden: false`
+  in a user/project file is the opt-out that unhides.
   Hidden specialists stay in `list`/`get` results — clients filter them out of
   specialist pickers while keeping them visible on editing surfaces (e.g. Settings → AI
   Behavior). The bundled `chief-of-staff` is flagged hidden.

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -1292,7 +1292,9 @@ non-existent or `bundled` definition → `-32602`.
   the body carries the authored fields and `scope` chooses the target tier.
 - **`hidden?`** — optional boolean sourced from `hidden: true` in the specialist file's
   frontmatter; emitted only when true (absent ⇒ not hidden) and round-tripped by
-  `create`/`edit`. Hidden specialists stay in `list`/`get` results — clients filter them out of
+  `create`/`edit`. On `create`/`edit` the spec's `hidden` is authoritative: omitting it (or
+  sending `hidden: false`) clears the flag — both are accepted and normalized to not-hidden.
+  Hidden specialists stay in `list`/`get` results — clients filter them out of
   specialist pickers while keeping them visible on editing surfaces (e.g. Settings → AI
   Behavior). The bundled `chief-of-staff` is flagged hidden.
 - The daemon watches the user (`~/.intent/specialists/`) and project


### PR DESCRIPTION
## Problem

Dogfooding surfaced a regression from the `hidden` specialist flag: hidden specialists (e.g. `chief-of-staff`) resurfaced in specialist listings. Specialist definitions merge across tiers (embedded → bundled dir → user → project) with winner-takes-all semantics, and pre-existing user-tier specialist files — written before the `hidden` key existed — omit the key, deserializing as `hidden: false` and silently overriding the lower tier's `hidden: true`. Any user who had ever customized a specialist that later became hidden saw it reappear.

## Changes

- Bumps the `packages/intentd` submodule to latest main, picking up intent-hq/intentd#480: `hidden` is now tri-state at the definition layer and **inherits across tiers** — an omitted key takes the effective value from the nearest lower tier that sets it, while an explicit `hidden: false` remains the deliberate opt-out to unhide. Wire contract unchanged (listings emit `hidden` only when the resolved value is true).
- Updates `docs/PROTOCOL.md` §5.11 to document the `hidden` flag, its inherit-on-omit semantics across tiers, and how it is unset on `specialist.create`/`edit`.
- Also carries routine cloudlands-fe and ios submodule bumps to latest main.

## Follow-up

Only `hidden` gets inherit-on-omit semantics; the other optional frontmatter scalars (`agentType`, `model`, `modelTier`, `roleReminder`, `codingAgent`) keep winner-takes-all, so the same stale-override hazard still applies to them. Tracked in #718.

Refs: intent-hq/intentd#480, #718

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author