### PR TITLE
ci: remove zero-job push trigger from CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 name: CI
-on: [push, pull_request]
+on: pull_request
 
 permissions:
   contents: read


### PR DESCRIPTION
Part of the CI audit to stop redundant runs on push to main (workspace: audit-cis).

## What

Change the `CI` workflow trigger from `on: [push, pull_request]` to `on: pull_request`.

## Why

The only job (`pr-title`) is gated with `if: github.event_name == 'pull_request'`, so every push to main spawned a zero-job, all-skipped noise run. Dropping the push trigger removes that noise with no behavior change for PRs — `pr-title` still runs on every pull request.

## Verification

- YAML remains valid (single-line trigger change).
- `pr-title` check runs on this PR itself.
