### PR TITLE
docs: note detached turn-end token-usage bookkeeping in PROTOCOL §5.23

### DIFF
--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -2212,7 +2212,11 @@ of each prompt turn, the `PromptResponse.usage` report (via the agent-client-pro
 daemon persists that snapshot per session with **REPLACE semantics** (each report replaces the
 session's previous snapshot — reports are never summed), mapping ACP `cachedReadTokens` →
 `cacheReadTokens` and `cachedWriteTokens` → `cacheCreationTokens`, then immediately re-aggregates
-per agent and per model and writes the durable `tokenUsage` field on the `Workspace`.
+per agent and per model and writes the durable `tokenUsage` field on the `Workspace`. The
+turn-end bookkeeping is **detached** from the turn itself — it never delays the terminal
+`agent:stream:end`, and bookkeeping for the same agent is ordered across turns — so a client
+reading `workspace.getTokenUsage` immediately after `agent:stream:end` may briefly see the
+previous tally; rely on `workspace:tokenUsage-changed` (§6.5) to observe the update.
 **Usage survives ACP session recreation:** when the resume-impossible fallback swaps in a fresh
 ACP session id (a failed `session/load` → `session/new` recreate), the outgoing session's
 cumulative snapshot is folded into a daemon-internal per-agent **baseline** (saturating sum) and


### PR DESCRIPTION
Closes #738

**Scope note**: this PR was originally the submodule bump for intent-hq/intentd#524, but #791 landed first and already moved `packages/intentd` to `298e6e1` (which contains #524). The branch has been rebased onto `main`; what remains is the documentation follow-up for the hardening.

## What #524 shipped (fix: harden token-usage recompute — merged as `c9f5846`, on main via #791)

- **Scoped workspace write**: `update_workspace_token_usage` updates only `token_usage` + `updated_at` instead of rewriting the full workspace row, eliminating cross-field clobbering of concurrent workspace mutations.
- **Transactional recompute**: the read-tally-compare-write recompute runs in a single `BEGIN IMMEDIATE` transaction on the write pool (with `commit_with_rollback_guard`), so concurrent turn-end updates and reconciliation scans serialize instead of racing.
- **Hydration skip**: `agent_message` content hydration is skipped for sessions with a snapshot/baseline (the common case), reducing write-lock hold time.
- **Detached, per-agent-ordered bookkeeping**: turn-end usage persistence runs in a spawned task so `agent:stream:end` is never delayed; tasks for the same agent are chained via a per-agent `JoinHandle` map so cross-turn ordering is preserved (stats deltas can't double-count; an older snapshot can't overwrite a newer one). Regression-tested (verified failing without the chain).

## This PR: docs

`docs/PROTOCOL.md` §5.23 gains a note that turn-end token-usage bookkeeping is detached from the turn — a `workspace.getTokenUsage` read immediately after `agent:stream:end` may briefly see the previous tally; clients should rely on `workspace:tokenUsage-changed`. The rest of §5.23 (REPLACE semantics, baseline folding, racing-sweep guard), §6.5's `workspace:tokenUsage-changed` row, and `docs/ARCHITECTURE.md` remain accurate — no other doc changes needed.

## Verification

`make check` and `make test` green at the current gitlink (`298e6e1`) — 148 suites, 0 failures. Along the way the `main` test breakage #790 was found and fixed (intent-hq/intentd#529; my equivalent #528 closed as superseded).

**Deferred (not in this PR)**: #783 tracks applying the same detached/ordered pattern to `write_acp_session_id`'s baseline fold.
