### PR TITLE
docs: document specialist modelOptions in PROTOCOL and ARCHITECTURE

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -361,8 +361,9 @@ feature from both the agent's system prompt and its MCP tool surface.
 - **Dynamic delegate-docs segment (specialist `modelOptions`).** The same
   per-bridge description assembly carries one dynamic segment: each visible
   specialist's `modelOptions` (PROTOCOL §5.11) is resolved through the 3-tier
-  fold at bridge creation (`Services::specialist_model_options`, project tier
-  derived from the stored workspace record) and injected as
+  fold at bridge creation (`Services::specialist_model_options_for_workspace`
+  → `specialist_model_options`, project tier derived from the stored workspace
+  record — worktree path, else repository path) and injected as
   continuation-indented lines of the `ws.agent.delegate` doc entry
   (`tools::workspace_api_description_with_model_options`), composing with the
   feature pruning above. Snapshot semantics match the `[agentFeatures]`

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -358,6 +358,17 @@ feature from both the agent's system prompt and its MCP tool surface.
   namespace-level except `attentionRequests`, which is method-level
   (`ws.agent.reportBlocker` / `ws.agent.requestDiscussion` only —
   `ws.agent.reportToParent` and the rest of `ws.agent.*` stay un-gated).
+- **Dynamic delegate-docs segment (specialist `modelOptions`).** The same
+  per-bridge description assembly carries one dynamic segment: each visible
+  specialist's `modelOptions` (PROTOCOL §5.11) is resolved through the 3-tier
+  fold at bridge creation (`Services::specialist_model_options`, project tier
+  derived from the stored workspace record) and injected as
+  continuation-indented lines of the `ws.agent.delegate` doc entry
+  (`tools::workspace_api_description_with_model_options`), composing with the
+  feature pruning above. Snapshot semantics match the `[agentFeatures]`
+  toggles — captured once at bridge creation, never live-read — and when no
+  specialist carries options (the default) the assembled description is
+  byte-identical to the plain assembly by construction.
 - **Prompt-section gating.** `rules::assemble_system_prompt` threads the
   captured flags into instruction assembly (`intent-services/instructions.rs`):
   disabled features drop their bundled-instruction sections (e.g. common.md's

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -1423,6 +1423,12 @@ The former specialist frontmatter `modelTier` step is **retired** (tolerated-and
 the settings chain; the static tier tables (§5.38 `modelTiers`) no longer participate in
 creation-time resolution.
 
+Specialist `modelOptions` (§5.11) likewise adds **no resolver step**: the list is advisory
+— surfaced to delegating agents in the `workspace_api` tool description's
+`ws.agent.delegate` docs — and a chosen option is sent as the explicit client `model`, i.e.
+step 1 above, which remains the first-match step exactly as before. A caller that omits
+`model` resolves through steps 2–4 unchanged, regardless of any `modelOptions`.
+
 The resolved provider is the explicit `provider` param, else the compound-`model` prefix,
 else the daemon default (legacy default-provider aliases normalized). The resolved model is
 persisted to `session.model` at creation time, **pinning it for the session's lifetime**:
@@ -2165,7 +2171,7 @@ resolved view; `create`/`edit` take a full `spec` body. Malformed params → `-3
 non-existent or `bundled` definition → `-32602`.
 
 - **SpecialistDef** — `{ id, name, description, codingAgent?, model?,
-  roleReminder?, agentType?, prompt?, hidden?: boolean,
+  roleReminder?, agentType?, prompt?, hidden?: boolean, modelOptions?: [{ model, hint }],
   source: "project"|"user"|"bundled", path?, resolvedModel?, resolvedProvider? }`. The optional
   scalars (`codingAgent`, `model`, `roleReminder`, `agentType`) are first-class **string**
   fields on the wire, not
@@ -2217,6 +2223,31 @@ non-existent or `bundled` definition → `-32602`.
   **winner-takes-all** (not inherited): it is coupled to the prompt body (itself
   winner-takes-all), so the derive-from-body fallback remains correct when a higher tier
   rewrites the body.
+- **`modelOptions?` (additive, [intent-hq/intentd#900](https://github.com/intent-hq/intentd/pull/900) /
+  [#908](https://github.com/intent-hq/intentd/pull/908))** — the ordered list of **delegation
+  model options** a specialist's author suggests: `[{ model, hint }]` entries where `model` is
+  the internal compound model id (e.g. `opencode:kimi-k3`) and `hint` is the author's free-text
+  guidance for choosing that option (`""` when none was given). Carried additively on
+  `specialist.get`/`list`/`create`/`edit` — emitted when the resolved list is non-empty, omitted
+  otherwise (never `null`/`[]` on the wire) — and accepted in `create`/`edit` `spec` bodies. In
+  the file it is a frontmatter scalar encoded as a **single-line JSON array**
+  (`modelOptions: [{"model":"opencode:kimi-k3","hint":"cheap"}]`) so it fits the line-based
+  frontmatter parser and round-trips parse→write→parse losslessly. Resolution follows the same
+  3-tier **inherit-on-omit** fold as the config scalars above, with **`[]` as the explicit
+  clear** (the array analogue of `key: ""`): an omitted key inherits the lower tiers' effective
+  list, an explicit `[]` clears it, and a non-empty list overrides **wholesale** — entries never
+  merge across tiers. Reads are **lenient** (files are never rejected): an unparseable scalar or
+  a non-array is treated as an omitted key (inherits), and unusable entries — non-objects, or no
+  non-empty string `model` — are skipped individually; only a **literal `[]`** clears — a
+  non-empty array whose entries are ALL unusable is treated as omitted (falls through to
+  inheritance), so one bad hand-authored entry never silently drops an inherited list. Writes
+  are **strict**: `create`/`edit` validate the `spec` value before writing — it must be a JSON
+  array of objects, each with a non-empty string `model`; `hint` must be a string when present
+  (defaults to `""`) — and any invalid shape → `-32602` with nothing written. The list adds
+  **no resolver step** (§5.5 "Creation-time default-model resolution"): it is advisory — the
+  daemon injects each visible specialist's options into the delegating agent's `workspace_api`
+  tool description (the `ws.agent.delegate` docs), and the delegating agent passes its pick as
+  the explicit `model` param (resolution step 1).
 - The daemon watches the user (`~/.intent/specialists/`) and project
   (`<workspace>/.intent/specialists/`) tiers (using `notify` watchers, the same infrastructure as
   workspace `file:changed` events); when a specialist file is created/modified/deleted under a

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -2224,10 +2224,11 @@ non-existent or `bundled` definition → `-32602`.
   winner-takes-all), so the derive-from-body fallback remains correct when a higher tier
   rewrites the body.
 - **`modelOptions?` (additive, [intent-hq/intentd#900](https://github.com/intent-hq/intentd/pull/900) /
-  [#908](https://github.com/intent-hq/intentd/pull/908))** — the ordered list of **delegation
+  [intent-hq/intentd#908](https://github.com/intent-hq/intentd/pull/908))** — the ordered list of **delegation
   model options** a specialist's author suggests: `[{ model, hint }]` entries where `model` is
-  the internal compound model id (e.g. `opencode:kimi-k3`) and `hint` is the author's free-text
-  guidance for choosing that option (`""` when none was given). Carried additively on
+  the model id to pass on delegation — typically an internal compound id (e.g.
+  `opencode:kimi-k3`); validation requires only a non-empty string — and `hint` is the author's
+  free-text guidance for choosing that option (`""` when none was given). Carried additively on
   `specialist.get`/`list`/`create`/`edit` — emitted when the resolved list is non-empty, omitted
   otherwise (never `null`/`[]` on the wire) — and accepted in `create`/`edit` `spec` bodies. In
   the file it is a frontmatter scalar encoded as a **single-line JSON array**
@@ -2238,7 +2239,8 @@ non-existent or `bundled` definition → `-32602`.
   list, an explicit `[]` clears it, and a non-empty list overrides **wholesale** — entries never
   merge across tiers. Reads are **lenient** (files are never rejected): an unparseable scalar or
   a non-array is treated as an omitted key (inherits), and unusable entries — non-objects, or no
-  non-empty string `model` — are skipped individually; only a **literal `[]`** clears — a
+  non-empty string `model` — are skipped individually (a non-string `hint` alone does not make
+  an entry unusable on read — it is coerced to `""`); only a **literal `[]`** clears — a
   non-empty array whose entries are ALL unusable is treated as omitted (falls through to
   inheritance), so one bad hand-authored entry never silently drops an inherited list. Writes
   are **strict**: `create`/`edit` validate the `spec` value before writing — it must be a JSON


### PR DESCRIPTION
Documents the specialist `modelOptions` feature in the durable engineering docs, following the merged intentd PRs [intent-hq/intentd#900](https://github.com/intent-hq/intentd/pull/900) (squash 96b6d59) and [intent-hq/intentd#908](https://github.com/intent-hq/intentd/pull/908) (squash f1ef33a). Docs only — no code, and no submodule ref bump (that happens separately).

## PROTOCOL.md

- **§5.11** — new `modelOptions?` bullet on the SpecialistDef contract (plus the field in the shape line): the ordered `{ model, hint }` delegation-option entries, the single-line JSON-array frontmatter scalar encoding (lossless parse→write→parse round-trip), the 3-tier inherit-on-omit fold with a **literal `[]` as the only explicit clear** (a non-empty array whose entries are all unusable falls through to inheritance instead of clearing), lenient reads (unparseable scalar treated as an omitted key, unusable entries skipped individually; files never rejected), and strict `-32602` validation on `create`/`edit` (nothing written on rejection).
- **§5.5** — a note under "Creation-time default-model resolution" that `modelOptions` adds **no resolver step**: the list is advisory, the delegating agent chooses and sends its pick as the explicit client `model` (step 1, unchanged); a caller that omits `model` resolves through steps 2–4 exactly as before.

## ARCHITECTURE.md

- New bullet in the `[agentFeatures]` section on the **dynamic delegate-docs segment** of the `workspace_api` tool description assembly: per-bridge injection of each visible specialist's resolved options as continuation lines of the `ws.agent.delegate` entry, snapshotted at bridge creation with the same semantics as the feature toggles, and byte-identical to the plain assembly when no specialist carries options.
