### PR TITLE
chore: update intentd and cloudlands-fe submodules for thinking-blocks HUD follow-up

### DIFF
--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -5077,7 +5077,7 @@ cacheCreationTokens, thoughtTokens }`:
   lexicographically in chronological order.
 - The token counters are the minute's accumulated per-turn deltas (same clamped-≥ 0
   semantics as §5.36's UsageTotals).
-- **thoughtTokens** *(additive within v6.0, [intent-hq/intentd#974](https://github.com/intent-hq/intentd/pull/974))*
+- **thoughtTokens** *(additive within v6.0, [intent-hq/intentd#976](https://github.com/intent-hq/intentd/pull/976))*
   — the minute's accumulated reasoning ("thought") token deltas, the per-minute counterpart
   of the `TokenUsageTotals.thoughtTokens` counter (§5.31). Unlike that omitted-when-zero
   field, samples here are **dense**: every counter is always present, so a minute with no


### PR DESCRIPTION
Phase-2 monorepo bump closing out the thinking-blocks feature.

## Submodule refs

- `packages/cloudlands-fe` → `8a8fa5530ec06a08d6e684a3df701bf47f291294` — picks up [intent-hq/cloudlands-fe#825](https://github.com/intent-hq/cloudlands-fe/pull/825) (*feat(hud): segmented token bars with thoughts and all-counter burn total*).
- `packages/intentd` → `7a6a18388542a058c795405e39ae379568d44773` — unchanged in this PR; `main` already tracks a tip that contains the squash commit of [intent-hq/intentd#976](https://github.com/intent-hq/intentd/pull/976) (*feat: carry thoughtTokens in per-minute usage rate history*), verified with `git merge-base --is-ancestor 01862fe 7a6a183`.

`packages/ios` is untouched.

## Docs

One-line citation fix in `docs/PROTOCOL.md`: the §5.39 `RateSample` `thoughtTokens` bullet cited intentd#974; the per-minute rate-history field actually shipped in intentd#976. Nothing else in the file changed.

Fixes intent-hq/monorepo#1604
