### PR TITLE
feat: optional dev seeds for providers and workspaces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,8 @@ FE_BUILD_HEAP_MB ?= 16384
 .PHONY: all help ensure-submodules ensure-intentd-submodule ensure-fe-submodule ensure-ios-submodule \
 	update \
 	build build-intentd build-sidecar test test-intentd fmt clippy check clean clean-dev \
-	sweep sweep-all seed-dev-providers dev-daemon release-daemon run-intentd run-fe run-fe-local dev ios-open ios-info dist-mac
+	sweep sweep-all seed-dev-providers seed-dev-workspaces dev-daemon release-daemon \
+	run-intentd run-fe run-fe-local dev ios-open ios-info dist-mac
 
 all: build
 
@@ -274,12 +275,39 @@ sweep-all: ## Sweep intentd build artifacts in every worktree under $(WORKSPACES
 		fi; \
 	done
 
-# First boot only: inherit non-secret provider choices from the packaged seat.
-# Existing $(DEV_DATA_DIR) contents always win; missing prod config is a no-op.
-seed-dev-providers:
+# Optional: inherit non-secret provider choices from the packaged seat into an
+# empty $(DEV_DATA_DIR). Existing contents always win; missing prod config is a
+# no-op. Not wired into `dev` / `dev-daemon` — run explicitly when you want it:
+#   make seed-dev-providers
+#   make seed-dev-providers DEV_DATA_DIR=...
+seed-dev-providers: ## Seed provider prefs from packaged intentd into empty $(DEV_DATA_DIR)
 	@python3 scripts/seed_dev_providers.py --dev-data-dir "$(DEV_DATA_DIR)"
 
-dev-daemon: ensure-intentd-submodule seed-dev-providers ## Dev seat: intentd on isolated data dir, UDS + insecure TCP on $(DEV_TCP_PORT)
+# Optional: copy workspace rows from the packaged intentd SQLite DB into the
+# dev seat. Creates/migrates $(DEV_DATA_DIR)/intentd.db via `intentd doctor`
+# when missing, then inserts Active (default) workspace metadata only — not
+# agents, notes, messages, or assets. Skips ids already present; does not
+# touch the on-disk worktrees (paths point at the shared ~/intent/workspaces).
+# Not wired into `dev` / `dev-daemon` — run explicitly, ideally with the dev
+# daemon stopped so WAL/locking stays quiet:
+#   make seed-dev-workspaces
+#   make seed-dev-workspaces SEED_INCLUDE_ARCHIVED=1
+#   make seed-dev-workspaces SEED_SOURCE_DB=/path/to/intentd.db
+SEED_INCLUDE_ARCHIVED ?= 0
+seed-dev-workspaces: ensure-intentd-submodule ## Seed workspace rows from packaged intentd.db into $(DEV_DATA_DIR)
+	@mkdir -p "$(DEV_DATA_DIR)"
+	@if [ ! -f "$(DEV_DATA_DIR)/intentd.db" ]; then \
+		echo "[seed-dev-workspaces] initializing empty dev DB via intentd doctor..."; \
+		INTENTD_DATA_DIR="$(DEV_DATA_DIR)" \
+			cargo run -q -p intentd --manifest-path $(INTENTD_DIR)/Cargo.toml -- doctor >/dev/null; \
+	fi
+	@if [ "$(SEED_INCLUDE_ARCHIVED)" = "1" ]; then \
+			python3 scripts/seed_dev_workspaces.py --dev-data-dir "$(DEV_DATA_DIR)" --include-archived; \
+		else \
+			python3 scripts/seed_dev_workspaces.py --dev-data-dir "$(DEV_DATA_DIR)"; \
+		fi
+
+dev-daemon: ensure-intentd-submodule ## Dev seat: intentd on isolated data dir, UDS + insecure TCP on $(DEV_TCP_PORT)
 	@mkdir -p "$(DEV_DATA_DIR)"
 	@echo "[dev-daemon] intentd dev data dir: $(DEV_DATA_DIR) (UDS: $(DEV_DATA_DIR)/intentd.sock, TCP: 0.0.0.0:$(DEV_TCP_PORT))"
 	@echo "[dev-daemon] INTENTD_LEGACY_IMPORT_ROOTS=\"\" (legacy import disabled for the dev seat)"
