### PR TITLE
chore: bump intentd for token-usage recreate baseline; document in PROTOCOL.md

### DIFF
--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -2146,7 +2146,14 @@ of each prompt turn, the `PromptResponse.usage` report (via the agent-client-pro
 daemon persists that snapshot per session with **REPLACE semantics** (each report replaces the
 session's previous snapshot — reports are never summed), mapping ACP `cachedReadTokens` →
 `cacheReadTokens` and `cachedWriteTokens` → `cacheCreationTokens`, then immediately re-aggregates
-per agent and per model and writes the durable `tokenUsage` field on the `Workspace`. A
+per agent and per model and writes the durable `tokenUsage` field on the `Workspace`.
+**Usage survives ACP session recreation:** when the resume-impossible fallback swaps in a fresh
+ACP session id (a failed `session/load` → `session/new` recreate), the outgoing session's
+cumulative snapshot is folded into a daemon-internal per-agent **baseline** (saturating sum) and
+the snapshot is cleared, atomically with the id swap — the recreated session's cumulative reports
+restart from zero, so per-agent effective totals are **baseline + snapshot**. The baseline is
+internal accounting only (never on the wire; `TokenUsage` shapes are unchanged), and the legacy
+per-message **message-sum fallback** applies only when both baseline and snapshot are absent. A
 daemon-internal periodic **scan** (300 s cadence) is demoted to a **reconciliation fallback** for
 sessions the live path cannot see (providers without end-of-turn usage reports / legacy
 per-message metadata); a reconciliation recount that comes back all-zero **never regresses** a


### PR DESCRIPTION
Phase 2 of the token-usage recreate-baseline fix. Closes #737.

## Changes

- **Bump `packages/intentd`** to `00238ad` — squash of [intent-hq/intentd#506](https://github.com/intent-hq/intentd/pull/506) (`fix: preserve token-usage across ACP session recreate (monorepo#737)`):
  - New nullable `agent_session.token_usage_baseline` column (migration 0054).
  - `replace_acp_session_id` folds the outgoing session's cumulative `token_usage` snapshot into the baseline (component-wise saturating sum) and clears the snapshot, atomically with the CAS id swap; the CAS predicate is re-checked inside the write transaction so a racing swap loses cleanly.
  - Per-agent effective totals = baseline + snapshot; the legacy message-sum fallback applies only when both are absent.
- **`docs/PROTOCOL.md` §5.23**: document that usage survives ACP session recreation via the internal baseline fold (baseline is internal accounting only — `TokenUsage` wire shapes unchanged), per the intentd#506 review follow-up.

`docs/ARCHITECTURE.md` checked — its only token-usage mention is the `services::token_usage` module listing, which is still accurate.

## Verification

At the bumped gitlink: `make check` and `make test` both pass (fmt, clippy `-D warnings`, full test suite).
