### PR TITLE
feat: GitHub repo-config detection for new workspaces

### DIFF
--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -2438,11 +2438,11 @@ are normalized to camelCase: `html_url → htmlUrl`, `created_at → createdAt`,
 **(req)** PR/issue number where applicable). Reads that paginate follow the uniform pagination
 contract: an optional `limit` (default **50**, max **200**) plus an opaque `nextToken` cursor echoed
 in the result (`nextToken: null` when there are no further pages). Errors reuse the §9 conventions:
-missing/invalid params and "not found" (404) lookups → `-32602`; a token that is absent or fails
-`GET /user`, and any other GitHub/service failure → `-32603` with a descriptive `message`
-(e.g. `"GitHub is not configured."`). There are **no** custom numeric codes. One documented
-exception to the 404→`-32602` rule: `github.repoConfig.get` folds every 404 (missing file, repo,
-or ref) into the success shape `{ config: null, exists: false }` — see the method row below.
+missing/invalid params and "not found" (404) lookups → `-32602` **unless a method row documents a
+graceful null/exists result** (e.g. `github.repos.get` → `{ repo: null }`, `github.repoConfig.get`
+→ `{ config: null, exists: false }`); a token that is absent or fails `GET /user`, and any other
+GitHub/service failure → `-32603` with a descriptive `message`
+(e.g. `"GitHub is not configured."`). There are **no** custom numeric codes.
 
 #### Repos & branches
 

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -2440,7 +2440,9 @@ contract: an optional `limit` (default **50**, max **200**) plus an opaque `next
 in the result (`nextToken: null` when there are no further pages). Errors reuse the §9 conventions:
 missing/invalid params and "not found" (404) lookups → `-32602`; a token that is absent or fails
 `GET /user`, and any other GitHub/service failure → `-32603` with a descriptive `message`
-(e.g. `"GitHub is not configured."`). There are **no** custom numeric codes.
+(e.g. `"GitHub is not configured."`). There are **no** custom numeric codes. One documented
+exception to the 404→`-32602` rule: `github.repoConfig.get` folds every 404 (missing file, repo,
+or ref) into the success shape `{ config: null, exists: false }` — see the method row below.
 
 #### Repos & branches
 
@@ -2450,7 +2452,7 @@ missing/invalid params and "not found" (404) lookups → `-32602`; a token that 
 | github.repos.search | query (req), limit?, nextToken? | { repos: GithubRepo[], nextToken? } — `GET /search/repositories` (FE rewrites `owner/name` → `name user:owner`, sorted by stars) |
 | github.repos.get | owner (req), repo (req) | { repo: GithubRepo \| null } — `GET /repos/{owner}/{repo}` (repo metadata incl. `defaultBranch`) |
 | github.branches.list | owner (req), repo (req), limit?, nextToken? | { branches: string[], nextToken? } — **remote** branch names (`GET /repos/{owner}/{repo}/branches`) |
-| github.repoConfig.get | owner (req), repo (req), ref? | { config: RepoConfig \| null, exists: boolean } — the repo's `.intent/config.json` fetched via the contents API (`GET /repos/{owner}/{repo}/contents/.intent/config.json`, no clone; `ref` defaults to the default branch). A missing file (or missing repo/ref) → `{ config: null, exists: false }`; a present but invalid/mis-shaped file folds **tolerantly** to `{ config: {}, exists: true }` (mirrors the `repoConfig.get` §5.33 parse semantics) — never an error. Same camelCase `RepoConfig` shape as §5.33, unknown keys preserved (v2.4) |
+| github.repoConfig.get | owner (req), repo (req), ref? | { config: RepoConfig \| null, exists: boolean } — the repo's `.intent/config.json` fetched via the contents API (`GET /repos/{owner}/{repo}/contents/.intent/config.json`, no clone; `ref` defaults to the default branch). A missing file (or missing repo/ref) → `{ config: null, exists: false }` — an **explicit exception** to the namespace's 404→`-32602` convention above: all 404s are graceful "no config" outcomes, never errors (transport/auth failures still surface as `-32603` like the other `github.*` methods). A present but invalid/mis-shaped file folds **tolerantly** to `{ config: {}, exists: true }` (mirrors the `repoConfig.get` §5.33 parse semantics). Same camelCase `RepoConfig` shape as §5.33, unknown keys preserved (v2.4) |
 
 #### Auth & identity
 

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -1,6 +1,6 @@
-# Intent Backend — JSON-RPC Protocol v2.3
+# Intent Backend — JSON-RPC Protocol v2.4
 
-**Protocol Version:** `2.3`
+**Protocol Version:** `2.4`
 
 This document is the canonical wire contract between Intent clients (desktop, iOS, CLI, and agent developers building clients) and the Intent backend daemon (`intentd`): transport, JSON-RPC envelope, the full method catalog, events, agent streaming, the permission flow, error codes, and thin-client guidance. It is a **living specification**: changes land through the compatibility policy below, and the method surface is enforced by golden tests in the `intent-transport` crate.
 
@@ -21,14 +21,14 @@ This document is the canonical wire contract between Intent clients (desktop, iO
 
 ## Protocol Version & Compatibility
 
-**Version:** `2.3`
+**Version:** `2.4`
 
-Version 2.1 was an **additive** minor bump over 2.0: it added the `pr.capabilities` router method and the provider capability gating described in §5.7. Version 2.2 is an **additive** minor bump over 2.1: it adds the `system.importLegacy` fast-path method (UDS-only — see the §5 fast-path catalog). Version 2.3 is an **additive** minor bump over 2.2: it adds the `system.capabilities` **router** method (available on both UDS and WSS — unlike the UDS-only `system.*` fast-path controls; see §5.1 and the fast-path notes). No existing method changed shape in any of these bumps.
+Version 2.1 was an **additive** minor bump over 2.0: it added the `pr.capabilities` router method and the provider capability gating described in §5.7. Version 2.2 is an **additive** minor bump over 2.1: it adds the `system.importLegacy` fast-path method (UDS-only — see the §5 fast-path catalog). Version 2.3 is an **additive** minor bump over 2.2: it adds the `system.capabilities` **router** method (available on both UDS and WSS — unlike the UDS-only `system.*` fast-path controls; see §5.1 and the fast-path notes). Version 2.4 is an **additive** minor bump over 2.3: it adds the `github.repoConfig.get` router method (§5.27) — a remote repository's `.intent/config.json` fetched via the GitHub contents API without a clone. No existing method changed shape in any of these bumps.
 
 The protocol version is advertised in two places:
 
-- `client.hello` response: `{ protocolVersion: "2.3", server: { protocolVersion: "2.3", ... }, ... }` — the top-level `protocolVersion` is an explicit copy of `server.protocolVersion` so clients can version-check without digging into the `server` block (§5.17).
-- `system.status` response: `{ protocolVersion: "2.3", ... }`
+- `client.hello` response: `{ protocolVersion: "2.4", server: { protocolVersion: "2.4", ... }, ... }` — the top-level `protocolVersion` is an explicit copy of `server.protocolVersion` so clients can version-check without digging into the `server` block (§5.17).
+- `system.status` response: `{ protocolVersion: "2.4", ... }`
 
 ### Compatibility Policy
 
@@ -153,22 +153,22 @@ Most methods operate within a workspace. `workspaceId` is read from `params.work
 
 ## 5. Method Catalog
 
