### PR TITLE
chore: update intentd submodule to latest main

### DIFF
--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -2036,7 +2036,7 @@ The namespace holds the **two** workspace/active-PR-scoped methods that survived
 > updatedAt, mergeable, mergeableState, mergeBlockedReason, checks: { total, passed,
 > failed, pending, failedNames }, reviews: { decision, approvals, changesRequested },
 > comments: { conversationCount, reviewCommentCount, unresolvedThreadCount,
-> threadResolutionUnknown, totalCount } }`. `mergeBlockedReason` is a human-readable
+> totalCount } }`. `mergeBlockedReason` is a human-readable
 > reason and is non-`null` exactly when the PR is open (draft included) and cannot be
 > merged. `checks` tallies the runs on the PR head (SHA, else source branch); a
 > provider without the `checkRuns` capability — or a PR whose head cannot be
@@ -2061,13 +2061,11 @@ The namespace holds the **two** workspace/active-PR-scoped methods that survived
 > replies** (threads come from GraphQL when available, else the REST list
 > grouped by reply parent), and `totalCount = conversationCount +
 > reviewCommentCount`, so a new reply anywhere moves the counter a hook can
-> diff. **`comments.threadResolutionUnknown`** *(new in intentd, same PR)* is
-> `true` when the GraphQL thread fetch failed and the snapshot fell back to the
-> REST comment list grouped by reply parent — that fallback carries no
-> resolution state, so every fallback thread counts as unresolved and
-> `unresolvedThreadCount` is unreliable (an overcount) whenever this flag is
-> set; `false` (the normal case) means `unresolvedThreadCount` reflects real
-> per-thread resolution state from GraphQL.
+> diff. `comments.unresolvedThreadCount` reflects real per-thread resolution
+> state from the GraphQL threads; on the REST fallback (grouped by reply parent)
+> no resolution state is available, so every thread counts as unresolved — that
+> fallback is logged at warn level with the underlying GraphQL error
+> *(intentd, [intentd#949](https://github.com/intent-hq/intentd/pull/949))*.
 
 ### 5.8 `script.*`
 


### PR DESCRIPTION
Phase 2 of the intent-hq/monorepo#1533 fix: bumps `packages/intentd` to `16f9948` (latest `main`), which lands intent-hq/intentd#949.

## What #949 fixed

`intent-sourcecontrol`'s `graphql_data()` unwrapped the GraphQL `data` envelope a second time even though octocrab's `graphql()` already unwraps it. Every GraphQL read (review threads, review decision, thread resolution) therefore failed with `graphql response returned no data`, forcing `pr.snapshot` onto the REST comment fallback, which has no resolution state and counts every thread as unresolved — the `unresolvedThreadCount` overcount reported in #1533. The fix is a single unwrap, plus a regression test and a warn-level log on the fallback path.

## Monorepo-side change

`docs/PROTOCOL.md` no longer mentions `comments.threadResolutionUnknown`. That mitigation flag (intentd#942, unreleased, no consumers) was removed from the snapshot payload by #949, so the documented `pr.snapshot` comments shape now matches the daemon:

`comments: { conversationCount, reviewCommentCount, unresolvedThreadCount, totalCount }`

The surrounding prose now describes the warn-level-logged REST fallback rather than the removed flag.

## Verification

- `make check` — green (fmt, clippy `-D warnings`)
- `make test` — green
- `git -C packages/intentd log --oneline -1` → `16f9948 fix(sourcecontrol): stop double-unwrapping the GraphQL data envelope (#949)`

Refs intent-hq/intentd#949, intent-hq/monorepo#1533 (issue already closed by the intentd merge, so no `Fixes` here).
