### PR TITLE
chore: bump intentd submodule for mcp__ tool-name fix

### DIFF
--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -5453,8 +5453,13 @@ identifier followed by `": "` or `":\t"` — is split, taking the prefix. Codex'
 MCP title form `mcp.<server>.<tool>` (server segment contains no dots; title carries no
 whitespace, so prose titles containing dots never match) is rewritten to `{server}_{tool}`
 and fed through the affix strip below (`mcp.workspace-mcp.workspace_api` → `workspace_api`,
-`mcp.other-server.some_tool` → `other-server_some_tool`). Titles without either
-shape (`Edit src/lib.rs`, URLs like `https://…`, times like `10:15 sync`) pass through as
+`mcp.other-server.some_tool` → `other-server_some_tool`). Claude Code's
+double-underscore-separated MCP title form `mcp__<server>__<tool>` (server segment runs to
+the first `__`; both segments must be non-empty; title carries no whitespace, so prose
+titles containing `mcp__` never match) gets the same treatment
+(`mcp__workspace-mcp__workspace_api` → `workspace_api`,
+`mcp__github__list_issues` → `github_list_issues`). Titles without any of these
+shapes (`Edit src/lib.rs`, URLs like `https://…`, times like `10:15 sync`) pass through as
 `name` unchanged. Trailing `_workspace-mcp` suffixes (one or more) are stripped: the registry
 tool names carry no suffix, and auggie's `<tool>_<server>` convention appends the server
 name, so stripping recovers the registry name (`add_to_note_workspace-mcp` → `add_to_note`).


### PR DESCRIPTION
## Summary

Phase 2 monorepo update for the "hide raw MCP tool names" work.

- Bumps `packages/intentd` to include intent-hq/intentd#935 (feat(acp): derive tool names from Claude Code `mcp__<server>__<tool>` titles), merge commit 565e3ed. The bump also rides along intent-hq/intentd#937 (fix(acp): answer delivered MCP bridge calls with non-retryable outcome-unknown error on TCP drop) since it's intentd `main` HEAD; no PROTOCOL.md gap (its stdio-proxy error codes aren't part of the documented wire contract).
- `packages/cloudlands-fe` is already at a commit including intent-hq/cloudlands-fe#779 (fix: never render raw MCP identifiers as tool labels, merge commit 40a1255) via the routine automated submodule-bump PRs that landed on `main` before this branch was cut, so no additional bump was needed there.
- Updates `docs/PROTOCOL.md` §7.1 to document the Claude Code `mcp__<server>__<tool>` title form alongside the existing `mcp.<server>.<tool>` form, matching the merged intentd behavior.

Refs #1539