-The API exposes **300 dispatchable method names** across the following categories:
+The API exposes **301 dispatchable method names** across the following categories:
 
-- **Router methods:** 265 methods dispatched via the main router (`router::dispatch`)
+- **Router methods:** 266 methods dispatched via the main router (`router::dispatch`)
 - **Fast-path methods:** 33 methods intercepted before the router for performance or per-connection state
 - **Method aliases:** 2 aliases accepted on the wire (`git.diff` → `git.diffs`, `git.log` → `git.commits`)
 
 Additionally, the protocol includes:
 
 - **Server→client notifications:** 1 notification (`events.event`, §6.3), plus the `subscription.push` frames of the snapshot+delta channels (§6.9)
-- **Client-served reverse RPCs:** 4 methods (dual-role, counted within the 300 dispatchable names: `browser.exec`, `host.openExternal`, `host.openInEditor`, `host.pickApplication` — see §5.9 and §5.14)
+- **Client-served reverse RPCs:** 4 methods (dual-role, counted within the 301 dispatchable names: `browser.exec`, `host.openExternal`, `host.openInEditor`, `host.pickApplication` — see §5.9 and §5.14)
 
-**Total:** 300 dispatchable names + 1 notification. The 4 reverse-RPC names are dual-role: they are dispatchable client→server methods AND are also issued daemon→client as reverse RPCs on remote connections.
+**Total:** 301 dispatchable names + 1 notification. The 4 reverse-RPC names are dual-role: they are dispatchable client→server methods AND are also issued daemon→client as reverse RPCs on remote connections.
 
 The method surface is enforced by the golden tests in `crates/intent-transport/src/catalog.rs`; the per-namespace subsections below (§5.1–§5.36) carry each method's parameter and result contract.
 
-### Router methods by namespace (265 total)
+### Router methods by namespace (266 total)
 
 | Namespace | Count | Methods |
 | --- | --- | --- |
