### PR TITLE
docs: fix "twoserver-handled" typo in PROTOCOL.md §6 intro

### DIFF
--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -3942,7 +3942,7 @@ The static provider registry (the `intent-providers` crate's `ACP_PROVIDERS` tab
 
 ## 6. Events & Subscriptions
 
-Live event streaming is the **canonical** way a thin client stays in sync. It uses twoserver-handled methods (the plural `events.` prefix) plus a server-pushed notification.
+Live event streaming is the **canonical** way a thin client stays in sync. It uses two server-handled methods (the plural `events.` prefix) plus a server-pushed notification.
 
 ### 6.1 `events.subscribe`
 


### PR DESCRIPTION
Closes #1055

One-word fix in `docs/PROTOCOL.md` §6 intro ("Events & Subscriptions"): "twoserver-handled" → "two server-handled". The typo was introduced in #475 and noted during the #1053 review.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author