### PR TITLE
docs: release mirrors are permanent public distribution channels

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,7 +92,10 @@ workflow dispatch.
   first with a coded fallback to intentd. Daemon release notes are mirrored too
   (source changelog with download URLs rewritten to the mirror; sitter releases
   keep their purpose-written notes). `mirror-release.yml` (manual dispatch)
-  backfills older releases. The mirror is temporary until intentd is open-sourced.
+  backfills older releases. The `-releases` repos ([intent-hq/intentd-releases](https://github.com/intent-hq/intentd-releases)
+  and [intent-hq/cloudlands-releases](https://github.com/intent-hq/cloudlands-releases))
+  are the **permanent** public distribution channels — manifests, download URLs, and
+  the Homebrew formula keep pointing at them even after the source repos go public.
   Sitter installers (Homebrew, `.deb`, `sitter-latest`) are also mirrored to
   intentd-releases by `release-sitter.yml`, and the published install URLs (Homebrew
   formula, README curl commands) point at the mirror.

--- a/README.md
+++ b/README.md
@@ -39,6 +39,23 @@ install that channel's version immediately — also the downgrade path — then
 `intentd restart` to activate it in place). Per-launch `--sitter-channel` /
 `INTENTD_CHANNEL` overrides take precedence over the pin.
 
+### One-line script (macOS & Linux)
+
+```sh
+curl -fsSL https://github.com/intent-hq/intentd-releases/releases/download/sitter-latest/install.sh | sh
+```
+
+Detects OS/arch, verifies the archive checksum, and installs `intentd` to
+`/usr/local/bin` when writable, else `~/.local/bin` (override with
+`INTENTD_INSTALL_DIR`). Then start the daemon with `intentd serve`, or use
+the Homebrew / `.deb` installs below for a managed background service.
+
+On Windows:
+
+```powershell
+powershell -c "irm https://github.com/intent-hq/intentd-releases/releases/download/sitter-latest/install.ps1 | iex"
+```
+
 ### Homebrew (macOS & Linux)
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -151,7 +151,8 @@ update checks against public GitHub Releases and actions you take yourself:
   [intent-hq/intentd-releases](https://github.com/intent-hq/intentd-releases)
   mirror, falling back to the
   [intentd releases page](https://github.com/intent-hq/intentd/releases). The
-  mirror is temporary until the intentd repo is open-sourced.
+  mirror is the permanent public distribution channel, kept even after the
+  intentd repo goes public.
 - **Auggie binary download (on demand)** — installing the Auggie CLI from the
   desktop app downloads the pre-built binary from the latest public release of
   [augmentcode/auggie](https://github.com/augmentcode/auggie).


### PR DESCRIPTION
## Summary

Updates AGENTS.md's release-process section: the `-releases` repos ([intent-hq/intentd-releases](https://github.com/intent-hq/intentd-releases) and [intent-hq/cloudlands-releases](https://github.com/intent-hq/cloudlands-releases)) are the **permanent** public distribution channels, replacing the "The mirror is temporary until intentd is open-sourced" framing.

Per the decision recorded on [#427 (comment)](https://github.com/intent-hq/monorepo/issues/427#issuecomment-5236204108): manifests, download URLs, and the Homebrew formula keep pointing at the `-releases` mirrors even after the source repos go public.

## Verification

- `grep -ri "temporary" AGENTS.md docs/` — no remaining mirror-is-temporary claims (the only prior hit was AGENTS.md:95).
- Other "mirror" occurrences in `docs/` are unrelated (byte-for-byte pipe-name mirroring, DTO field mirroring) and untouched.

Refs #427.
