### PR TITLE
ci: move pr-title job to self-hosted Linux runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ permissions:
 
 jobs:
   pr-title:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     if: github.event_name == 'pull_request'
     steps:
       - uses: amannn/action-semantic-pull-request@v6


### PR DESCRIPTION
Moves the monorepo's only CI job (`pr-title`) from `ubuntu-latest` to the self-hosted Linux runner (`[self-hosted, Linux, X64]`), so monorepo PRs (submodule bumps) no longer depend on GitHub-hosted runners for workflow CI. Part of the self-hosted runner migration; follows the intentd and cloudlands-fe moves.

**Caveat — CodeQL stays GitHub-hosted**: CodeQL (default setup) cannot be migrated to self-hosted runners and remains billing-dependent. The org ruleset additionally requires CodeQL code-scanning results on `main`, so merges remain gated on CodeQL until org billing is fixed or an admin adjusts that rule. This PR only removes the workflow-CI dependency on hosted runners.