@@ -416,7 +444,7 @@ dist-mac: update ## Pull/rebase monorepo+submodules, then package Intent.app int
 	cd $(FE_DIR) && NODE_OPTIONS="--max-old-space-size=$(FE_BUILD_HEAP_MB) $$NODE_OPTIONS" CSC_IDENTITY_AUTO_DISCOVERY=false pnpm run dist:mac
 	@echo "[dist-mac] Done. Artifacts in $(FE_DIR)/dist-electron"
 
-dev: ensure-intentd-submodule ensure-fe-submodule seed-dev-providers ## One-command dev: launch the FE with intentd as a sidecar (INTENTD_SIDECAR=1)
+dev: ensure-intentd-submodule ensure-fe-submodule ## One-command dev: launch the FE with intentd as a sidecar (INTENTD_SIDECAR=1)
 	# Launches the FE with sidecar spawning enabled (INTENTD_SIDECAR=1). The FE will
 	# spawn and supervise its own intentd binary, giving a one-command dev stack.
 	# Always runs the intentd release build first so the sidecar reflects the

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ FE_BUILD_HEAP_MB ?= 16384
 .PHONY: all help ensure-submodules ensure-intentd-submodule ensure-fe-submodule ensure-ios-submodule \
 	update \
 	build build-intentd build-sidecar test test-intentd fmt clippy check clean clean-dev \
-	sweep sweep-all dev-daemon release-daemon run-intentd run-fe run-fe-local dev ios-open ios-info dist-mac
+	sweep sweep-all seed-dev-providers dev-daemon release-daemon run-intentd run-fe run-fe-local dev ios-open ios-info dist-mac
 
 all: build
 
@@ -274,7 +274,12 @@ sweep-all: ## Sweep intentd build artifacts in every worktree under $(WORKSPACES
 		fi; \
 	done
 
-dev-daemon: ensure-intentd-submodule ## Dev seat: intentd on isolated data dir, UDS + insecure TCP on $(DEV_TCP_PORT)
+# First boot only: inherit non-secret provider choices from the packaged seat.
+# Existing $(DEV_DATA_DIR) contents always win; missing prod config is a no-op.
+seed-dev-providers:
+	@python3 scripts/seed_dev_providers.py --dev-data-dir "$(DEV_DATA_DIR)"
+
+dev-daemon: ensure-intentd-submodule seed-dev-providers ## Dev seat: intentd on isolated data dir, UDS + insecure TCP on $(DEV_TCP_PORT)
 	@mkdir -p "$(DEV_DATA_DIR)"
 	@echo "[dev-daemon] intentd dev data dir: $(DEV_DATA_DIR) (UDS: $(DEV_DATA_DIR)/intentd.sock, TCP: 0.0.0.0:$(DEV_TCP_PORT))"
 	@echo "[dev-daemon] INTENTD_LEGACY_IMPORT_ROOTS=\"\" (legacy import disabled for the dev seat)"
@@ -411,7 +416,7 @@ dist-mac: update ## Pull/rebase monorepo+submodules, then package Intent.app int
 	cd $(FE_DIR) && NODE_OPTIONS="--max-old-space-size=$(FE_BUILD_HEAP_MB) $$NODE_OPTIONS" CSC_IDENTITY_AUTO_DISCOVERY=false pnpm run dist:mac
 	@echo "[dist-mac] Done. Artifacts in $(FE_DIR)/dist-electron"
 
-dev: ensure-intentd-submodule ensure-fe-submodule ## One-command dev: launch the FE with intentd as a sidecar (INTENTD_SIDECAR=1)
+dev: ensure-intentd-submodule ensure-fe-submodule seed-dev-providers ## One-command dev: launch the FE with intentd as a sidecar (INTENTD_SIDECAR=1)
 	# Launches the FE with sidecar spawning enabled (INTENTD_SIDECAR=1). The FE will
 	# spawn and supervise its own intentd binary, giving a one-command dev stack.
 	# Always runs the intentd release build first so the sidecar reflects the