@@ -178,7 +178,7 @@ The method surface is enforced by the golden tests in `crates/intent-transport/s
 | event | 5 | agentActivity, directoryChanges, query, recentFiles, workspaceSummary |
 | file | 9 | delete, exists, list, mkdir, read, rename, stat, tree, write |
 | git | 28 | agentCommit, branchDiff, branchStatus, changes, checkMergeConflicts, checkoutBranch, clone, commit, commitDetails, commits, createBranch, diffs, discard, fetch, getBranches, getConfig, getRemoteUrl, numstat, pull, push, removeLockFile, renameBranch, showFile, stage, stageHunk, status, unstage, unstageHunk |
-| github | 22 | authStatus, branches.list, cancelAuth, connect, getReviewThreads, getUser, issues.list, issues.search, listReviewComments, pulls.create, pulls.get, pulls.list, pulls.merge, pulls.search, pulls.updateBranch, replyReviewComment, repos.get, repos.list, repos.search, resolveThread, revoke, unresolveThread |
+| github | 23 | authStatus, branches.list, cancelAuth, connect, getReviewThreads, getUser, issues.list, issues.search, listReviewComments, pulls.create, pulls.get, pulls.list, pulls.merge, pulls.search, pulls.updateBranch, replyReviewComment, repoConfig.get, repos.get, repos.list, repos.search, resolveThread, revoke, unresolveThread |
 | linear | 11 | authStatus, createIssue, getIssue, listIssues, listLabels, listProjects, listTeams, listWorkflowStates, searchIssues, updateIssue, viewer |
 | mcp | 11 | oauth.delete, oauth.get, oauth.list, oauth.set, servers.create, servers.delete, servers.getStatus, servers.list, servers.restart, servers.toggle, servers.update |
 | metrics | 4 | clearAgentStats, getAgentStats, getAllWorkspaceStats, getWorkspaceStats |
@@ -1961,7 +1961,7 @@ bookkeeping and never crosses the wire.
 - **`server` block.** The result advertises daemon capabilities so a client can gate UI right
   after the handshake (mirrors `host.status`, §5.14): `locality` (`local` | `remote`),
   `hasDisplay` (GUI present on the daemon host), `osArch` (e.g. `darwin/arm64`), `version`
-  (daemon version string), `protocolVersion` (the JSON-RPC surface version, `"2.3"`), and
+  (daemon version string), `protocolVersion` (the JSON-RPC surface version, `"2.4"`), and
   `capabilities` (feature-detection flags, e.g. `{ "liveState": true }` for the snapshot+delta
   channels of §6.9).
 - **`protocolVersion`.** The top-level `protocolVersion` is an explicit copy of
@@ -1973,18 +1973,18 @@ bookkeeping and never crosses the wire.
 { "jsonrpc":"2.0","id":1,"method":"client.hello",
   "params":{ "clientId":"cli-7f3a","name":"Intent Desktop","capabilities":{ "forward":true,"openExternal":true } } }
 // ← response — capabilities of the daemon host
-{ "jsonrpc":"2.0","id":1,"result":{ "clientId":"cli-7f3a","protocolVersion":"2.3",
+{ "jsonrpc":"2.0","id":1,"result":{ "clientId":"cli-7f3a","protocolVersion":"2.4",
   "server":{ "locality":"remote","hasDisplay":false,"osArch":"linux/x86_64","version":"0.1.0",
-    "protocolVersion":"2.3","capabilities":{ "liveState":true } } } }
+    "protocolVersion":"2.4","capabilities":{ "liveState":true } } } }
 ```
 
 ```json
 // → first-ever connect: no clientId yet, server mints one
 { "jsonrpc":"2.0","id":1,"method":"client.hello","params":{ "name":"Intent Desktop" } }
 // ← server returns a clientId for the client to persist
-{ "jsonrpc":"2.0","id":1,"result":{ "clientId":"cli-9b21","protocolVersion":"2.3",
+{ "jsonrpc":"2.0","id":1,"result":{ "clientId":"cli-9b21","protocolVersion":"2.4",
   "server":{ "locality":"local","hasDisplay":true,"osArch":"darwin/arm64","version":"0.1.0",
-    "protocolVersion":"2.3","capabilities":{ "liveState":true } } } }
+    "protocolVersion":"2.4","capabilities":{ "liveState":true } } } }
 ```
 
 **Errors.** A malformed `clientId` (non-string) → `-32602`. The handshake is idempotent:
@@ -2391,7 +2391,7 @@ script's exit code (§5.1).
 
 ### 5.27 `github.*` namespace
 
