### PR TITLE
chore: update intentd submodule to latest main

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,7 +70,9 @@ workflow dispatch.
   (`INTENTD_RELEASES_TOKEN` secret; mirror steps are skipped with a warning if it is
   absent). Manifests are dual-published — the mirror's copy points at the mirrored
   assets, the intentd repo's copy is unchanged — and the sitter fetches the mirror
-  first with a coded fallback to intentd. `mirror-release.yml` (manual dispatch)
+  first with a coded fallback to intentd. Daemon release notes are mirrored too
+  (source changelog with download URLs rewritten to the mirror; sitter releases
+  keep their purpose-written notes). `mirror-release.yml` (manual dispatch)
   backfills older releases. The mirror is temporary until intentd is open-sourced.
   Sitter installers (Homebrew, `.deb`, `sitter-latest`) are also mirrored to
   intentd-releases by `release-sitter.yml`, and the published install URLs (Homebrew


### PR DESCRIPTION
Bumps `packages/intentd` to the latest main (`361085d`), picking up intent-hq/intentd#809 — mirror source release notes to the intentd-releases daemon mirrors (source changelog copied as the mirror release body with download URLs rewritten to the mirror; empty bodies fall back to the placeholder; re-running `mirror-release.yml` backfills notes on existing mirror releases; sitter releases keep their purpose-written notes).

Also updates the intentd mirroring bullet in `AGENTS.md` (Release Process → intentd) to mention that daemon release notes are mirrored too.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author