### PR TITLE
chore: add cargo-sweep make targets (sweep, sweep-all)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,9 @@ SUBMODULES = $(INTENTD_DIR) $(FE_DIR) $(IOS_DIR)
 DEV_DATA_DIR ?= $(CURDIR)/.dev/intentd
 DEV_TCP_PORT ?= 5181
 DEV_PORT ?= 5190
+# Export DEV_PORT so `make run-fe` (and any recipe that shells out to the FE)
+# actually sees the default/override in the child environment.
+export DEV_PORT
 
 # Build-artifact GC (cargo-sweep). Rust target/ dirs grow without bound as
 # deps and toolchains churn; `sweep` prunes artifacts older than SWEEP_DAYS
@@ -61,9 +64,6 @@ DEV_PORT ?= 5190
 # or `make sweep-all WORKSPACES_DIR=/elsewhere/workspaces`.
 WORKSPACES_DIR ?= $(HOME)/intent/workspaces
 SWEEP_DAYS ?= 3
-# Export DEV_PORT so `make run-fe` (and any recipe that shells out to the FE)
-# actually sees the default/override in the child environment.
-export DEV_PORT
 
 .PHONY: all help ensure-submodules ensure-intentd-submodule ensure-fe-submodule ensure-ios-submodule \
 	build build-intentd build-sidecar test test-intentd fmt clippy check clean clean-dev \
@@ -139,12 +139,19 @@ clean: ## Remove cargo build artifacts (packages/intentd/target)
 clean-dev: ## Wipe the dev-seat state dir (.dev/)
 	rm -rf "$(CURDIR)/.dev"
 
+# `sweep` deliberately has no ensure-intentd-submodule prerequisite:
+# initializing the submodule just to sweep a target/ dir that cannot exist yet
+# would be overkill, so it short-circuits with a friendly no-op instead.
 sweep: ## Prune intentd build artifacts older than $(SWEEP_DAYS) days (needs cargo-sweep)
 	@command -v cargo-sweep >/dev/null 2>&1 || { \
 		echo "[sweep] ERROR: cargo-sweep is not installed — run 'cargo install cargo-sweep'"; \
 		exit 1; \
 	}
