### PR TITLE
ci: run route job and utility burst on WarpBuild runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,25 +6,25 @@ permissions:
   pull-requests: read
 
 env:
-  # Burst pr-title to a GitHub-hosted runner when more than this many
-  # Linux jobs are queued/running ahead of this run (see the route job).
-  # Bursted jobs don't carry the self-hosted+Linux labels and stop
-  # counting toward the depth, so the system naturally falls back to
-  # tinybox as it frees up.
+  # Burst pr-title to WarpBuild when more than this many Linux jobs are
+  # queued/running ahead of this run (see the route job). Bursted jobs
+  # don't carry the self-hosted+Linux labels and stop counting toward
+  # the depth, so the system naturally falls back to tinybox as it
+  # frees up.
   LINUX_BURST_THRESHOLD: 2
 
 jobs:
-  # Decides where pr-title runs: the local tinybox runner normally, or a
-  # GitHub-hosted runner when the tinybox queue is backed up. Runs on a
-  # small GitHub-hosted runner so the burst decision is independent of
-  # the tinybox queue: a tinybox-pinned probe would queue behind the
-  # very backlog it measures (and deadlock entirely with tinybox
-  # offline). The probe fails open to tinybox on API errors; if the job
-  # itself fails (runner outage, timeout), pr-title is skipped and needs
-  # a re-run — a deliberate trade-off. Pattern ported from
+  # Decides where pr-title runs: the local tinybox runner normally, or
+  # WarpBuild ephemeral runners when the tinybox queue is backed up. Runs
+  # on a small WarpBuild ephemeral runner so the burst decision is
+  # independent of the tinybox queue: a tinybox-pinned probe would queue
+  # behind the very backlog it measures (and deadlock entirely with
+  # tinybox offline). The probe fails open to tinybox on API errors; if
+  # the job itself fails (runner outage, timeout), pr-title is skipped
+  # and needs a re-run — a deliberate trade-off. Pattern ported from
   # intent-hq/intentd#762.
   route:
-    runs-on: ubuntu-latest
+    runs-on: warp-ubuntu-latest-x64-2x
     if: github.event_name == 'pull_request'
     timeout-minutes: 5
     permissions:
@@ -49,13 +49,13 @@ jobs:
           github-token: ${{ secrets.CI_QUEUE_READ_TOKEN || github.token }}
           script: |
             const tinybox = ["self-hosted", "Linux", "X64"];
-            // pr-title is seconds-long; a standard runner is plenty when bursting.
-            const utilityBurst = ["ubuntu-latest"];
+            // pr-title is seconds-long; a 2x runner is plenty when bursting.
+            const utilityBurst = ["warp-ubuntu-latest-x64-2x"];
             const threshold = parseInt(process.env.THRESHOLD || "2", 10);
             // Count self-hosted Linux jobs that are queued or running in
             // queued/in-progress runs: a running job occupies the single
-            // tinybox slot just as much as a queued one. GitHub-hosted
-            // jobs — including this route job — don't match the
+            // tinybox slot just as much as a queued one. WarpBuild jobs —
+            // including this route job — don't match the
             // self-hosted+Linux label filter, so they never inflate the depth.
             const owner = context.repo.owner;
             const repos = ["intentd", "cloudlands-fe", "monorepo"];


### PR DESCRIPTION
## Summary

Moves the monorepo CI `route` job (and the `pr-title` utility burst target) off GitHub-hosted runners onto WarpBuild ephemeral runners, mirroring intentd's `ci.yml`.

- `route`: `runs-on: ubuntu-latest` -> `warp-ubuntu-latest-x64-2x`
- `utilityBurst`: `["ubuntu-latest"]` -> `["warp-ubuntu-latest-x64-2x"]`
- Comments updated to WarpBuild wording; tinybox default labels, `LINUX_BURST_THRESHOLD`, and the queue-depth probe are unchanged (WarpBuild jobs don't carry the self-hosted+Linux labels, so they never inflate the depth)

## Motivation

GitHub-hosted jobs are currently refused ("recent account payments have failed or your spending limit needs to be increased"), which blocked the `route` job on PR #1187 (run #3537). intentd already routes on WarpBuild (intent-hq/intentd#762 pattern); the same switch is being applied to cloudlands-fe separately.

## Verification

- YAML parses (`yaml.safe_load`)
- `grep -n ubuntu-latest` shows only the `warp-ubuntu-latest-x64-2x` labels
- This PR's own CI run exercises the new route job end-to-end on WarpBuild

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author