### PR TITLE
docs: document automatic auto_vacuum activation at daemon startup (#720)

### DIFF
--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -1257,9 +1257,10 @@ These are **historical/aggregate read** helpers — distinct from live streaming
 > fixed **24h TTL**. Historical reads only see rows within these windows;
 > lifecycle/note/task/workspace events are not swept. The loop also reclaims freed pages via
 > bounded `PRAGMA incremental_vacuum` on incremental-auto-vacuum databases. Legacy databases
-> created with `auto_vacuum=NONE` are converted automatically: at daemon startup a one-time
-> `VACUUM` switches them to `auto_vacuum=INCREMENTAL`, so space reclamation applies to all
-> databases.
+> created with `auto_vacuum=NONE` are converted automatically: the daemon's write connection
+> sets `PRAGMA auto_vacuum=INCREMENTAL` at connect (inert on an existing NONE-mode file by
+> itself), and a one-time `VACUUM` at daemon startup rebuilds the file to apply it, so space
+> reclamation applies to all databases.
 
 | Method | Params | Result |
 | --- | --- | --- |

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -1256,7 +1256,10 @@ These are **historical/aggregate read** helpers — distinct from live streaming
 > the sweep; `INTENTD_STREAM_RETENTION_HOURS` env override), and `agent:tool:call` rows on a
 > fixed **24h TTL**. Historical reads only see rows within these windows;
 > lifecycle/note/task/workspace events are not swept. The loop also reclaims freed pages via
-> bounded `PRAGMA incremental_vacuum` on incremental-auto-vacuum databases.
+> bounded `PRAGMA incremental_vacuum` on incremental-auto-vacuum databases. Legacy databases
+> created with `auto_vacuum=NONE` are converted automatically: at daemon startup a one-time
+> `VACUUM` switches them to `auto_vacuum=INCREMENTAL`, so space reclamation applies to all
+> databases.
 
 | Method | Params | Result |
 | --- | --- | --- |


### PR DESCRIPTION
Closes #720 — both findings are now resolved:

- **Finding 2** (`line-attribution:updated` persisted to the event table) was fixed by intent-hq/intentd#488 and documented via #739 (already merged).
- **Finding 1** (legacy `auto_vacuum=NONE` databases never reclaim space) was fixed by intent-hq/intentd#500, which auto-activates incremental auto_vacuum via a one-time `VACUUM` at daemon startup. The intentd gitlink on main already includes that commit (`a37a0c4`, via #751).

## Changes

- **docs/PROTOCOL.md** — the §5.10 event-retention note previously scoped space reclamation to "incremental-auto-vacuum databases". It now states that legacy `auto_vacuum=NONE` databases are converted automatically by a one-time `VACUUM` at daemon startup, so space reclamation applies to all databases.
- `docs/ARCHITECTURE.md` does not describe the auto_vacuum/retention story, so it is untouched.
- No submodule bump needed: main's `packages/intentd` gitlink already contains intentd#500.

## Verification

- `make check` (cargo fmt --check, clippy -D warnings, build) — pass
- `make test` — pass (exit 0)

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author
