### PR TITLE
chore: bump intentd for CoW-to-worktree fallback; update protocol/architecture docs

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -117,9 +117,12 @@ Wire contract: PROTOCOL.md §5.1 (`checkoutMode`, `cowSupported`), §5.5/§5.5a
   (`intent_git::worktree::provision_worktree`); on ⇒ CoW reflink probe from the
   repository directory into the workspace dir (`intent_git::cow_probe(&repo_dir,
   &ws_dir)`), then a standalone clone of the whole repository directory
-  (`intent_git::cow_checkout::provision_cow_checkout`), failing loudly when the
-  filesystem is unsupported (no silent worktree fallback; the separate root→root
-  probe backing the `cowSupported` aggregate is advisory only). Both paths run under the
+  (`intent_git::cow_checkout::provision_cow_checkout`). When the probe reports
+  Unsupported (or errors) — e.g. the repository lives on a different volume than
+  the workspaces root, since reflinks cannot cross filesystems — provisioning
+  logs a warning and falls back to the linked-worktree path (the setting is a
+  preference, not a guarantee; the separate root→root probe backing the
+  `cowSupported` aggregate is advisory only). Both paths run under the
   per-repository worktree lock. `workspace.duplicate` applies the same matrix when
   provisioning the copy's checkout. The setting is consulted **only** at
   provisioning time; the persisted `checkoutMode` is immutable per workspace.

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -452,10 +452,11 @@ directory (OS reflink primitives — macOS `copyfile(COPYFILE_CLONE)`, Linux
 (`node_modules`, `target`, …) into the checkout for free; inside the clone the workspace
 `branch` is created + checked out from the same `baseRef` resolution order as above,
 tracked files are hard-reset to that base, untracked files are preserved, and the row
-persists `checkoutMode: "cow"`. When the probe reports Unsupported (or errors), the
-create **fails** with `-32603` ("CoW isolation is enabled but the filesystem does not
-support CoW cloning — disable workspace.cowIsolation or move the workspaces root to a
-supported filesystem") — there is **no silent fallback to a worktree checkout**. Because
+persists `checkoutMode: "cow"`. When the probe reports Unsupported (or errors) — e.g.
+the repository lives on a different volume than the workspaces root, since reflinks
+cannot cross filesystems — the create **falls back to the linked-worktree path**
+(`checkoutMode: "worktree"`, normal worktree provisioning) with a logged warning
+instead of failing: `workspace.cowIsolation` is a preference, not a guarantee. Because
 a CoW checkout is a standalone clone, `workspace.delete`'s git-metadata phase skips the
 worktree-registration prune and the source-repo branch-delete guard (the workspace
 branch lives only inside the clone); the checkout is still renamed to a trash path and
@@ -467,12 +468,12 @@ branch named for the new id (uniquified against the source repo's local and
 remote-tracking branches), using the **same decision matrix as `workspace.create`**:
 `workspace.cowIsolation` off ⇒ linked worktree (`checkoutMode: "worktree"`); on ⇒ CoW
 probe from the repository directory to `<root>/<newId>` — supported ⇒ standalone CoW
-clone (`checkoutMode: "cow"`), Unsupported/probe error ⇒ the duplicate **fails** with
-the same `-32603` message as create (**no silent worktree fallback**). Provisioning is
-skipped for remote / skip-isolation sources and for a `repositoryPath` that is not a
-local git repository. Unlike the fail-loud CoW probe, an ordinary provisioning failure
-is logged and swallowed (FE parity — "continue without worktree"): the row persists
-without `worktreePath`/`checkoutMode`.
+clone (`checkoutMode: "cow"`), Unsupported/probe error ⇒ the duplicate **falls back to
+a linked worktree** with a logged warning (same fallback semantics as create).
+Provisioning is skipped for remote / skip-isolation sources and for a `repositoryPath`
+that is not a local git repository. An ordinary provisioning failure is logged and
+swallowed (FE parity — "continue without worktree"): the row persists without
+`worktreePath`/`checkoutMode`.
 
 **`checkoutMode` is immutable.** `workspace.cowIsolation` is consulted **only** at
 provisioning time (`workspace.create` / `workspace.duplicate`); the resulting
@@ -613,9 +614,10 @@ list/get poll). It reports the machine's capability independent of how the speci
 workspace was provisioned; the FE gates the `workspace.cowIsolation` opt-in toggle
 (§5.12) on it. **Caveat — root-scoped, not repo-scoped:** provisioning probes from the
 *repository directory* into the workspaces root (§5.1), so a repository on a different
-filesystem than the workspaces root (reflinks cannot cross filesystems) can still fail
-`workspace.create` with the fail-loud `-32603` even when `cowSupported` is `true`;
-`cowSupported` is a toggle-gating advisory, not a per-repository guarantee.
+filesystem than the workspaces root (reflinks cannot cross filesystems) can still land
+`workspace.create` on the worktree-fallback path (`checkoutMode: "worktree"`, §5.1)
+even when `cowSupported` is `true`; `cowSupported` is a toggle-gating advisory, not a
+per-repository guarantee.
 `checkoutMode` (`"worktree" | "cow"`, lowercase on the wire) records how
 `workspace.create` provisioned this workspace's checkout (§5.1) and is omitted for rows
 without a daemon-provisioned checkout (skip-isolation/direct, remote, caller-supplied


### PR DESCRIPTION
Bumps `packages/intentd` to latest main for intent-hq/intentd#540 and updates the wire-contract docs to match.

## Submodule change (intent-hq/intentd#540)

- **`cowSupported` capability fix**: `compute_cow_supported` now resolves the workspaces root via `default_workspaces_root()` when none is injected, so production daemons (which never call `.with_workspaces_root()`) actually report the capability and the FE CoW toggle can appear.
- **CoW→worktree creation fallback**: `workspace.create` / `workspace.duplicate` with `workspace.cowIsolation` ON now fall back to the linked-worktree path (`checkoutMode: "worktree"`) with a logged warning when the repo→workspaces-root CoW probe reports Unsupported or errors, instead of failing with `-32603`. The setting is a preference, not a guarantee (reflinks cannot cross volumes, and the repository can live on any filesystem).

## Docs

- **PROTOCOL.md §5.1**: create/duplicate fallback semantics replace the fail-loud `-32603` contract; the `cowSupported` root-scoped caveat now describes landing on the worktree-fallback path.
- **ARCHITECTURE.md**: provisioning decision matrix updated for the fallback.

## FE audit

cloudlands-fe carries no fail-loud copy (the toggle gates on `cowSupported` only; `isolation-mode.ts` already treats unknown capability as worktree), so no FE change is needed.
