### PR TITLE
chore: switch make test to cargo nextest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -202,10 +202,18 @@ clippy: ensure-intentd-submodule ## cargo clippy --all-targets -- -D warnings
 
 check: fmt clippy ## fmt + clippy
 
-test: test-intentd ## Run the Rust test suite
+test: test-intentd ## Run the Rust test suite (cargo nextest; needs cargo-nextest)
 
+# Runs under nextest so local full-suite runs pick up the same
+# .config/nextest.toml protections CI uses (timing-serial test group,
+# retries, slow-timeout). nextest does not run doctests; the workspace has
+# none, so nothing is lost.
 test-intentd: ensure-intentd-submodule
-	cd $(INTENTD_DIR) && cargo test --workspace
+	@command -v cargo-nextest >/dev/null 2>&1 || { \
+		echo "[test-intentd] ERROR: cargo-nextest is not installed — run 'cargo install cargo-nextest --locked'"; \
+		exit 1; \
+	}
+	cd $(INTENTD_DIR) && cargo nextest run --workspace
 
 clean: ## Remove cargo build artifacts (packages/intentd/target)
 	rm -rf $(INTENTD_DIR)/target

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ cd monorepo
 git submodule update --init --recursive packages/intentd packages/cloudlands-fe
 
 make check   # cargo fmt --check + cargo clippy -- -D warnings
-make test    # cargo test --workspace
+make test    # cargo nextest run --workspace (needs cargo-nextest: cargo install cargo-nextest --locked)
 make build   # cargo build --workspace
 ```
 


### PR DESCRIPTION
Switches the monorepo `test-intentd` target from `cargo test --workspace` to `cargo nextest run --workspace`, so local full-suite runs (`make test`) pick up the same protections CI already has via `packages/intentd/.config/nextest.toml`: the `timing-serial` test group serialization, retries=1 (FLAKY reporting), and slow-timeout.

Part of intent-hq/monorepo#1630 (reference only — related hardening tasks remain open).

## Changes

- `test-intentd` now runs `cargo nextest run --workspace` from `packages/intentd`.
- A guard checks for the `cargo-nextest` binary first and fails with an actionable hint (`cargo install cargo-nextest --locked`, mirroring `packages/intentd/scripts/coverage-all.sh`) instead of a raw cargo failure.
- `make help` text for `test` updated to mention nextest.

Notes: nextest does not run doctests; the intentd workspace has none (see comment in `packages/intentd/scripts/coverage-all.sh`), so nothing is lost. No submodule contents are touched.

## Verification

- `make help` shows the updated `test` description.
- Guard verified: with `cargo-nextest` stripped from `PATH`, `make test-intentd` fails with `[test-intentd] ERROR: cargo-nextest is not installed — run 'cargo install cargo-nextest --locked'`.
- Full `make test` runs (twice, green under nextest) pending — the shared `packages/intentd` checkout is currently in exclusive use by a sibling task; results will be posted on this PR before merge.