-> The `github.*` namespace is served **daemon-owned** against `api.github.com` — 22 methods, with real `nextToken`/`limit` pagination on the list reads (the uniform-pagination contract described in the conventions below), reusing the `intent-sourcecontrol` **octocrab** engine — the same engine that already backs `pr.*`. The auth trio (`connect` / `cancelAuth` / `revoke`) drives a daemon-owned **OAuth device flow** (see the auth-model note below). The field names and shapes here are the source of truth for both sides.
+> The `github.*` namespace is served **daemon-owned** against `api.github.com` — 23 methods, with real `nextToken`/`limit` pagination on the list reads (the uniform-pagination contract described in the conventions below), reusing the `intent-sourcecontrol` **octocrab** engine — the same engine that already backs `pr.*`. The auth trio (`connect` / `cancelAuth` / `revoke`) drives a daemon-owned **OAuth device flow** (see the auth-model note below). The field names and shapes here are the source of truth for both sides.
 >
 > **Namespace split.** Local git operations stay on `git.*` (§5.6). Everything
 > that hits `api.github.com` — repo/PR/issue browse, PR review comments + threads — plus GitHub
@@ -2450,6 +2450,7 @@ missing/invalid params and "not found" (404) lookups → `-32602`; a token that 
 | github.repos.search | query (req), limit?, nextToken? | { repos: GithubRepo[], nextToken? } — `GET /search/repositories` (FE rewrites `owner/name` → `name user:owner`, sorted by stars) |
 | github.repos.get | owner (req), repo (req) | { repo: GithubRepo \| null } — `GET /repos/{owner}/{repo}` (repo metadata incl. `defaultBranch`) |
 | github.branches.list | owner (req), repo (req), limit?, nextToken? | { branches: string[], nextToken? } — **remote** branch names (`GET /repos/{owner}/{repo}/branches`) |
+| github.repoConfig.get | owner (req), repo (req), ref? | { config: RepoConfig \| null, exists: boolean } — the repo's `.intent/config.json` fetched via the contents API (`GET /repos/{owner}/{repo}/contents/.intent/config.json`, no clone; `ref` defaults to the default branch). A missing file (or missing repo/ref) → `{ config: null, exists: false }`; a present but invalid/mis-shaped file folds **tolerantly** to `{ config: {}, exists: true }` (mirrors the `repoConfig.get` §5.33 parse semantics) — never an error. Same camelCase `RepoConfig` shape as §5.33, unknown keys preserved (v2.4) |
 
 #### Auth & identity
 


### PR DESCRIPTION
# Summary

Lands GitHub repo-config detection for new workspaces: when the repo selected in the new-workspace modal or onboarding flow is a GitHub repo with no local checkout, the FE probes the committed `.intent/config.json` via the new `github.repoConfig.get` daemon RPC and pre-populates the setup script ("From repo config"), matching the existing local-path behavior. This PR bumps both submodules to the merged commits and carries the PROTOCOL v2.4 contract documentation.

**3 files changed, +23 / −35**

# What Changed

- `docs/PROTOCOL.md` — v2.4: documents `github.repoConfig.get` (§5.27) — params `{ owner, repo, ref? }` → `{ config: RepoConfig | null, exists: boolean }`; the daemon reads the repo's committed `.intent/config.json` via the GitHub contents API (no clone).
- `packages/intentd` — gitlink bump to `9823bb2` (merged main), which includes intent-hq/intentd#557: the `github.repoConfig.get` RPC implementation.
- `packages/cloudlands-fe` — gitlink bump to `4614876` (merged main), which includes intent-hq/cloudlands-fe#417: the FE client seam (`IntegrationsClient.githubRepoConfig`), `fetchGitHubRepoConfigSetupScript` helper, and GitHub-type probing with spinner + no-clobber/staleness guards in both the new-workspace modal and onboarding.

# References

- Daemon PR: intent-hq/intentd#557 (merged)
- FE PR: intent-hq/cloudlands-fe#417 (merged)

# Testing

- intentd#557: cargo fmt/clippy/build/test green in its PR CI.
- cloudlands-fe#417: full CI green (typechecks, lint, CodeQL, 4-shard unit tests, builds); locally 95 test files / 1184 vitest tests, `svelte-check` 0 errors, 3× `tsc --noEmit` clean.
- Monorepo: submodule gitlinks verified to point at the respective merged main commits.

# What's NOT Changed

- No monorepo code changes beyond the protocol doc and the two gitlink bumps.
- Deferred follow-ups (tracked in the workspace spec, not this PR): shared probe-helper extraction between the modal and onboarding, and branch-change re-probe for an already-selected GitHub repo.

# Risk Analysis

### 🟢 P3 — Low
- **Docs + submodule pointer bumps only** — both submodule commits already merged and CI-verified in their own repos.
  - [x] Test: `git submodule status` matches intentd `9823bb2` / cloudlands-fe `4614876`.

| Risk Level | Areas | Items |
| --- | --- | --- |
| P3 | Docs, submodule refs | 1 |
