### PR TITLE
docs: document intentd-releases mirror and bump intentd submodule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,14 @@ workflow dispatch.
   cargo-dist builds the artifacts, and the beta manifest publishes automatically.
 - Stable is promotion-only: dispatch `promote-stable.yml` with the `version` input, then
   verify `stable.json` on the `channel-stable` release.
+- Daemon archives and channel manifests are **mirrored** to the public
+  [intent-hq/intentd-releases](https://github.com/intent-hq/intentd-releases) repo
+  (`INTENTD_RELEASES_TOKEN` secret; mirror steps are skipped with a warning if it is
+  absent). Manifests are dual-published — the mirror's copy points at the mirrored
+  assets, the intentd repo's copy is unchanged — and the sitter fetches the mirror
+  first with a coded fallback to intentd. `mirror-release.yml` (manual dispatch)
+  backfills older releases. The mirror is temporary until intentd is open-sourced.
+  Sitter installers (Homebrew, `.deb`, `sitter-latest`) still ship from intentd itself.
 
 ### cloudlands-fe
 

--- a/README.md
+++ b/README.md
@@ -24,8 +24,12 @@ daemon as thin clients.
 ## Install
 
 Installing `intentd` installs the **sitter** — a small self-updating shim,
-itself named `intentd`, that downloads the latest real daemon from GitHub
-Releases, forwards all CLI arguments to it, and respawns it if it crashes.
+itself named `intentd`, that downloads the latest real daemon from the public
+[intent-hq/intentd-releases](https://github.com/intent-hq/intentd-releases)
+mirror (falling back to the
+[intentd repo's own releases](https://github.com/intent-hq/intentd/releases)),
+forwards all CLI
+arguments to it, and respawns it if it crashes.
 Update checks run only for `intentd serve` (at startup and every 12–24
 hours); one-shot subcommands (e.g. `intentd doctor`) run the installed
 daemon as-is and fail fast with guidance if none is installed yet. The
@@ -117,7 +121,11 @@ update checks against public GitHub Releases and actions you take yourself:
   [intent-hq/cloudlands-releases](https://github.com/intent-hq/cloudlands-releases).
 - **intentd sitter self-update** — the sitter (see [Install](#install))
   downloads the daemon and checks the channel manifests published on the
-  [intentd releases page](https://github.com/intent-hq/intentd/releases).
+  public
+  [intent-hq/intentd-releases](https://github.com/intent-hq/intentd-releases)
+  mirror, falling back to the
+  [intentd releases page](https://github.com/intent-hq/intentd/releases). The
+  mirror is temporary until the intentd repo is open-sourced.
 - **Auggie binary download (on demand)** — installing the Auggie CLI from the
   desktop app downloads the pre-built binary from the latest public release of
   [augmentcode/auggie](https://github.com/augmentcode/auggie).


### PR DESCRIPTION
# Summary

Phase 2 of the public-releases-mirror documentation work: update the monorepo docs for the public `intent-hq/intentd-releases` mirror and bump the `packages/intentd` submodule to capture all related intentd PRs.

## Doc changes

- **README.md — Install intro**: the sitter now downloads the daemon from the public `intent-hq/intentd-releases` mirror, falling back to the intentd repo's own releases.
- **README.md — Network & privacy**: the sitter self-update bullet now names the mirror as the primary manifest/download source with fallback to the intentd releases page, and notes the mirror is temporary until intentd is open-sourced.
- **AGENTS.md — Release Process (intentd)**: documents the mirroring step (`INTENTD_RELEASES_TOKEN`, skip-with-warning), the dual-published manifests, the sitter's mirror-first fetch order, the manual `mirror-release.yml` backfill workflow, and that sitter installers still ship from intentd.

Sitter installer pointers (`sitter-latest`, `.deb`) intentionally still reference `intent-hq/intentd`.

## Submodule bump

`packages/intentd` `2d7d2ea` → `d4d4e43`. The bump range (`git log 2d7d2ea..d4d4e43`) newly captures:

- intent-hq/intentd#711 — sitter mirror-first manifest fetch with fallback
- intent-hq/intentd#713 — intentd README docs for the mirror (Phase 1 of this task)

intent-hq/intentd#708 (mirror + dual publish) and intent-hq/intentd#714 (manual `mirror-release.yml` backfill workflow) are already ancestors of the old pin `2d7d2ea`, so all mirror-related intentd changes are contained in the new pin.

## Verification

- `grep -rn "intent-hq/intentd/releases" README.md AGENTS.md packages/intentd/README.md` — remaining hits are only sitter installer URLs and the explicit fallback mention (intentional).
