### PR TITLE
docs: repoint sitter install URLs to intentd-releases and bump intentd submodule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,7 +72,9 @@ workflow dispatch.
   assets, the intentd repo's copy is unchanged — and the sitter fetches the mirror
   first with a coded fallback to intentd. `mirror-release.yml` (manual dispatch)
   backfills older releases. The mirror is temporary until intentd is open-sourced.
-  Sitter installers (Homebrew, `.deb`, `sitter-latest`) still ship from intentd itself.
+  Sitter installers (Homebrew, `.deb`, `sitter-latest`) are also mirrored to
+  intentd-releases by `release-sitter.yml`, and the published install URLs (Homebrew
+  formula, README curl commands) point at the mirror.
 
 ### cloudlands-fe
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ public
 # On arm64, use intentd_arm64.deb in both commands.
 curl -fLO https://github.com/intent-hq/intentd-releases/releases/download/sitter-latest/intentd_amd64.deb
 sudo apt install ./intentd_amd64.deb
+# The package does not auto-enable the unit (it is per-user); start it at login with:
+systemctl --user enable --now intentd
 ```
 
 ### Direct download

--- a/README.md
+++ b/README.md
@@ -59,8 +59,9 @@ public
 [intentd-releases page](https://github.com/intent-hq/intentd-releases/releases):
 
 ```sh
+# On arm64, use intentd_arm64.deb in both commands.
 curl -fLO https://github.com/intent-hq/intentd-releases/releases/download/sitter-latest/intentd_amd64.deb
-sudo apt install ./intentd_amd64.deb   # arm64: intentd_arm64.deb
+sudo apt install ./intentd_amd64.deb
 ```
 
 ### Direct download

--- a/README.md
+++ b/README.md
@@ -55,13 +55,19 @@ brew-managed one when configured to; it can also spawn its own bundled
 
 `.deb` packages ship the sitter with a systemd user unit that runs
 `intentd serve --resume-all`; download them from the sitter releases on the
-[intentd releases page](https://github.com/intent-hq/intentd/releases).
+public
+[intentd-releases page](https://github.com/intent-hq/intentd-releases/releases):
+
+```sh
+curl -fLO https://github.com/intent-hq/intentd-releases/releases/download/sitter-latest/intentd_amd64.deb
+sudo apt install ./intentd_amd64.deb   # arm64: intentd_arm64.deb
+```
 
 ### Direct download
 
 Prebuilt sitter archives for macOS, Linux, and Windows are published on the
-intentd repo's
-[`sitter-latest` release](https://github.com/intent-hq/intentd/releases/tag/sitter-latest).
+public intentd-releases repo's
+[`sitter-latest` release](https://github.com/intent-hq/intentd-releases/releases/tag/sitter-latest).
 
 The desktop app is not yet packaged for download; it will ship via GitHub
 Releases. Until then, you can [build it from source](#build-from-source).


### PR DESCRIPTION
Phase 2 follow-up to intent-hq/intentd#722 (merged as 9821fad): now that sitter installer assets are mirrored to the public [intent-hq/intentd-releases](https://github.com/intent-hq/intentd-releases) repo, repoint the monorepo README install pointers and bump the intentd submodule.

## Changes

- **README**: Debian/Ubuntu section now points at the public intentd-releases page and includes the stable `sitter-latest` curl command for the constant-named `.deb`s; Direct download section points at the intentd-releases `sitter-latest` release.
- **Submodule**: `packages/intentd` bumped `8e4049f` → `9821fad` (latest main; the one new commit is #722: sitter CI mirroring + formula template/README repoint).
- **AGENTS.md**: release-process note updated — sitter installers are now mirrored to intentd-releases and the published install URLs point at the mirror.

## Verification (unauthenticated)

- `curl -fIL` on `sitter-latest` archives (macOS arm64, both linux musl) and `intentd_amd64.deb` on intentd-releases → all 200.
- Live Homebrew formula on intent-hq/homebrew-tap re-rendered against intentd-releases URLs (commit 4187951); all four formula URLs fetch 200 with identical sha256s.
