### PR TITLE
docs: document standalone-source duplication; bump intentd

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -143,7 +143,9 @@ Wire contract: PROTOCOL.md §5.1 (`checkoutMode`, `cowSupported`), §5.5/§5.5a
   `repositoryPath`: CoW probe ⇒ `cow` clone, Unsupported/probe error ⇒ a plain
   local clone of the source checkout persisted as `direct`
   (`intent_git::cow_checkout::provision_local_clone_checkout`, which carries
-  committed state only). `workspace.cowIsolation` is **ignored** for such sources
+  committed state only and resolves `origin` so no relative or self-referencing
+  URL survives into the duplicate — the CoW path copies `.git/config` verbatim
+  instead). `workspace.cowIsolation` is **ignored** for such sources
   (parity with cache-hydrated create), and the duplicate persists
   `repository_path` = its **own** checkout so it is fully self-contained. A linked
   worktree rooted in a sibling workspace's checkout is never provisioned: the

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -123,7 +123,7 @@ bus — never on the transport or on each other directly.
 Wire contract: PROTOCOL.md §5.1 (`checkoutMode`, `cowSupported`), §5.5/§5.5a
 (sandboxes). Architectural split of responsibilities:
 
-- **Provisioning (`workspace.create` / `workspace.duplicate`).** `intent-services`
+- **Provisioning (`workspace.create`).** `intent-services`
   owns the decision matrix — `workspace.cowIsolation` off ⇒ linked worktree
   (`intent_git::worktree::provision_worktree`); on ⇒ CoW reflink probe from the
   repository directory into the workspace dir (`intent_git::cow_probe(&repo_dir,
@@ -134,9 +134,23 @@ Wire contract: PROTOCOL.md §5.1 (`checkoutMode`, `cowSupported`), §5.5/§5.5a
   logs a warning and falls back to the linked-worktree path (the setting is a
   preference, not a guarantee; the separate root→root probe backing the
   `cowSupported` aggregate is advisory only). Both paths run under the
-  per-repository worktree lock. `workspace.duplicate` applies the same matrix when
-  provisioning the copy's checkout. The setting is consulted **only** at
+  per-repository worktree lock. The setting is consulted **only** at
   provisioning time; the persisted `checkoutMode` is immutable per workspace.
+- **Duplication (`workspace.duplicate`).** Applies that matrix only for
+  shared-checkout (worktree-mode) sources. A **standalone** source — the source's
+  own `checkoutMode` is `cow` or `direct` — always duplicates as a standalone
+  checkout, cloned from the source's own checkout rather than from its
+  `repositoryPath`: CoW probe ⇒ `cow` clone, Unsupported/probe error ⇒ a plain
+  local clone of the source checkout persisted as `direct`
+  (`intent_git::cow_checkout::provision_local_clone_checkout`, which carries
+  committed state only). `workspace.cowIsolation` is **ignored** for such sources
+  (parity with cache-hydrated create), and the duplicate persists
+  `repository_path` = its **own** checkout so it is fully self-contained. A linked
+  worktree rooted in a sibling workspace's checkout is never provisioned: the
+  source's deletion detaches that directory and would orphan the duplicate, and
+  deleting the duplicate would mutate the source (intent-hq/monorepo#1560). If
+  provisioning fails, the inherited `repository_path` is cleared for standalone
+  sources so no checkout-less row references the source's directory.
 - **Repo cache & cache-hydrated creation.** `intent-git::repo_cache` owns a hidden,
   daemon-managed cache of read-only GitHub clones at
   `<workspaces_root>/.repo-cache/<owner>/<repo>` (dot-prefixed so it stays invisible to

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -568,17 +568,19 @@ standalone:
   is the source's **own checkout** (`worktreePath`, or `repositoryPath` when the
   repository itself is the checkout), not the source's `repositoryPath`. A CoW probe from
   that checkout to `<root>/<newId>` decides the mode: supported ⇒ CoW clone
-  (`checkoutMode: "cow"`); Unsupported, probe error, or a CoW clone that still reports
-  Unsupported ⇒ a **plain local `git clone`** of the source checkout
-  (`checkoutMode: "direct"`) with a logged warning. A source checkout whose `.git` is a
-  gitfile skips the probe and goes straight to the local clone. `workspace.cowIsolation`
+  (`checkoutMode: "cow"`); Unsupported ⇒ a **plain local `git clone`** of the source
+  checkout (`checkoutMode: "direct"`), and the same local-clone fallback is taken — with a
+  logged warning — on a probe error or when a CoW clone still reports Unsupported despite a
+  passing probe. A source checkout whose `.git` is a gitfile skips the probe and goes
+  straight to the local clone (also warned). `workspace.cowIsolation`
   is **ignored** for standalone sources (parity with cache-hydrated create). Like a
   hydrated create, the checkout *is* the repository: the duplicate persists
-  `repositoryPath` = its **own** checkout path, and `origin` is retargeted at the source's
-  own resolved `origin` — a network URL and an absolute local path carry over verbatim, a
-  relative local path is absolutized against the source repository so it still names the
-  same upstream, and `origin` is **removed** when the source has none or when it resolves
-  to the source checkout itself — so nothing references the source workspace's directory.
+  `repositoryPath` = its **own** checkout path, so nothing in the row references the source
+  workspace's directory. The `direct` local-clone path additionally **resolves `origin`**
+  (a CoW clone is a byte copy and keeps the source's `.git/config` verbatim): a network URL
+  and an absolute local path carry over as-is, a relative local path is absolutized against
+  the source repository so it still names the same upstream, and the remote is **removed**
+  when the source has no `origin` or when `origin` resolves to the source checkout itself.
   The local-clone fallback carries **committed state only** —
   uncommitted/untracked work in the source is not copied. Rationale
   ([intent-hq/monorepo#1560](https://github.com/intent-hq/monorepo/issues/1560)): a linked

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -559,15 +559,45 @@ removed in the background as usual.
 **Duplication (`workspace.duplicate`).** Duplicating a local workspace off a local git
 repository provisions a fresh checkout for the copy at `<root>/<newId>/<repo-slug>` on a
 branch named for the new id (uniquified against the source repo's local and
-remote-tracking branches), using the **same decision matrix as `workspace.create`**:
-`workspace.cowIsolation` off ⇒ linked worktree (`checkoutMode: "worktree"`); on ⇒ CoW
-probe from the repository directory to `<root>/<newId>` — supported ⇒ standalone CoW
-clone (`checkoutMode: "cow"`), Unsupported/probe error ⇒ the duplicate **falls back to
-a linked worktree** with a logged warning (same fallback semantics as create).
-Provisioning is skipped for remote / skip-isolation sources and for a `repositoryPath`
-that is not a local git repository. An ordinary provisioning failure is logged and
+remote-tracking branches). The decision depends on whether the **source** checkout is
+standalone:
+
+- **Standalone source** (the source's own `checkoutMode` is `"cow"` or `"direct"`, which
+  includes every cache-hydrated workspace and an `isNewRepo` `direct` workspace): the
+  duplicate is **always standalone too, and never a linked worktree**. The clone source
+  is the source's **own checkout** (`worktreePath`, or `repositoryPath` when the
+  repository itself is the checkout), not the source's `repositoryPath`. A CoW probe from
+  that checkout to `<root>/<newId>` decides the mode: supported ⇒ CoW clone
+  (`checkoutMode: "cow"`); Unsupported, probe error, or a CoW clone that still reports
+  Unsupported ⇒ a **plain local `git clone`** of the source checkout
+  (`checkoutMode: "direct"`) with a logged warning. A source checkout whose `.git` is a
+  gitfile skips the probe and goes straight to the local clone. `workspace.cowIsolation`
+  is **ignored** for standalone sources (parity with cache-hydrated create). Like a
+  hydrated create, the checkout *is* the repository: the duplicate persists
+  `repositoryPath` = its **own** checkout path, and `origin` is retargeted at the source's
+  own resolved `origin` — a network URL and an absolute local path carry over verbatim, a
+  relative local path is absolutized against the source repository so it still names the
+  same upstream, and `origin` is **removed** when the source has none or when it resolves
+  to the source checkout itself — so nothing references the source workspace's directory.
+  The local-clone fallback carries **committed state only** —
+  uncommitted/untracked work in the source is not copied. Rationale
+  ([intent-hq/monorepo#1560](https://github.com/intent-hq/monorepo/issues/1560)): a linked
+  worktree rooted in a sibling workspace's checkout is orphaned when that workspace is
+  deleted (the checkout dir is detached), and deleting the duplicate would mutate the
+  source's checkout.
+- **Shared-checkout source** (no `checkoutMode` — a worktree-mode or shared workspace):
+  the **same decision matrix as `workspace.create`** applies against the source's
+  `repositoryPath` — `workspace.cowIsolation` off ⇒ linked worktree
+  (`checkoutMode: "worktree"`); on ⇒ CoW probe from the repository directory to
+  `<root>/<newId>` — supported ⇒ standalone CoW clone (`checkoutMode: "cow"`),
+  Unsupported/probe error ⇒ fall back to a linked worktree with a logged warning.
+
+Provisioning is skipped for remote / skip-isolation sources and when the resolved source
+directory is not a local git repository. An ordinary provisioning failure is logged and
 swallowed (FE parity — "continue without worktree"): the row persists without
-`worktreePath`/`checkoutMode`.
+`worktreePath`/`checkoutMode`. For a standalone source the inherited `repositoryPath` is
+also **cleared** in that case, so a checkout-less duplicate never points at the source
+workspace's directory.
 
 **`checkoutMode` is immutable.** `workspace.cowIsolation` is consulted **only** at
 provisioning time (`workspace.create` / `workspace.duplicate`); the resulting
@@ -2434,7 +2464,7 @@ the overriding flag ("overridden by startup flag …").
 **BE-exposed setting paths.** Only settings that affect daemon behavior are exposed:
 
 - **Providers / agents:** `providers.active`, `providers.enabled`, `providers.paths.{auggie,claude-code,codex,…}`,`model.default`, `model.providerDefaults`, `backgroundAgents.defaultModel`,`backgroundAgents.typeOverrides`, `backgroundAgents.providerSettings`, `specialists.default`. Background-agent model resolution walks `backgroundAgents.typeOverrides[agentType]` → `backgroundAgents.defaultModel` → `model.providerDefaults[provider]` → `model.default` (the settings-chain step of the daemon-side creation-time resolver, §5.5 — specialist frontmatter `model` takes precedence over this chain, and every result is provider-guarded). These two keys also derive the **effective default provider** ([intent-hq/intentd#922](https://github.com/intent-hq/intentd/pull/922)): the provider prefix of `model.default` when it is a compound id naming a registered provider, else `providers.active` (registry-validated, so a stale/mistyped value falls through), else no derived default — resolution bottoms out at the first registered provider (no provider carries a hardcoded default designation). The former `model.workspaceOverrides` key is **retired**: it is gone from the catalog (`settings.list` never advertises it; `settings.get` / `settings.reset` yield `-32602`), but `settings.update` **tolerates-and-ignores** the retired path for old clients — the entry is skipped (never validated, persisted, echoed in `applied`, or published in `settings:changed`) instead of rejecting the batch. Any stale SQLite row is deleted at boot, and a legacy `config.toml` key is still tolerated + stripped on boot with its value discarded.
-- **Workspace / git:** `workspace.branchPrefix`, `workspace.worktreesLocation`,`workspace.sshKeyPath` *(string — filesystem path to the key, not key material; the real secret is the key file on disk, so the value is read back verbatim by the FE `git`-env consumer)*, `workspace.defaultShell`, `workspace.autoCommit`, `workspace.cowIsolation` *(boolean, default `false` — CoW workspaces + per-agent sandboxes: `workspace.create`/`workspace.duplicate` provision the checkout as a standalone CoW clone instead of a linked worktree (§5.1), and `agent.delegate` defaults `isolation` to `"cow"` when the param is omitted (§5.5); consulted only at provisioning time — the resulting `checkoutMode` is immutable per workspace (§5.1); requires CoW filesystem support on the workspaces root — the FE gates the toggle on `Workspace.cowSupported`)*.
+- **Workspace / git:** `workspace.branchPrefix`, `workspace.worktreesLocation`,`workspace.sshKeyPath` *(string — filesystem path to the key, not key material; the real secret is the key file on disk, so the value is read back verbatim by the FE `git`-env consumer)*, `workspace.defaultShell`, `workspace.autoCommit`, `workspace.cowIsolation` *(boolean, default `false` — CoW workspaces + per-agent sandboxes: `workspace.create`/`workspace.duplicate` provision the checkout as a standalone CoW clone instead of a linked worktree (§5.1), and `agent.delegate` defaults `isolation` to `"cow"` when the param is omitted (§5.5); ignored by cache-hydrated creation and by `workspace.duplicate` of a standalone-checkout source, which are always standalone (§5.1); consulted only at provisioning time — the resulting `checkoutMode` is immutable per workspace (§5.1); requires CoW filesystem support on the workspaces root — the FE gates the toggle on `Workspace.cowSupported`)*.
 - **MCP:** `mcp.enableUserServers`, `mcp.disabledServers`, `mcp.servers` *(sensitive)*.
 - **Server / transport (new in intentd):** `server.socketPath`,`server.bindAddress`, `server.port` *(legacy port key — still exposed and validated, used in the `settings.*` examples below; the live WSS listener reads `server.wsApi.port`)*, `server.wsApi.enabled`, `server.wsApi.port`, `server.tls.enabled`, `server.auth.enabled`,`server.auth.token` *(sensitive; read-only / regenerate)*, `server.originAllowList`. The UDS listener always serves; the TCP/WSS listener is toggled at runtime by `server.wsApi.enabled` (the former `server.listenMode` key is retired — a config.toml still carrying it boots, is discarded, and is stripped from the file).
 - **Source control (new in intentd, provider-agnostic):** `sourceControl.activeProvider` (enum,**default **`github`; v1 ships only `github`), `sourceControl.github.tokenSource`(`auto`|`env`|`gh-cli`|`explicit`; default `auto` — secrets store → env → `gh` CLI), `sourceControl.github.token` *(sensitive)*,`sourceControl.github.apiBaseUrl` (GitHub Enterprise support), `sourceControl.github.exposeGitCredentialToChildren` *(boolean, default `true` — inject the daemon-managed GitHub credential into child process environments (PTY terminals, agent provider shells) as a scoped github.com-only credential helper; never as a raw `GITHUB_TOKEN`/`GH_TOKEN`)*. Per-provider config is namespaced as`sourceControl.<provider>.*` so future hosts slot in as `sourceControl.gitlab.*`,`sourceControl.bitbucket.*`, etc. (replaces any flat `github.*` keys).


### PR DESCRIPTION
Phase 2 for #1560. Bumps `packages/intentd` to `fd033b2` and lands the matching
protocol/architecture docs.

Submodule PR: intent-hq/intentd#956 (merged).

## What the daemon change does

Duplicating a workspace whose source is a **standalone** checkout (`cow` or `direct`)
now provisions a standalone checkout instead of a linked worktree, so the duplicate
survives deletion of the source. Previously the duplicate got a linked worktree rooted
in the source workspace's checkout: deleting the source detached that directory and
orphaned the duplicate, and deleting the duplicate mutated the source.

- Standalone source → always standalone duplicate, cloned from the source's **own
  checkout** (not its `repositoryPath`). CoW probe decides `cow` vs. a plain local
  clone persisted as `direct` (committed state only). `workspace.cowIsolation` is
  ignored, matching cache-hydrated create.
- `origin` is **resolved**, not copied verbatim: network URL and absolute local path
  carry over; a relative local path is absolutized against the source repository; it is
  removed when the source has none or when it resolves to the source checkout itself.
- On provisioning failure the inherited `repositoryPath` is cleared for standalone
  sources, so a checkout-less duplicate row never points at the source's directory.
- Shared-checkout (worktree-mode) sources keep the existing `workspace.create`
  decision matrix.

## Docs

- `docs/PROTOCOL.md` §5.1 — duplication rules split by source kind (standalone vs.
  shared-checkout), the origin-resolution rules, the provisioning-failure
  `repositoryPath` clearing, and the standalone exemption noted on the
  `workspace.cowIsolation` settings entry.
- `docs/ARCHITECTURE.md` — `workspace.duplicate` split out of the create bullet into
  its own duplication bullet, including the failure-cleanup behavior.

## Follow-up

#1582 tracks a pre-existing CoW-clone limitation surfaced while reviewing this change
(not a regression from it).

Fixes #1560
