### PR TITLE
chore: update intentd submodule for override-aware provider discovery (intentd#717)

### DIFF
--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -387,7 +387,7 @@ Daemon-owned provider auth probes: reports whether each CLI-backed agent provide
 
 #### `host.providerDiscovery`
 
-Daemon-owned provider discovery: reports which CLI-backed agent providers are installed on the daemon host (binary resolution + npx fallback status), so clients render install state without probing `PATH` themselves.
+Daemon-owned provider discovery: reports which CLI-backed agent providers are installed on the daemon host (binary resolution + npx fallback status, honoring valid `providers.paths` overrides), so clients render install state without probing `PATH` themselves.
 
 **Request:** `{}` (no parameters)
 
@@ -401,12 +401,12 @@ Daemon-owned provider discovery: reports which CLI-backed agent providers are in
       "displayName": "Unsloth",
       "command": "opencode",
       "installed": true,
-      "resolvedPath": "/usr/local/bin/opencode",  // optional — present when the primary binary resolved
+      "resolvedPath": "/usr/local/bin/opencode",  // optional — present when the primary binary auto-detected (never an override path)
       "hasNpxFallback": false,
       "npxOnly": false,
       "secondaryCommand": "unsloth",               // optional — dual-binary providers only
       "secondaryResolved": true,                   // optional — dual-binary providers only
-      "secondaryResolvedPath": "/Users/me/.unsloth/bin/unsloth"  // optional — present only when the secondary resolved
+      "secondaryResolvedPath": "/Users/me/.unsloth/bin/unsloth"  // optional — present only when the secondary auto-detected
     },
     {
       "id": "claude-code",
@@ -423,9 +423,10 @@ Daemon-owned provider discovery: reports which CLI-backed agent providers are in
 }
 ```
 
-- `providers` carries one entry per registered provider, in registry order. `installed` reflects the daemon's binary resolution, which checks Intent-managed / native installer locations (e.g. `~/.opencode/bin/opencode`, `~/.grok/bin/grok`) ahead of the `PATH` scan (see §5.30).
-- **`secondaryCommand` / `secondaryResolved`** *(additive, monorepo#991)* — secondary-binary attribution for **dual-binary providers** (today only `unsloth`, which requires both `opencode` and `unsloth` on the daemon host). `secondaryCommand` names the required secondary CLI and `secondaryResolved` reports whether it resolved via the same discovery precedence as the primary — so when a dual-binary provider shows `installed: false`, clients can attribute the failure to the actually-missing binary instead of the primary `command`. The two fields are always emitted **together**, and are **omitted (never null)** for providers without a secondary requirement and for gated-off providers (gated providers are never probed, so no attribution exists). Clients detect by presence.
-- **`secondaryResolvedPath`** *(additive, intentd#701)* — the secondary binary's resolved **absolute path** string, sitting alongside `secondaryCommand` / `secondaryResolved` on dual-binary provider entries. Present **only when the secondary resolved** (`secondaryResolved: true`); omitted (never null) when the secondary did not resolve or the provider has no secondary requirement.
+- `providers` carries one entry per registered provider, in registry order. `installed` reflects the daemon's binary resolution, which checks Intent-managed / native installer locations (e.g. `~/.opencode/bin/opencode`, `~/.grok/bin/grok`) ahead of the `PATH` scan (see §5.30). Since intentd#717, `installed` (and `secondaryResolved`) also honor **valid `providers.paths` overrides** — an override value that is an absolute path to an executable file (the same validation as spawn resolution) counts as installed even when auto-detection finds nothing, matching what the daemon would actually launch; invalid overrides (missing, relative, non-executable) contribute nothing. Override keys follow spawn resolution: for `unsloth` the `opencode` key covers the primary binary and the `unsloth` key covers the secondary CLI.
+- `resolvedPath` is **strictly auto-detected** — an override never surfaces there — so `installed: true` can coexist with `resolvedPath` absent (valid override, nothing auto-detected).
+- **`secondaryCommand` / `secondaryResolved`** *(additive, monorepo#991)* — secondary-binary attribution for **dual-binary providers** (today only `unsloth`, which requires both `opencode` and `unsloth` on the daemon host). `secondaryCommand` names the required secondary CLI and `secondaryResolved` reports whether it resolved via the same discovery precedence as the primary (including valid `providers.paths` overrides, intentd#717) — so when a dual-binary provider shows `installed: false`, clients can attribute the failure to the actually-missing binary instead of the primary `command`. The two fields are always emitted **together**, and are **omitted (never null)** for providers without a secondary requirement and for gated-off providers (gated providers are never probed, so no attribution exists). Clients detect by presence.
+- **`secondaryResolvedPath`** *(additive, intentd#701)* — the secondary binary's resolved **absolute path** string, sitting alongside `secondaryCommand` / `secondaryResolved` on dual-binary provider entries. Like `resolvedPath`, it is **strictly auto-detected**: present only when the secondary **auto-detected**; omitted (never null) when nothing auto-detected or the provider has no secondary requirement. Consequently `secondaryResolved: true` can coexist with `secondaryResolvedPath` absent (valid override satisfied the requirement, nothing auto-detected) — clients must not treat `secondaryResolved: true` as implying the path field.
 - `gatedOff` (optional string, not shown above) is present — with a human-readable reason — only when the provider is gated off (e.g. a required env var or feature code is missing). Gated providers skip binary probing entirely, so a gated entry never carries `resolvedPath`, `secondaryCommand`, `secondaryResolved`, or `secondaryResolvedPath` and always reports `installed: false`.
 - `npxOnly` is `true` for providers with no local-binary path at all (claude-code): they are launched via `npx <package>`, `installed` reflects npx resolution, and `resolvedPath` (when present) is the npx binary. `npxPackage` (the pinned package spec) is present **iff** `npxOnly` is `true`.
 - `hasNpxFallback` is `true` for providers that prefer a local binary but can fall back to an npx-launched adapter when the binary is absent — so a `hasNpxFallback: true` provider with `installed: false` may still be usable if the `npx` probe below reports `versionOk: true`.


### PR DESCRIPTION
Wrap-up for the provider-discovery override fix (intent-hq/intentd#717, squash `5ec2aad7`).

## What changed

- **`docs/PROTOCOL.md` §5.14 `host.providerDiscovery`** — documents the override-aware semantics:
  - `installed` / `secondaryResolved` now honor **valid `providers.paths` overrides** (absolute path to an executable file, the same validation as spawn resolution). Override keys follow spawn resolution: for `unsloth` the `opencode` key covers the primary binary and the `unsloth` key covers the secondary CLI.
  - `resolvedPath` / `secondaryResolvedPath` remain **strictly auto-detected** — an override never surfaces there. Consequently `secondaryResolved: true` can now coexist with `secondaryResolvedPath` absent (valid override, nothing auto-detected), and likewise `installed: true` with `resolvedPath` absent.
  - No new wire fields.
- **`packages/intentd` gitlink** → `d4d4e436` (latest main, contains the intentd#717 squash `5ec2aad7`).

## Verification

`make check && make test` from the monorepo root — fmt, clippy (`-D warnings`), build, and the full `cargo test --workspace` suite all green.

Refs intent-hq/intentd#717
Closes #1065