--- a/scripts/seed_dev_providers.py
+++ b/scripts/seed_dev_providers.py
@@ -37,7 +37,7 @@ def render_seed(providers: object) -> str | None:
     enabled = providers.get("enabled")
     paths = providers.get("paths")
     lines = [
-        "# Seeded once by make dev from the packaged intentd config.",
+        "# Seeded by make seed-dev-providers from the packaged intentd config.",
         "[providers]",
     ]
     seeded = False

--- a/scripts/seed_dev_providers.py
+++ b/scripts/seed_dev_providers.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Seed an empty intentd dev seat with non-secret provider preferences."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import sys
+import tomllib
+
+
+def default_prod_config() -> Path | None:
+    home = Path.home()
+    if sys.platform == "darwin":
+        return home / "Library/Application Support/intentd/config.toml"
+    if sys.platform == "win32":
+        app_data = os.environ.get("APPDATA")
+        return Path(app_data) / "intentd/data/config.toml" if app_data else None
+    if sys.platform.startswith("linux"):
+        data_home = os.environ.get("XDG_DATA_HOME")
+        if data_home:
+            return Path(data_home) / "intentd/config.toml"
+        return home / ".local/share/intentd/config.toml"
+    return None
+
+
+def toml_string(value: str) -> str:
+    return json.dumps(value, ensure_ascii=False)
+
+
+def render_seed(providers: object) -> str | None:
+    if not isinstance(providers, dict):
+        return None
+    active = providers.get("active")
+    enabled = providers.get("enabled")
+    paths = providers.get("paths")
+    lines = [
+        "# Seeded once by make dev from the packaged intentd config.",
+        "[providers]",
+    ]
+    seeded = False
+    if isinstance(active, str) and active:
+        lines.append(f"active = {toml_string(active)}")
+        seeded = True
+    if isinstance(enabled, dict) and all(
+        isinstance(key, str) and isinstance(value, bool) for key, value in enabled.items()
+    ):
+        entries = ", ".join(
+            f"{toml_string(key)} = {'true' if value else 'false'}"
+            for key, value in sorted(enabled.items())
+        )
+        lines.append(f"enabled = {{ {entries} }}")
+        seeded = True
+    absolute_paths = {}
+    if isinstance(paths, dict):
+        absolute_paths = {
+            key: value
+            for key, value in paths.items()
+            if isinstance(key, str) and isinstance(value, str) and os.path.isabs(value)
+        }
+    if absolute_paths:
+        entries = ", ".join(
+            f"{toml_string(key)} = {toml_string(value)}"
+            for key, value in sorted(absolute_paths.items())
+        )
+        lines.append(f"paths = {{ {entries} }}")
+        seeded = True
+    return "\n".join(lines) + "\n" if seeded else None
+
+
+def seed(dev_data_dir: Path, source: Path | None) -> str:
+    if dev_data_dir.exists() and any(dev_data_dir.iterdir()):
+        return "existing dev seat; provider seed skipped"
+    if source is None or not source.is_file():
+        return "packaged config not found; provider seed skipped"
+    try:
+        config = tomllib.loads(source.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError) as error:
+        return f"packaged config unreadable ({error}); provider seed skipped"
+    rendered = render_seed(config.get("providers"))
+    if rendered is None:
+        return "packaged config has no provider preferences; provider seed skipped"
+    dev_data_dir.mkdir(parents=True, exist_ok=True)
+    if any(dev_data_dir.iterdir()):
+        return "existing dev seat; provider seed skipped"
+    try:
+        with (dev_data_dir / "config.toml").open("x", encoding="utf-8") as config_file:
+            config_file.write(rendered)
+    except FileExistsError:
+        return "existing dev config; provider seed skipped"
+    return f"seeded provider preferences from {source}"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dev-data-dir", required=True, type=Path)
+    parser.add_argument("--source", type=Path)
+    args = parser.parse_args()
+    source = args.source or default_prod_config()
+    print(f"[seed-dev-providers] {seed(args.dev_data_dir, source)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/seed_dev_workspaces.py
+++ b/scripts/seed_dev_workspaces.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Seed a dev intentd SQLite DB with workspace rows from the packaged seat.
+
+Copies workspace *metadata* only (title, paths, branch, status, …). Does not
+copy agents, notes, messages, assets, or on-disk worktrees — paths keep pointing
+at the shared production checkouts (typically ~/intent/workspaces).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+# Keep in sync with intent-store WORKSPACE_COLUMNS + auto_commit_enabled.
+WORKSPACE_COLUMNS = (
+    "id, title, branch, base_ref, base_commit_sha, status, "
+    "status_message, status_image_asset_id, attention, path, repository_path, "
+    "repository_owner, repository_name, worktree_path, scope, skip_worktree, "
+    "is_remote, default_model, pr_number, pr_url, pr_status, active_pull_request, "
+    "pull_requests, archived, archived_at, tags, created_at, updated_at, "
+    "last_activity, token_usage, setup_script, checkout_mode, auto_commit_enabled"
+)
+
+# Skip virtual rows the daemon recreates itself (chief of staff).
+SKIP_IDS = frozenset({"__chief__"})
+
+
+def default_prod_db() -> Path | None:
+    home = Path.home()
+    if sys.platform == "darwin":
+        return home / "Library/Application Support/intentd/intentd.db"
+    if sys.platform == "win32":
+        app_data = os.environ.get("APPDATA")
+        return Path(app_data) / "intentd/data/intentd.db" if app_data else None
+    if sys.platform.startswith("linux"):
+        data_home = os.environ.get("XDG_DATA_HOME")
+        if data_home:
+            return Path(data_home) / "intentd/intentd.db"
+        return home / ".local/share/intentd/intentd.db"
+    return None
+
+
+def open_ro(path: Path) -> sqlite3.Connection:
+    # URI read-only: survives a running packaged daemon's write lock / WAL.
+    conn = sqlite3.connect(path.resolve().as_uri() + "?mode=ro", uri=True)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _cols(conn: sqlite3.Connection) -> set[str]:
+    return {row[1] for row in conn.execute("PRAGMA table_info(workspace)")}
+
+
+def seed(
+    dev_data_dir: Path,
+    source_db: Path | None,
+    *,
+    include_archived: bool = False,
+) -> str:
+    if source_db is None or not source_db.is_file():
+        return "packaged intentd.db not found; workspace seed skipped"
+
+    dest_db = dev_data_dir / "intentd.db"
+    if not dest_db.is_file():
+        return f"dev DB missing at {dest_db}; initialize via make seed-dev-workspaces first"
+
+    try:
+        src, dst = open_ro(source_db), sqlite3.connect(dest_db)
+    except sqlite3.Error as error:
+        return f"DB unreadable ({error}); workspace seed skipped"
+
+    try:
+        wanted = [c.strip() for c in WORKSPACE_COLUMNS.split(",")]
+        cols = [c for c in wanted if c in _cols(src) and c in _cols(dst)]
+        if "id" not in cols:
+            return "workspace table/columns missing; workspace seed skipped"
+
+        status_filter = (
+            "status IN ('Active', 'Archived')" if include_archived else "status = 'Active'"
+        )
+        col_sql = ", ".join(cols)
+        rows = src.execute(
+            f"SELECT {col_sql} FROM workspace WHERE {status_filter} ORDER BY id"
+        ).fetchall()
+        existing = {r[0] for r in dst.execute("SELECT id FROM workspace")}
+        insert_sql = f"INSERT INTO workspace ({col_sql}) VALUES ({', '.join('?' for _ in cols)})"
+
+        inserted = skipped = 0
+        for row in rows:
+            ws_id = row["id"]
+            if ws_id in SKIP_IDS or ws_id in existing:
+                skipped += 1
+                continue
+            try:
+                dst.execute(insert_sql, [row[c] for c in cols])
+            except sqlite3.IntegrityError:
+                skipped += 1
+                continue
+            inserted += 1
+            existing.add(ws_id)
+
+        dst.commit()
+        label = "Active+Archived" if include_archived else "Active"
+        return f"seeded {inserted} {label} workspace(s) from {source_db} ({skipped} skipped)"
+    except sqlite3.Error as error:
+        return f"workspace seed failed ({error})"
+    finally:
+        src.close()
+        dst.close()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dev-data-dir", required=True, type=Path)
+    parser.add_argument("--source", type=Path, help="path to packaged intentd.db")
+    parser.add_argument(
+        "--include-archived",
+        action="store_true",
+        help="also copy Archived workspaces (default: Active only)",
+    )
+    args = parser.parse_args()
+    source = args.source or default_prod_db()
+    print(
+        f"[seed-dev-workspaces] {seed(args.dev_data_dir, source, include_archived=args.include_archived)}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test_seed_dev_providers.py
+++ b/scripts/test_seed_dev_providers.py
@@ -1,0 +1,79 @@
+import importlib.util
+from pathlib import Path
+import tempfile
+import tomllib
+import unittest
+
+
+SCRIPT = Path(__file__).with_name("seed_dev_providers.py")
+SPEC = importlib.util.spec_from_file_location("seed_dev_providers", SCRIPT)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(MODULE)
+
+
+class SeedDevProvidersTests(unittest.TestCase):
+    def test_seeds_preferences_and_only_absolute_paths(self):
+        with tempfile.TemporaryDirectory() as root:
+            root_path = Path(root)
+            source = root_path / "prod.toml"
+            dev = root_path / "dev"
+            absolute = str(root_path / "bin/codex")
+            source.write_text(
+                "[providers]\n"
+                'active = "auggie"\n'
+                'enabled = { auggie = true, codex = false }\n'
+                f'paths = {{ codex = "{absolute}", auggie = "relative/bin" }}\n',
+                encoding="utf-8",
+            )
+
+            result = MODULE.seed(dev, source)
+
+            self.assertIn("seeded provider preferences", result)
+            providers = tomllib.loads((dev / "config.toml").read_text())["providers"]
+            self.assertEqual(providers["active"], "auggie")
+            self.assertEqual(providers["enabled"], {"auggie": True, "codex": False})
+            self.assertEqual(providers["paths"], {"codex": absolute})
+
+    def test_second_run_never_overwrites_dev_edits(self):
+        with tempfile.TemporaryDirectory() as root:
+            root_path = Path(root)
+            source = root_path / "prod.toml"
+            dev = root_path / "dev"
+            source.write_text('[providers]\nactive = "auggie"\nenabled = { codex = true }\n')
+            MODULE.seed(dev, source)
+            edited = '[providers]\nactive = "codex"\nenabled = { codex = false }\n'
+            (dev / "config.toml").write_text(edited)
+            source.write_text('[providers]\nactive = "grok"\nenabled = { grok = true }\n')
+
+            result = MODULE.seed(dev, source)
+
+            self.assertIn("existing dev seat", result)
+            self.assertEqual((dev / "config.toml").read_text(), edited)
+
+    def test_missing_source_is_a_clean_noop(self):
+        with tempfile.TemporaryDirectory() as root:
+            dev = Path(root) / "dev"
+
+            result = MODULE.seed(dev, Path(root) / "missing.toml")
+
+            self.assertIn("not found", result)
+            self.assertFalse(dev.exists())
+
+    def test_existing_default_config_is_not_modified(self):
+        with tempfile.TemporaryDirectory() as root:
+            root_path = Path(root)
+            source = root_path / "prod.toml"
+            dev = root_path / "dev"
+            dev.mkdir()
+            existing = "[providers]\npaths = {}\n"
+            (dev / "config.toml").write_text(existing)
+            source.write_text('[providers]\nactive = "auggie"\n')
+
+            MODULE.seed(dev, source)
+
+            self.assertEqual((dev / "config.toml").read_text(), existing)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_seed_dev_workspaces.py
+++ b/scripts/test_seed_dev_workspaces.py
@@ -1,0 +1,168 @@
+import importlib.util
+import sqlite3
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).with_name("seed_dev_workspaces.py")
+SPEC = importlib.util.spec_from_file_location("seed_dev_workspaces", SCRIPT)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(MODULE)
+
+SCHEMA = """
+CREATE TABLE workspace (
+  id TEXT PRIMARY KEY,
+  title TEXT NOT NULL,
+  branch TEXT NOT NULL,
+  base_ref TEXT,
+  base_commit_sha TEXT,
+  status TEXT NOT NULL DEFAULT 'Active',
+  status_message TEXT,
+  status_image_asset_id TEXT,
+  attention TEXT NOT NULL DEFAULT 'none',
+  path TEXT,
+  repository_path TEXT,
+  repository_owner TEXT,
+  repository_name TEXT,
+  worktree_path TEXT,
+  scope TEXT,
+  skip_worktree INTEGER NOT NULL DEFAULT 0,
+  is_remote INTEGER NOT NULL DEFAULT 0,
+  default_model TEXT,
+  pr_number INTEGER,
+  pr_url TEXT,
+  pr_status TEXT,
+  active_pull_request TEXT,
+  pull_requests TEXT,
+  archived INTEGER NOT NULL DEFAULT 0,
+  archived_at TEXT,
+  tags TEXT NOT NULL DEFAULT '[]',
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  last_activity TEXT,
+  token_usage TEXT,
+  setup_script TEXT,
+  checkout_mode TEXT,
+  auto_commit_enabled INTEGER
+);
+"""
+
+
+def _make_db(path: Path, rows: list[tuple]) -> None:
+    conn = sqlite3.connect(path)
+    conn.executescript(SCHEMA)
+    cols = "id, title, branch, status, path, repository_path, worktree_path, created_at, updated_at"
+    for row in rows:
+        conn.execute(
+            f"INSERT INTO workspace ({cols}) VALUES (?,?,?,?,?,?,?,?,?)",
+            row,
+        )
+    conn.commit()
+    conn.close()
+
+
+def _ids(path: Path) -> set[str]:
+    conn = sqlite3.connect(path)
+    out = {r[0] for r in conn.execute("SELECT id FROM workspace")}
+    conn.close()
+    return out
+
+
+class SeedDevWorkspacesTests(unittest.TestCase):
+    def test_seeds_active_only_and_skips_chief(self):
+        with tempfile.TemporaryDirectory() as root:
+            root_path = Path(root)
+            source = root_path / "prod.db"
+            dev = root_path / "dev"
+            dev.mkdir()
+            dest = dev / "intentd.db"
+            ts = "2026-01-01T00:00:00Z"
+            _make_db(
+                source,
+                [
+                    ("__chief__", "Chief", "main", "Active", None, None, None, ts, ts),
+                    ("alpha", "Alpha", "b1", "Active", "/p/a", "/r/a", "/w/a", ts, ts),
+                    ("beta", "Beta", "b2", "Archived", "/p/b", "/r/b", "/w/b", ts, ts),
+                ],
+            )
+            _make_db(dest, [])
+
+            result = MODULE.seed(dev, source)
+
+            self.assertIn("seeded 1 Active", result)
+            self.assertEqual(_ids(dest), {"alpha"})
+            conn = sqlite3.connect(dest)
+            row = conn.execute(
+                "SELECT title, path, worktree_path FROM workspace WHERE id='alpha'"
+            ).fetchone()
+            conn.close()
+            self.assertEqual(row, ("Alpha", "/p/a", "/w/a"))
+
+    def test_include_archived(self):
+        with tempfile.TemporaryDirectory() as root:
+            root_path = Path(root)
+            source = root_path / "prod.db"
+            dev = root_path / "dev"
+            dev.mkdir()
+            dest = dev / "intentd.db"
+            ts = "2026-01-01T00:00:00Z"
+            _make_db(
+                source,
+                [
+                    ("alpha", "Alpha", "b1", "Active", "/p/a", "/r/a", "/w/a", ts, ts),
+                    ("beta", "Beta", "b2", "Archived", "/p/b", "/r/b", "/w/b", ts, ts),
+                ],
+            )
+            _make_db(dest, [])
+
+            result = MODULE.seed(dev, source, include_archived=True)
+
+            self.assertIn("seeded 2 Active+Archived", result)
+            self.assertEqual(_ids(dest), {"alpha", "beta"})
+
+    def test_idempotent_second_run(self):
+        with tempfile.TemporaryDirectory() as root:
+            root_path = Path(root)
+            source = root_path / "prod.db"
+            dev = root_path / "dev"
+            dev.mkdir()
+            dest = dev / "intentd.db"
+            ts = "2026-01-01T00:00:00Z"
+            _make_db(
+                source,
+                [("alpha", "Alpha", "b1", "Active", "/p/a", "/r/a", "/w/a", ts, ts)],
+            )
+            _make_db(dest, [])
+            MODULE.seed(dev, source)
+            result = MODULE.seed(dev, source)
+            self.assertIn("seeded 0", result)
+            self.assertIn("1 skipped", result)
+            self.assertEqual(_ids(dest), {"alpha"})
+
+    def test_missing_source_is_noop(self):
+        with tempfile.TemporaryDirectory() as root:
+            dev = Path(root) / "dev"
+            dev.mkdir()
+            (dev / "intentd.db").write_bytes(b"")
+            # empty file is still "present"; use a missing path
+            result = MODULE.seed(dev, Path(root) / "missing.db")
+            self.assertIn("not found", result)
+
+    def test_missing_dest_db_is_noop(self):
+        with tempfile.TemporaryDirectory() as root:
+            root_path = Path(root)
+            source = root_path / "prod.db"
+            dev = root_path / "dev"
+            dev.mkdir()
+            ts = "2026-01-01T00:00:00Z"
+            _make_db(
+                source,
+                [("alpha", "Alpha", "b1", "Active", "/p/a", "/r/a", "/w/a", ts, ts)],
+            )
+            result = MODULE.seed(dev, source)
+            self.assertIn("dev DB missing", result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Optional monorepo dev-seat seeding — nothing runs automatically on `make dev` / `make dev-daemon`.

### `make seed-dev-providers`
- Copies non-secret `providers.active` / `providers.enabled` (and absolute path overrides) from the packaged intentd `config.toml` into an empty `DEV_DATA_DIR`
- First-boot only: existing dev seat contents always win; missing prod config is a clean no-op

### `make seed-dev-workspaces` (new)
- Copies **workspace metadata** rows from the packaged app `intentd.db` into `$(DEV_DATA_DIR)/intentd.db`
- Default: **Active** only; `SEED_INCLUDE_ARCHIVED=1` also takes Archived
- Skips `__chief__`; idempotent (existing ids left alone)
- Does **not** copy agents, notes, messages, assets, or on-disk worktrees — path fields keep pointing at shared `~/intent/workspaces` checkouts
- Initializes a missing dev DB via `intentd doctor` first

```bash
make seed-dev-providers
make seed-dev-workspaces
make seed-dev-workspaces SEED_INCLUDE_ARCHIVED=1
```

## Test plan
- [x] `python3 scripts/test_seed_dev_providers.py` (4/4)
- [x] `python3 scripts/test_seed_dev_workspaces.py` (5/5)
- [x] Smoke seed against live packaged DB → 22 Active workspaces; second run no-op
- [x] `make -n dev` / `make -n dev-daemon` no longer invoke provider seed
- [ ] Optional: wipe `.dev/intentd`, `make seed-dev-workspaces`, `make dev`, confirm sidebar shows prod Active workspaces

## Notes
Rebased onto latest `main`. FE settings redesign / intentd nvm PATH discovery remain companion work; submodule pin bumps can follow separately.
