### PR TITLE
chore: update intentd submodule for explicit reply-anchoring contract

### DIFF
--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -762,7 +762,7 @@ each recompute so the read path is O(1) and survives restart. `note.delete` casc
 | comment.add | noteId (req), searchContext (req), commentTarget (req), comment (req), type?, author?, authorType? ("user" \| "agent", default "agent"), idempotencyKey? | { success, message, commentId, anchored, noteRev, location: { line, anchoredText } } (anchors by text search). A replay with the same `(workspaceId, idempotencyKey)` returns the stored result without re-executing (no duplicate comment, no second `comment:added` / `note:updated`); empty/whitespace-only keys are treated as absent. |
 | comment.list | noteId (req), since?, authorType?, status?, includeComments? | { threads: [...] } |
 | comment.getThread | noteId (req), threadId? or commentId? | { thread } |
-| comment.respond | noteId (req), comment (req), threadId? or commentId?, type?, author?, authorType? ("user" \| "agent", default "agent"), suggestionOriginal?, suggestionProposed? | { ok, ... } |
+| comment.respond | noteId (req), comment (req), threadId? or commentId?, type?, author?, authorType? ("user" \| "agent", default "agent"), suggestionOriginal?, suggestionProposed? | { ok, ... } — the reply carries **no** `anchor`/`anchorText` (see "Reply anchoring" below) |
 | comment.delete | noteId (req), commentId (req) | { ok, ... } |
 
 **Anchor resilience on note edits (Audit D H1+M1).** `comment.add` embeds
@@ -822,6 +822,18 @@ other than `user`/`agent`, and a `status` other than `open`/`resolved`/
 caller-input errors and stay `-32603`: an unknown `commentId` ("Comment not
 found: …") or unknown `threadId` ("Thread not found: …") on
 `comment.getThread`/`comment.resolveThread` returns `-32603 Internal error`.
+
+**Reply anchoring (monorepo#729).** Only **root** comments carry an
+authoritative `anchor` / `anchorText`: `comment.add` embeds the anchor markers
+and persists the anchor on the root it creates. Replies created via
+`comment.respond` anchor through their thread — `threadId` / `parentId` — and
+never independently, so the persisted reply has no anchor and the wire
+`Comment` shape **omits** the `anchor` and `anchorText` keys (both fields are
+optional on the wire). Clients resolving a thread's position in the document
+must read the thread root's anchor (the FE's anchor reconciliation already
+does exactly this). Replies stored before this contract change may still carry
+a legacy clone of the parent's anchor; clients must treat any reply anchor as
+non-authoritative.
 
 **Thread resolution.** One additional method addresses an entire thread by `threadId` **or** `commentId`. Emits the `comment:resolved` event (§6.5).
 


### PR DESCRIPTION
Fixes intent-hq/monorepo#729

Bumps `packages/intentd` to intent-hq/intentd#496 (squash commit `8547359`), which makes the `comment.respond` reply-anchoring contract explicit:

- Only **root** comments carry an authoritative `anchor`/`anchorText`; replies anchor through their thread (`threadId`/`parentId`) and persist `anchor: None`.
- The wire `Comment` shape **omits** the `anchor` and `anchorText` keys on replies (both fields are now optional on the wire).
- Store decodes `anchor_json` as `Option` — legacy replies with cloned parent anchors still decode (non-authoritative); no migration needed.
- Legacy import stores no anchor when `markId` is absent.

Also documents the contract in `docs/PROTOCOL.md` §5.3: a new "Reply anchoring (monorepo#729)" section plus a note on the `comment.respond` row.

Submodule PR: intent-hq/intentd#496 (merged; reviewer verdict LGTM, CI green — fmt/clippy/test all clean).

Scope check: only `docs/PROTOCOL.md` and the `packages/intentd` gitlink change; `packages/cloudlands-fe` (`682bb1c4`) and `packages/ios` (`480957da`) are untouched from main.

Non-blocking FE follow-up (reviewer finding): `scanAnchorHealth` lacks a `parentId` guard and will flag anchorless replies `isOrphaned` (not user-visible today) — tracked separately in intent-hq/monorepo#749.