-	cd $(INTENTD_DIR) && cargo sweep --time $(SWEEP_DAYS)
+	@if [ -d "$(INTENTD_DIR)/target" ]; then \
+		cd $(INTENTD_DIR) && cargo sweep --time $(SWEEP_DAYS); \
+	else \
+		echo "[sweep] nothing to sweep — $(INTENTD_DIR)/target does not exist"; \
+	fi
 
 sweep-all: ## Sweep intentd build artifacts in every worktree under $(WORKSPACES_DIR)
 	@command -v cargo-sweep >/dev/null 2>&1 || { \
@@ -152,6 +159,7 @@ sweep-all: ## Sweep intentd build artifacts in every worktree under $(WORKSPACES
 		exit 1; \
 	}
 	@for dir in $(WORKSPACES_DIR)/*/monorepo/$(INTENTD_DIR); do \
+		[ -d "$$dir" ] || continue; \
 		if [ -d "$$dir/target" ]; then \
 			echo "[sweep-all] sweeping $$dir"; \
 			(cd "$$dir" && cargo sweep --time $(SWEEP_DAYS)) \

--- a/Makefile
+++ b/Makefile
@@ -51,13 +51,23 @@ SUBMODULES = $(INTENTD_DIR) $(FE_DIR) $(IOS_DIR)
 DEV_DATA_DIR ?= $(CURDIR)/.dev/intentd
 DEV_TCP_PORT ?= 5181
 DEV_PORT ?= 5190
+
+# Build-artifact GC (cargo-sweep). Rust target/ dirs grow without bound as
+# deps and toolchains churn; `sweep` prunes artifacts older than SWEEP_DAYS
+# days in this worktree's intentd, and `sweep-all` does the same across every
+# sibling worktree under WORKSPACES_DIR (the per-worktree monorepo checkouts
+# live at $(WORKSPACES_DIR)/<name>/monorepo). Both need cargo-sweep
+# (`cargo install cargo-sweep`). Overridable, e.g. `make sweep SWEEP_DAYS=7`
+# or `make sweep-all WORKSPACES_DIR=/elsewhere/workspaces`.
+WORKSPACES_DIR ?= $(HOME)/intent/workspaces
+SWEEP_DAYS ?= 3
 # Export DEV_PORT so `make run-fe` (and any recipe that shells out to the FE)
 # actually sees the default/override in the child environment.
 export DEV_PORT
 
 .PHONY: all help ensure-submodules ensure-intentd-submodule ensure-fe-submodule ensure-ios-submodule \
 	build build-intentd build-sidecar test test-intentd fmt clippy check clean clean-dev \
-	dev-daemon release-daemon run-intentd run-fe dev ios-open ios-info
+	sweep sweep-all dev-daemon release-daemon run-intentd run-fe dev ios-open ios-info
 
 all: build
 
@@ -128,6 +138,28 @@ clean: ## Remove cargo build artifacts (packages/intentd/target)
 
 clean-dev: ## Wipe the dev-seat state dir (.dev/)
 	rm -rf "$(CURDIR)/.dev"
+
+sweep: ## Prune intentd build artifacts older than $(SWEEP_DAYS) days (needs cargo-sweep)
+	@command -v cargo-sweep >/dev/null 2>&1 || { \
+		echo "[sweep] ERROR: cargo-sweep is not installed — run 'cargo install cargo-sweep'"; \
+		exit 1; \
+	}
+	cd $(INTENTD_DIR) && cargo sweep --time $(SWEEP_DAYS)
+
+sweep-all: ## Sweep intentd build artifacts in every worktree under $(WORKSPACES_DIR)
+	@command -v cargo-sweep >/dev/null 2>&1 || { \
+		echo "[sweep-all] ERROR: cargo-sweep is not installed — run 'cargo install cargo-sweep'"; \
+		exit 1; \
+	}
+	@for dir in $(WORKSPACES_DIR)/*/monorepo/$(INTENTD_DIR); do \
+		if [ -d "$$dir/target" ]; then \
+			echo "[sweep-all] sweeping $$dir"; \
+			(cd "$$dir" && cargo sweep --time $(SWEEP_DAYS)) \
+				|| echo "[sweep-all] WARNING: sweep failed in $$dir — continuing"; \
+		else \
+			echo "[sweep-all] skipping $$dir (no target/ dir)"; \
+		fi; \
+	done
 
 dev-daemon: ensure-intentd-submodule ## Dev seat: intentd on isolated data dir, UDS + insecure TCP on $(DEV_TCP_PORT)
 	@mkdir -p "$(DEV_DATA_DIR)"


### PR DESCRIPTION
Adds build-artifact GC targets to the monorepo-root Makefile so stale `target/` artifacts can be pruned regularly.

## Changes
- `make sweep` — runs `cargo sweep --time $(SWEEP_DAYS)` (default 3 days) in `$(INTENTD_DIR)`; fails with a clear message suggesting `cargo install cargo-sweep` when the tool is missing.
- `make sweep-all` — iterates `$(WORKSPACES_DIR)/*/monorepo/packages/intentd` (default `WORKSPACES_DIR ?= $(HOME)/intent/workspaces`, overridable) and sweeps each worktree that has a `target/` dir, skipping missing/uninitialized ones gracefully and continuing past per-worktree failures.
- Both targets added to `.PHONY` with `## description` comments so `make help` lists them; `SWEEP_DAYS` and `WORKSPACES_DIR` are overridable vars in the existing Makefile style.

## Verification
- `make help | grep sweep` lists both targets.
- `make sweep` runs in the current worktree (exits 0; this worktree's `target/` was already removed by a separate cleanup, so cargo-sweep prints its own warning).
- `make sweep-all` iterated 13 sibling worktrees: swept 8 with `target/` dirs, skipped 5 without, exit 0.
- Missing-tool path verified by inspection (`command -v cargo-sweep` guard).

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author