### PR TITLE
docs: add read-path performance principles to ARCHITECTURE.md

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -338,6 +338,58 @@ polling. The subsystem lives in `intent-services`
   10 s floor and hook names are capped at 19 characters — all enforced at
   schedule time.
 
+## Read-path performance principles
+
+Hot read RPCs — the methods clients poll or fan out on focus (`workspace.list`
+/ `workspace.get`, `agent.list` / `agent.get`, conversation pagination, event
+reads) — obey one invariant: **cost is O(rows returned)**. Work is
+proportional to the size of the response, never to transcript length, blob
+size, repository size, or history depth — and no unbounded filesystem or git
+work (workdir walks, `git diff`, reflink probes) runs inline on these paths.
+Every recent performance regression attached unbounded-cost computation to a
+bounded-expectation read path (monorepo#958, #963, #1010, #1061, #1395/#1396);
+this section records the design that prevents the next one.
+
+Derived or enriched fields on hot read paths sit on a three-rung ladder —
+prefer the highest rung that fits:
+
+1. **Stored on write.** Maintain the derived value in the same transaction as
+   the write that changes it; the read path only selects columns. Embodiment:
+   the persisted `last_assistant_preview` / `last_user_preview` /
+   `last_message_role` columns on `agent_session` (migrations 0066/0070) —
+   `agent.list` previews are written at message-append time, so the read path
+   never hydrates or decodes transcript bodies (#958).
+2. **Cached with invalidation.** Compute off the hot path and serve from a
+   shared cache with explicit invalidation or a TTL. Embodiments: the
+   `workspace_aggregates` cache (`intent-services/src/workspace_aggregates.rs`
+   — lifetime-cached CoW probe, single-flight, per-call budget), the
+   `agent.list` projection cache (`agent_list_cache.rs` — event-driven
+   invalidation on transcript writes, epoch-guarded against stale in-flight
+   loads), and the disk-usage cache (`disk_usage.rs` — ~60 s TTL,
+   stale-while-revalidate: an expired entry is served immediately while a
+   single-flight background walk refreshes it).
+3. **On-demand RPC.** If a field cannot be made cheap, it does not belong on
+   a list payload: give it its own method the client calls when it actually
+   needs the value. Embodiment: `diffSummary` was removed from workspace
+   metadata payloads (its per-workspace `head_diff_rollup` pinned the
+   blocking pool on every list poll, #963) in favor of on-demand `git.diffs`.
+
+Two corollaries:
+
+- **Degrade by omission, never by blocking.** When a cached aggregate is
+  cold or over budget, the read omits the optional field and lets a detached
+  task backfill the cache for the next poll (`cowSupported`'s 1.5 s budget,
+  disk usage's first-poll omission) — a hot RPC never waits out a probe or a
+  filesystem walk.
+- **Window before materializing.** Pagination selects and decodes only the
+  requested page inside SQLite (`get_agent_messages_page`; the preview
+  window query runs on a covering index and never fetches `content`), rather
+  than hydrating the full log and slicing in memory (#1010).
+
+New enrichment fields on hot read paths carry the burden of proof: they must
+name their rung on this ladder before they land. The companion agent-facing
+contract lives in the intentd repo's AGENTS.md.
+
 ## Dependency-direction rules
 
 ```text


### PR DESCRIPTION
Adds a durable **Read-path performance principles** section to `docs/ARCHITECTURE.md`, part of the expensive-RPC guardrails work.

The section records the system as designed (not aspiration):

- **Invariant** for hot read RPCs (`workspace.list`/`get`, `agent.list`/`get`, conversation pagination, event reads): cost is O(rows returned); no unbounded filesystem/git work inline. Motivated by the recent regressions (#958, #963, #1010, #1061, #1395/#1396).
- **Three-rung derived-field ladder**, each rung grounded in an existing embodiment:
  1. *Stored on write* — persisted `agent_session` preview columns (migrations 0066/0070, #958)
  2. *Cached with invalidation* — `workspace_aggregates` CoW probe cache, `agent_list_cache` event-driven projection cache, `disk_usage` stale-while-revalidate cache
  3. *On-demand RPC* — `diffSummary` removal from workspace metadata in favor of `git.diffs` (#963)
- **Corollaries**: degrade by omission (budget + backfill) rather than blocking; window inside SQLite before materializing (#1010).
- New enrichment fields on hot read paths must name their rung before landing; points at the companion agent-facing contract in intentd's AGENTS.md (separate PR).

Docs-only; no code or wire-contract changes. `docs/README.md` does not list section anchors, so it is untouched.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author