### PR TITLE
chore: update intentd submodule for immediate attention-request parent wake

### DIFF
--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -1240,9 +1240,11 @@ delegated or not, with or without a linked task. `reason` is required (trimmed; 
 5. **Parent wake** — a delegated caller's parent receives an immediate kind-flavored
    `[WORKSPACE EVENTS]` wake (`… requests a discussion: <reason>` / `… reports a blocker:
    <reason>`) with `event_notification` metadata embedding the `agent:attention-requested`
-   payload. Children in an undelivered `after_all` delegation group skip the immediate wake —
-   the group's single aggregated wake folds the attention request in; non-delegated callers
-   have no parent to wake.
+   payload. The wake is immediate even for children in an undelivered `after_all` delegation
+   group (mirroring the immediate grouped-failure wake: the request is an alert the parent
+   must hear now, not at group settlement); the group's single aggregated wake still folds the
+   attention request into that child's line as the record. Non-delegated callers have no
+   parent to wake.
 
 ```json
 // → request

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -1241,8 +1241,9 @@ delegated or not, with or without a linked task. `reason` is required (trimmed; 
    `[WORKSPACE EVENTS]` wake (`… requests a discussion: <reason>` / `… reports a blocker:
    <reason>`) with `event_notification` metadata embedding the `agent:attention-requested`
    payload. The wake is immediate even for children in an undelivered `after_all` delegation
-   group (mirroring the immediate grouped-failure wake: the request is an alert the parent
-   must hear now, not at group settlement); the group's single aggregated wake still folds the
+   group — unlike a grouped child's completion report, which reaches the parent only inside
+   the group's single aggregated wake (`agent.reportToParent`, §5.5 table above), an attention
+   request is an alert the parent must hear now; the aggregated group wake still folds the
    attention request into that child's line as the record. Non-delegated callers have no
    parent to wake.
 


### PR DESCRIPTION
## Summary

Follow-up round for agent attention requests: bumps `packages/intentd` to latest main and updates `docs/PROTOCOL.md` §5.5 to match the new wake semantics.

## Changes

- **`packages/intentd`** → `06a195f8` (intent-hq/intentd main), picking up:
  - intent-hq/intentd#758 — `fix: deliver attention-request parent wake immediately in after_all groups` + reportToParent guidance disambiguation
  - intent-hq/intentd#751 rides along (already on intentd main)
- **`docs/PROTOCOL.md` §5.5 bullet 5** — attention-request parent wake is now immediate even for children in an undelivered `after_all` delegation group (mirroring the immediate grouped-failure wake); the group's single aggregated wake still folds the attention request into that child's line as the record. Documents intent-hq/intentd#758.

## Why no ios bump

intent-hq/ios#61 (`feat: surface agent attention requests — blocked status, notice cards, indicators`, merge commit `ad4ee9f2`) is **already included** on monorepo main: PR #1127 recorded the ios pointer at `94aa6a28` (ios#58), a descendant of the #61 merge commit. Re-pinning to `ad4ee9f2` would regress the pointer, so the ios gitlink is left untouched.

## Verification

- `git -C packages/intentd rev-parse HEAD` → `06a195f8f859dc8f27c5a82a8279d76cd9545e75` (== intentd `origin/main`)
- `git merge-base --is-ancestor 20415933 06a195f8` → fast-forward bump confirmed
- `git merge-base --is-ancestor ad4ee9f2 94aa6a28` → ios#61 already contained in main's recorded pointer
