### PR TITLE
fix: skip private packages/ios submodule for public clones

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,4 @@
 	path = packages/ios
 	url = https://github.com/intent-hq/ios.git
 	branch = main
+	update = none

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,10 @@ submodules:
 Code lives in the submodule repos. The monorepo tracks specific commits of each submodule.
 `packages/ios` is private and marked `update = none` in `.gitmodules`: recursive clones and
 `git submodule update --init --recursive` skip it by design, and internal devs initialize it
-on demand with `make ensure-ios-submodule`.
+on demand with `make ensure-ios-submodule`. When iOS goes public, deleting the `update = none`
+line is not enough for clones registered during the private period — they must also run
+`git config --unset submodule.packages/ios.update`, because `git submodule init` copies the
+key into the clone's local `.git/config` and `git submodule sync` does not refresh it.
 The durable engineering docs live in `docs/ARCHITECTURE.md` (backend architecture) and
 `docs/PROTOCOL.md` (canonical wire contract); see `docs/README.md` for the docs index.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,9 +9,12 @@ submodules:
 
 - `packages/intentd` → [intent-hq/intentd](https://github.com/intent-hq/intentd) — Rust backend daemon
 - `packages/cloudlands-fe` → [intent-hq/cloudlands-fe](https://github.com/intent-hq/cloudlands-fe) — Electron + SvelteKit desktop frontend
-- `packages/ios` → [intent-hq/ios](https://github.com/intent-hq/ios) — SwiftUI iOS companion app
+- `packages/ios` → [intent-hq/ios](https://github.com/intent-hq/ios) — SwiftUI iOS companion app (private)
 
 Code lives in the submodule repos. The monorepo tracks specific commits of each submodule.
+`packages/ios` is private and marked `update = none` in `.gitmodules`: recursive clones and
+`git submodule update --init --recursive` skip it by design, and internal devs initialize it
+on demand with `make ensure-ios-submodule`.
 The durable engineering docs live in `docs/ARCHITECTURE.md` (backend architecture) and
 `docs/PROTOCOL.md` (canonical wire contract); see `docs/README.md` for the docs index.
 
@@ -171,7 +174,7 @@ bootstrap", "Crate skeleton", "Core + SQLite store", "UDS JSON-RPC slice").
 ## Local Setup
 
 ```bash
-git submodule update --init --recursive
+git submodule update --init --recursive   # skips the private packages/ios (update = none)
 make check
 make test
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,11 @@ lives in the submodule repos:
 |------|------------|-----------|
 | `packages/intentd` | [intent-hq/intentd](https://github.com/intent-hq/intentd) | Rust backend daemon |
 | `packages/cloudlands-fe` | [intent-hq/cloudlands-fe](https://github.com/intent-hq/cloudlands-fe) | Electron + SvelteKit desktop frontend |
-| `packages/ios` | [intent-hq/ios](https://github.com/intent-hq/ios) | SwiftUI iOS companion app |
+| `packages/ios` | [intent-hq/ios](https://github.com/intent-hq/ios) | SwiftUI iOS companion app (private) |
+
+`packages/ios` is private and marked `update = none` in `.gitmodules`, so
+recursive clones and submodule updates skip it by default; internal developers
+with access initialize it via `make ensure-ios-submodule`.
 
 The durable engineering docs live in [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)
 (backend architecture) and [docs/PROTOCOL.md](docs/PROTOCOL.md) (the canonical
@@ -88,7 +92,7 @@ Keep the relevant checks green before opening a PR:
 ## Local setup
 
 ```bash
-git submodule update --init --recursive
+git submodule update --init --recursive   # skips the private packages/ios by design
 make check
 make test
 ```

--- a/Makefile
+++ b/Makefile
@@ -82,11 +82,21 @@ all: build
 help: ## List documented targets
 	@awk 'BEGIN {FS = ":.*## "} /^[a-zA-Z0-9_-]+:.*## / {printf "  %-16s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 
-ensure-submodules: ## Initialize any missing submodules — intentd, FE, iOS (idempotent)
+# The iOS submodule is private and marked `update = none` in .gitmodules, so
+# the generic `git submodule update --init` would silently skip it while
+# claiming success. Its leg passes `--checkout` to override `update = none`,
+# and fails soft (warning, not error) when the clone fails — e.g. no access to
+# the private repo.
+ensure-submodules: ## Initialize any missing submodules — intentd, FE, iOS (idempotent; iOS is fail-soft)
 	@for sm in $(SUBMODULES); do \
 		if [ ! -e "$$sm/.git" ]; then \
 			echo "[ensure-submodules] initializing $$sm"; \
-			git submodule update --init --recursive "$$sm" || exit 1; \
+			if [ "$$sm" = "$(IOS_DIR)" ]; then \
+				git submodule update --init --checkout --recursive "$$sm" \
+					|| echo "[ensure-submodules] WARNING: could not initialize $$sm (private repo; skipping — check GitHub access if you need it)"; \
+			else \
+				git submodule update --init --recursive "$$sm" || exit 1; \
+			fi; \
 		else \
 			echo "[ensure-submodules] $$sm already initialized — leaving as-is"; \
 		fi; \
@@ -114,11 +124,13 @@ ensure-fe-submodule:
 	fi
 
 # On-demand init for the iOS submodule — pulled in only by targets that need
-# it (`ios-open`); backend-only workflows stay fast.
+# it (`ios-open`); backend-only workflows stay fast. `--checkout` overrides the
+# `update = none` in .gitmodules (set so external clones skip this private
+# repo) so it still initializes on machines with access.
 ensure-ios-submodule:
 	@if [ ! -e "$(IOS_DIR)/.git" ]; then \
 		echo "[ensure-ios-submodule] initializing $(IOS_DIR)"; \
-		git submodule update --init --recursive "$(IOS_DIR)"; \
+		git submodule update --init --checkout --recursive "$(IOS_DIR)"; \
 	else \
 		echo "[ensure-ios-submodule] $(IOS_DIR) already initialized — leaving as-is"; \
 	fi
@@ -156,11 +168,15 @@ update: ## git pull --rebase monorepo + each submodule onto its .gitmodules bran
 	git submodule update --init --recursive; \
 	for sm in $(SUBMODULES); do \
 		branch=$$(git config -f .gitmodules --get "submodule.$$sm.branch" 2>/dev/null || echo main); \
-		echo "[update] $$sm → $$branch (pull --rebase --autostash)"; \
 		if [ ! -e "$$sm/.git" ]; then \
+			if [ "$$(git config -f .gitmodules --get "submodule.$$sm.update" 2>/dev/null)" = "none" ]; then \
+				echo "[update] $$sm is not initialized (update = none) — skipping"; \
+				continue; \
+			fi; \
 			echo "[update] ERROR: $$sm is not initialized after submodule update --init"; \
 			exit 1; \
 		fi; \
+		echo "[update] $$sm → $$branch (pull --rebase --autostash)"; \
 		git -C "$$sm" fetch --prune origin; \
 		cur=$$(git -C "$$sm" rev-parse --abbrev-ref HEAD); \
 		if [ "$$cur" = "HEAD" ] || [ "$$cur" != "$$branch" ]; then \
@@ -181,7 +197,11 @@ update: ## git pull --rebase monorepo + each submodule onto its .gitmodules bran
 	echo "[update] done."; \
 	echo "[update] monorepo $$(git rev-parse --abbrev-ref HEAD) @ $$(git rev-parse --short HEAD)"; \
 	for sm in $(SUBMODULES); do \
-		echo "[update]   $$sm $$(git -C $$sm rev-parse --abbrev-ref HEAD) @ $$(git -C $$sm rev-parse --short HEAD)"; \
+		if [ -e "$$sm/.git" ]; then \
+			echo "[update]   $$sm $$(git -C $$sm rev-parse --abbrev-ref HEAD) @ $$(git -C $$sm rev-parse --short HEAD)"; \
+		else \
+			echo "[update]   $$sm (not initialized — skipped)"; \
+		fi; \
 	done; \
 	if ! git diff --quiet -- $(SUBMODULES) 2>/dev/null \
 		|| ! git diff --cached --quiet -- $(SUBMODULES) 2>/dev/null; then \

--- a/Makefile
+++ b/Makefile
@@ -86,13 +86,16 @@ help: ## List documented targets
 # the generic `git submodule update --init` would silently skip it while
 # claiming success. Its leg passes `--checkout` to override `update = none`,
 # and fails soft (warning, not error) when the clone fails — e.g. no access to
-# the private repo.
+# the private repo. GIT_TERMINAL_PROMPT=0 makes that failure fast and
+# non-interactive (no `Username for https://github.com:` prompt when no
+# credentials are cached); internal devs who want to authenticate
+# interactively can use `make ensure-ios-submodule`, which still prompts.
 ensure-submodules: ## Initialize any missing submodules — intentd, FE, iOS (idempotent; iOS is fail-soft)
 	@for sm in $(SUBMODULES); do \
 		if [ ! -e "$$sm/.git" ]; then \
 			echo "[ensure-submodules] initializing $$sm"; \
 			if [ "$$sm" = "$(IOS_DIR)" ]; then \
-				git submodule update --init --checkout --recursive "$$sm" \
+				GIT_TERMINAL_PROMPT=0 git submodule update --init --checkout --recursive "$$sm" \
 					|| echo "[ensure-submodules] WARNING: could not initialize $$sm (private repo; skipping — check GitHub access if you need it)"; \
 			else \
 				git submodule update --init --recursive "$$sm" || exit 1; \

--- a/README.md
+++ b/README.md
@@ -78,15 +78,18 @@ Releases. Until then, you can [build it from source](#build-from-source).
 ## Build from source
 
 ```sh
-git clone https://github.com/intent-hq/monorepo.git
+git clone --recurse-submodules https://github.com/intent-hq/monorepo.git
 cd monorepo
-# Init the public submodules (packages/ios is currently private):
-git submodule update --init --recursive packages/intentd packages/cloudlands-fe
 
 make check   # cargo fmt --check + cargo clippy -- -D warnings
 make test    # cargo nextest run --workspace (needs cargo-nextest: cargo install cargo-nextest --locked)
 make build   # cargo build --workspace
 ```
+
+`packages/ios` is a private submodule and is skipped automatically
+(`update = none` in `.gitmodules`), so the clone succeeds without access to
+[intent-hq/ios](https://github.com/intent-hq/ios) — the directory is simply
+left empty.
 
 Run the stack locally in one of two ways:
 


### PR DESCRIPTION
## Summary

Prepares the monorepo for going public while `intent-hq/ios` stays private: keeps the `packages/ios` gitlink (and its version pin) but marks it `update = none` in `.gitmodules`, so external users' recursive clones skip it cleanly instead of failing with a 404/credential prompt.

Fixes intent-hq/monorepo#418

## Changes

- **.gitmodules**: `update = none` for `packages/ios` — `git clone --recurse-submodules` and `git submodule update --init --recursive` now skip it (exit 0, empty dir).
- **Makefile**:
  - `ensure-ios-submodule` uses `--checkout` to force-init despite `update = none` (internal devs with access).
  - `ensure-submodules` ios leg is `--checkout` + fail-soft warning when the clone fails due to no access.
  - `update` skips uninitialized `update = none` submodules with a notice instead of erroring (incl. the summary loop).
- **Docs** (README, CONTRIBUTING, AGENTS): `packages/ios` documented as private/optional, skipped by default, initializable via `make ensure-ios-submodule`; README build-from-source simplified to plain `git clone --recurse-submodules`.

## Verification

- Fresh `file://` recursive clone: exit 0, "Skipping submodule 'packages/ios'", ios dir empty, intentd + fe checked out; `git submodule update --init --recursive` in the clone: exit 0, ios still empty.
- `make ensure-submodules` / `make ensure-ios-submodule`: succeed both with ios uninitialized and as no-ops when initialized.
- Independently re-verified end-to-end by a verifier agent.

## Notes

- Follow-up when iOS goes public: delete the `update = none` line.
- Known git quirk (outside the Makefile): a global `submodule.recurse=true` makes `git pull` itself try to clone ios during `make update`.
