### PR TITLE
chore: update intentd submodule for channel pin + in-place restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Update checks run only for `intentd serve` (at startup and every 12–24
 hours); one-shot subcommands (e.g. `intentd doctor`) run the installed
 daemon as-is and fail fast with guidance if none is installed yet. The
 sitter tracks the stable channel by default; `intentd sitter channel beta`
-durably pins beta in `<data-dir>/sitter/config.toml` (add `--redownload` to
+durably pins beta in `<data_dir>/sitter/config.toml` (add `--redownload` to
 install that channel's version immediately — also the downgrade path — then
 `intentd restart` to activate it in place). Per-launch `--sitter-channel` /
 `INTENTD_CHANNEL` overrides take precedence over the pin.

--- a/README.md
+++ b/README.md
@@ -29,8 +29,11 @@ Releases, forwards all CLI arguments to it, and respawns it if it crashes.
 Update checks run only for `intentd serve` (at startup and every 12–24
 hours); one-shot subcommands (e.g. `intentd doctor`) run the installed
 daemon as-is and fail fast with guidance if none is installed yet. The
-sitter tracks the stable channel by default; pass `--sitter-channel beta`
-(or set `INTENTD_CHANNEL=beta`) to track beta.
+sitter tracks the stable channel by default; `intentd sitter channel beta`
+durably pins beta in `<data-dir>/sitter/config.toml` (add `--redownload` to
+install that channel's version immediately — also the downgrade path — then
+`intentd restart` to activate it in place). Per-launch `--sitter-channel` /
+`INTENTD_CHANNEL` overrides take precedence over the pin.
 
 ### Homebrew (macOS & Linux)
 


### PR DESCRIPTION
Bumps `packages/intentd` to `c28edc0` — the squash-merge of [intent-hq/intentd#545](https://github.com/intent-hq/intentd/pull/545) (persistent update-channel pin, `intentd sitter channel` command with `--redownload`, and in-place `intentd restart` via SIGHUP), which also picks up #544 (usage-stats wall-clock bucketing) already on main.

Also updates the monorepo README channels paragraph to document the new flow:

- `intentd sitter channel [stable|beta]` — durable channel pin in `<data_dir>/sitter/config.toml`; precedence flag > `INTENTD_CHANNEL` > config > stable.
- `intentd sitter channel beta --redownload && intentd restart` — switch and activate immediately with no service-manager involvement (explicit downgrade path included).

Submodule PR: intent-hq/intentd#545 (merged, CI green, review comments addressed).

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author