### PR TITLE
docs: PROTOCOL §5.3 documents Round 15 comment semantics (intentd#541)

### DIFF
--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -849,6 +849,33 @@ markers scrubbed from the persisted content and the comment is flipped to
 `isOrphaned: bool` field (omitted when unset, `true` for orphaned comments,
 `false` explicitly when a previously-orphaned comment heals).
 
+**Overlapping ranges + phantom-marker scrub (intentd#541).** Overlapping
+comment ranges are allowed: a `comment.add` target span may contain other
+comments' `<!--anchor:…-->` markers, producing interleaved pairs
+(`a:start … b:start … a:end … b:end`) that are valid note content — each
+comment's own id still pins its markers, and interleaved anchors stay
+healthy. The add embeds the raw span (contained markers intact, in place)
+back between the new pair, while the STORED `anchorText` / `anchorBefore` /
+`anchorAfter` fields are stripped of all `<!--anchor:…-->` substrings —
+markers are stripped from the full prefix/suffix before the 50-character
+context window is taken, so a marker adjacent to the span cannot leak a
+clipped fragment — and raw marker text never appears in comment rows. The
+recovery pass additionally scrubs **phantom markers**: after the per-comment
+classification above, any UUID-format marker whose id has no live
+(non-orphaned) comment row — an id with no comment row at all, or markers
+left behind by a row already flagged `isOrphaned` — is removed from the
+persisted content, so a polluted note self-heals on its next content-changing
+`note.*` mutation. `comment.add` runs the same scrub on the fetched note
+content before matching, so phantom debris can never block a new comment; the
+cleaned content persists only as part of the add's atomic note rewrite (a
+failed add changes nothing — no separate rev bump). Non-UUID
+marker-lookalikes (documentation literals such as
+`<!--anchor:{id}:start-->`) are ordinary user content: commentable, and never
+scrubbed. This is also why a client-supplied `commentId` must be a
+**canonical hyphenated** UUID — the scrub only recognizes canonical ids
+inside markers, so a looser spelling would mint markers the recovery pass
+could never classify or clean up.
+
 **Note rewrite visibility (monorepo#638).** Because `comment.add` rewrites the
 note markdown (anchor-marker insertion is an `update_note` that bumps the
 note's `rev`), the result echoes the authoritative post-rewrite revision as

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -828,7 +828,7 @@ each recompute so the read path is O(1) and survives restart. `note.delete` casc
 
 | Method | Params | Result |
 | --- | --- | --- |
-| comment.add | noteId (req), searchContext (req), commentTarget (req), comment (req), type?, author?, authorType? ("user" \| "agent", default "agent"), idempotencyKey?, commentId? (UUID) | { success, message, commentId, anchored, noteRev, location: { line, anchoredText } } (anchors by text search). A replay with the same `(workspaceId, idempotencyKey)` returns the stored result without re-executing (no duplicate comment, no second `comment:added` / `note:updated`); empty/whitespace-only keys are treated as absent. When `commentId` is supplied, the daemon uses it as the canonical id — comment row, `threadId`, anchor `startId`/`endId`, and the embedded `<!--anchor:{id}:start/end-->` markers — instead of minting a fresh UUID, so a client that already inserted optimistic editor anchors under that id converges with the daemon's note rewrite. A non-UUID value or a collision with an existing comment id is rejected with `-32602` InvalidParams (after the idempotency replay check, which still returns the cached result first). Omitting it keeps the mint-a-UUID behavior. |
+| comment.add | noteId (req), searchContext (req), commentTarget (req), comment (req), type?, author?, authorType? ("user" \| "agent", default "agent"), idempotencyKey?, commentId? (UUID) | { success, message, commentId, anchored, noteRev, location: { line, anchoredText } } (anchors by text search). A replay with the same `(workspaceId, idempotencyKey)` returns the stored result without re-executing (no duplicate comment, no second `comment:added` / `note:updated`); empty/whitespace-only keys are treated as absent. When `commentId` is supplied, the daemon uses it as the canonical id — comment row, `threadId`, anchor `startId`/`endId`, and the embedded `<!--anchor:{id}:start/end-->` markers — instead of minting a fresh UUID, so a client that already inserted optimistic editor anchors under that id converges with the daemon's note rewrite. A non-canonical-UUID value (only the hyphenated 8-4-4-4-12 form is accepted; e.g. the 32-hex simple form is rejected) or a collision with an existing comment id is rejected with `-32602` InvalidParams (after the idempotency replay check, which still returns the cached result first). Omitting it keeps the mint-a-UUID behavior. |
 | comment.list | noteId (req), since?, authorType?, status?, includeComments? | { threads: [...] } |
 | comment.getThread | noteId (req), threadId? or commentId? | { thread } |
 | comment.respond | noteId (req), comment (req), threadId? or commentId?, type?, author?, authorType? ("user" \| "agent", default "agent"), suggestionOriginal?, suggestionProposed? | { ok, ... } — the reply carries **no** `anchor`/`anchorText` (see "Reply anchoring" below) |
@@ -872,9 +872,9 @@ failed add changes nothing — no separate rev bump). Non-UUID
 marker-lookalikes (documentation literals such as
 `<!--anchor:{id}:start-->`) are ordinary user content: commentable, and never
 scrubbed. This is also why a client-supplied `commentId` must be a
-**canonical hyphenated** UUID — the scrub only recognizes canonical ids
-inside markers, so a looser spelling would mint markers the recovery pass
-could never classify or clean up.
+**canonical hyphenated** UUID — the phantom scrub only recognizes canonical
+ids inside markers, so a looser spelling would mint markers the scrub could
+never recognize or clean up once the comment row is gone.
 
 **Note rewrite visibility (monorepo#638).** Because `comment.add` rewrites the
 note markdown (anchor-marker insertion is an `update_note` that bumps the


### PR DESCRIPTION
Docs-only follow-up closing the doc drift flagged by the Round 15 verifier: PROTOCOL.md §5.3 did not yet describe the comment-anchoring semantics that landed in intent-hq/intentd#541 (merged as intentd `7f46466`, pulled into this repo via #808).

## What changed

Adds one paragraph to §5.3 (“Overlapping ranges + phantom-marker scrub (intentd#541)”) documenting the current daemon behavior:

- **Overlap acceptance** — a `comment.add` target span may contain other comments' `<!--anchor:…-->` markers; interleaved pairs (`a:start … b:start … a:end … b:end`) are valid content and stay healthy (the overlap rejection in `find_and_anchor_text` was removed).
- **Phantom scrub in the recovery pass** — after per-comment classification, `reanchor_note_comments` scrubs UUID-format markers whose id has no live (non-orphaned) comment row (phantom debris and stale-orphan debris alike, per `live_comment_ids`), so polluted notes self-heal on the next content-changing `note.*` mutation.
- **`comment.add` pre-scrub** — the same scrub runs on the fetched note content before matching, so phantom debris can no longer block a new comment; the cleaned content persists only as part of the add's atomic rewrite.
- **Stored-field stripping** — `anchorText` / `anchorBefore` / `anchorAfter` are stripped of all marker substrings via `strip_anchor_marker_text`, with markers stripped from the full prefix/suffix before the 50-char context window is taken (the PR #541 review fix).
- **Doc-literal exemption** — non-UUID marker-lookalikes (e.g. the literal `<!--anchor:{id}:start-->`) are ordinary user content: commentable, never scrubbed; this also motivates the canonical-hyphenated-UUID requirement on client-supplied `commentId`.

## References

- Implementation: intent-hq/intentd#541
- Submodule bump that brought it into this repo: #808
- Wording checked against `crates/intent-services/src/note_ops.rs` (`scrub_phantom_anchor_markers`, `strip_anchor_marker_text`, `find_and_anchor_text`) and `crates/intent-services/src/lib.rs` (`reanchor_note_comments`, `live_comment_ids`, the `comment.add` pre-scrub) at `7f46466`.

No code changes; `packages/intentd` gitlink untouched.
