### PR TITLE
docs: migrate audited cloudlands-fe docs to docs/fe

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,46 @@ subscriptions, and error codes. The detailed wire contract from the porting era 
 merged in, making this the single canonical spec. The method surface is enforced by
 golden tests in the `intent-transport` crate.
 
+## Frontend — `fe/`
+
+Durable documentation for the `cloudlands-fe` desktop frontend (Electron + SvelteKit),
+migrated from `packages/cloudlands-fe/docs/` after an accuracy audit:
+
+**Architecture & state**
+
+- [fe/STATE_MANAGEMENT.md](./fe/STATE_MANAGEMENT.md) — Redux/Themis state architecture and side-effect ownership
+- [fe/EVENT_SYSTEM.md](./fe/EVENT_SYSTEM.md) — workspace event system and renderer IPC event handling
+- [fe/COMPONENTS_DESIGN.md](./fe/COMPONENTS_DESIGN.md) — Svelte 5 + Redux component design guidance
+- [fe/MODULE_BOUNDARY_GUIDE.md](./fe/MODULE_BOUNDARY_GUIDE.md) — directory roles and module placement rules
+- [fe/TYPE_SYSTEM_GUIDE.md](./fe/TYPE_SYSTEM_GUIDE.md) — IPC type-system contracts, validation, and codegen
+- [fe/agent-message-dedup-and-stream-sagas.md](./fe/agent-message-dedup-and-stream-sagas.md) — agent message dedup and stream saga ownership
+
+**Guides**
+
+- [fe/DEVELOPER_GUIDE.md](./fe/DEVELOPER_GUIDE.md) — project structure, agent factory, tab registry, provider system
+- [fe/TROUBLESHOOTING_GUIDE.md](./fe/TROUBLESHOOTING_GUIDE.md) — common issues and debugging workflow
+- [fe/IPC_DEBUG_GUIDE.md](./fe/IPC_DEBUG_GUIDE.md) — IPC debug tooling and adding new channels
+- [fe/ERROR_HANDLING_SYSTEM.md](./fe/ERROR_HANDLING_SYSTEM.md) — error handler, reporter, and toast utilities
+- [fe/KEYBINDINGS.md](./fe/KEYBINDINGS.md) — keyboard shortcut reference and audit notes
+- [fe/PR_DESCRIPTION_GUIDE.md](./fe/PR_DESCRIPTION_GUIDE.md) — PR description conventions
+- [fe/RULES_SYSTEM.md](./fe/RULES_SYSTEM.md) — agent instruction layers and rules loading
+
+**Features**
+
+- [fe/BROWSER_PANEL_SPEC.md](./fe/BROWSER_PANEL_SPEC.md) — embedded browser panel
+- [fe/CDP_MCP_TOOLS.md](./fe/CDP_MCP_TOOLS.md) — Chrome DevTools Protocol MCP tools
+- [fe/MULTI_BACKEND_CONNECT.md](./fe/MULTI_BACKEND_CONNECT.md) — multi-backend connections and switching
+- [fe/PANEL_TAB_UX_SPEC.md](./fe/PANEL_TAB_UX_SPEC.md) — panel/tab UX design spec (leader-key system)
+- [fe/panel-system-refactoring.md](./fe/panel-system-refactoring.md) — tab-type registry architecture
+- [fe/code-review-ui.md](./fe/code-review-ui.md) — code review panel design
+- [fe/tasks-block-syntax.md](./fe/tasks-block-syntax.md) — `@@@task` block syntax
+- [fe/workspaces-link-handler.md](./fe/workspaces-link-handler.md) — `intent://` link handling
+
+**Release engineering**
+
+- [fe/RELEASING.md](./fe/RELEASING.md) — release process (beta/stable channels)
+- [fe/DEPLOYING.md](./fe/DEPLOYING.md) — deployment infrastructure, runners, and feeds
+
 ## Initial porting phase — **COMPLETE (historical)**
 
 The **initial port of Intent's backend to a headless Rust daemon** (`intentd`)

--- a/docs/fe/BROWSER_PANEL_SPEC.md
+++ b/docs/fe/BROWSER_PANEL_SPEC.md
@@ -1,0 +1,213 @@
+# Browser Panel Implementation Spec
+
+## Overview
+
+Add an embedded browser feature to the Intent app that allows users to:
+1. Enter URLs and view web pages in the main content area
+2. Access recent URLs quickly from the sidebar
+3. Toggle embedded DevTools from the browser toolbar; future work can add richer console capture for agents
+
+## Current State
+
+### What Exists
+- Third-party sources feature - Persists external references (Linear, GitHub, etc.) but not integrated in new sidebar
+- `mainContentType` includes `'browser'` - Main content area has conditional for browser type
+- `webviewTag: true` enabled in Electron's BrowserWindow config
+
+### Implemented Components
+- `BrowserPanel.svelte` - Sidebar panel for URL input and recent URLs
+- `EmbeddedBrowser.svelte` - Main content component using Electron's `<webview>` tag
+- `src/store/renderer/slices/browser/` - Redux slice for browser state (recent URLs etc.)
+- Browser sidebar and main-panel integration are wired into the workspace layout
+
+## Architecture
+
+### File Structure
+```
+src/features/browser/
+├── types.ts                   # BrowserSession, RecentUrl types
+
+src/store/renderer/slices/browser/
+├── browser-slice.ts           # State: recent URLs, current session
+
+src/lib/components/browser/
+├── BrowserPanel.svelte        # Sidebar: URL input + recent list
+├── EmbeddedBrowser.svelte     # Main content: webview component
+```
+
+### Key Technical Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Webview vs iframe | `<webview>` tag | No CORS restrictions, console access, DevTools |
+| State management | Redux slice (`src/store/renderer/slices/browser/`) | Matches current state architecture |
+| Recent URLs limit | 20 per workspace | Balance between utility and clutter |
+| URL validation | URL constructor | Simple, built-in validation |
+
+## Phase 1: Core Browser Feature
+
+### 1.1 Browser State (`src/store/renderer/slices/browser/browser-slice.ts`)
+
+> Originally implemented as `browser.store.svelte.ts`; state has since moved to the Redux `browser` slice.
+
+```typescript
+interface RecentUrl {
+  url: string;
+  title?: string;
+  favicon?: string;
+  lastVisited: string; // ISO timestamp
+}
+
+interface BrowserState {
+  recentUrls: RecentUrl[];
+  currentUrl: string | null;
+  isLoading: boolean;
+}
+```
+
+**Features (slice actions):**
+- `addRecentUrl(url, title?)` - Adds URL, deduplicates, maintains max 20
+- `removeRecentUrl(url)` - Removes single URL
+- `clearRecentUrls()` - Clears all
+- `setCurrentUrl(url)` - Sets active URL
+- Persists to localStorage per workspace: `browser-recent-${workspaceId}`
+
+### 1.2 Browser Panel (`src/lib/components/browser/BrowserPanel.svelte`)
+
+Sidebar component for the `WorkspaceDetailSidebar`.
+
+**UI Elements:**
+- URL input field with Enter-to-submit
+- Recent URLs list using `ListContainer`/`ListItem`
+- Delete button (×) on hover for each URL
+- Clear all button in header
+
+**Props:**
+```typescript
+interface Props {
+  workspaceId: string;
+  onOpenUrl: (url: string) => void;
+  class?: string;
+}
+```
+
+### 1.3 Embedded Browser (`src/lib/components/browser/EmbeddedBrowser.svelte`)
+
+Main content component using Electron's webview.
+
+**Features:**
+- Navigation: back, forward, refresh, home
+- URL bar with current URL display
+- Loading indicator
+- Error handling for failed loads
+- Webview partition isolation via `BROWSER_PANEL_PARTITION`
+- Protocol allowlist enforcement via `BROWSER_PROTOCOLS.NAVIGATION_ALLOWED`
+- Browser zoom controls via `browser:zoom` events
+- Embedded DevTools toggle (`webview.openDevTools()` / `closeDevTools()`)
+- Focus propagation and browser-specific shortcut handling for the active panel
+
+**Webview Events to Handle:**
+- `did-start-loading` / `did-stop-loading` - Loading state
+- `did-navigate` / `did-navigate-in-page` - URL updates
+- `page-title-updated` - Title for recent URLs
+- `page-favicon-updated` - Favicon for recent URLs
+- `did-fail-load` - Error handling
+
+**Props:**
+```typescript
+interface Props {
+  url: string;
+  workspaceId: string;
+  tabId?: string;
+  onNavigate?: (url: string) => void;
+  onClose?: () => void;
+  onTitleChange?: (title: string) => void;
+  onFaviconChange?: (faviconUrl: string) => void;
+  onFocus?: () => void;
+  focusUrlBarOnMount?: boolean;
+  isFocused?: boolean;
+}
+```
+
+### 1.4 Integration Points
+
+**WorkspaceDetailSidebar.svelte:**
+- Add `BrowserPanel` as a collapsible section (similar to Notes)
+- Place between Notes and Files/Changes toggle
+- Add `onOpenUrl` prop and handler
+
+**Main Content Area (WorkspaceContent or page.svelte):**
+- Handle `open-url-in-browser` event from sidebar
+- Set `mainContentType = 'browser'` and `currentBrowserUrl`
+- Render `EmbeddedBrowser` when type is 'browser'
+
+**Event Flow:**
+```
+BrowserPanel (sidebar)
+    ↓ onOpenUrl(url)
+WorkspaceDetailSidebar
+    ↓ dispatches 'open-url-in-browser' event
++page.svelte
+    ↓ sets mainContentType='browser', stores URL
+Main Content Area
+    ↓ renders EmbeddedBrowser with URL
+```
+
+## Phase 2: Console Capture (Future)
+
+- Capture console logs via `console-message` event
+- Create `BrowserConsolePanel.svelte` for log display
+- Filter logs by level (log, warn, error, info, debug)
+
+## Phase 3: Agent Integration (Future)
+
+- MCP tools: `browser_get_console_logs`, `browser_screenshot`, `browser_execute_js`
+- DOM inspection for agents
+- Screenshot with annotation support
+
+## Implementation Tasks
+
+### Phase 1 Checklist (historical)
+
+#### Implementation (completed)
+
+- [x] Create `src/features/browser/types.ts`
+- [x] Create browser state store (originally `browser.store.svelte.ts`, since moved to the Redux `browser` slice)
+- [x] Create `src/lib/components/browser/BrowserPanel.svelte`
+- [x] Create `src/lib/components/browser/EmbeddedBrowser.svelte`
+- [x] Add BrowserPanel to `WorkspaceDetailSidebar.svelte`
+- [x] Wire up event handling in `+page.svelte`
+- [x] Update main content rendering for browser type
+- [x] Enable `webviewTag: true` in BrowserWindow config
+
+#### Verification (pending/manual)
+
+- [ ] Test: URL input opens in main panel
+- [ ] Test: Recent URLs persist across sessions
+- [ ] Test: Navigation controls work (back/forward/refresh)
+- [ ] Test: Sites that block iframes load correctly
+
+## UI Design Notes
+
+- Follow existing sidebar patterns (Notes section structure)
+- Use `ListContainer`/`ListItem` for recent URLs
+- Use shadcn `Input` for URL field
+- Use Font Awesome icons (`faGlobe`, `faArrowLeft`, `faArrowRight`, `faRefresh`)
+- Subtle, sleek Vercel-like aesthetic
+- Collapsible section header matching Notes pattern
+
+## Open Questions
+
+1. **Should browser panel be always visible or collapsible?**
+   - Recommendation: Collapsible, starts collapsed
+
+2. **How to handle multiple browser tabs/sessions?**
+   - Phase 1: Single session, URL replaces previous
+   - Future: Tab support if needed
+
+3. **Should recent URLs sync across workspaces?**
+   - Recommendation: No, keep per-workspace for context relevance
+
+4. **Keyboard shortcuts?**
+   - `Cmd+L` to focus URL bar (when browser panel focused)
+   - Standard nav: `Alt+Left/Right` for back/forward

--- a/docs/fe/CDP_MCP_TOOLS.md
+++ b/docs/fe/CDP_MCP_TOOLS.md
@@ -1,0 +1,207 @@
+# CDP MCP Tools for Agents
+
+## Overview
+
+The CDP (Chrome DevTools Protocol) MCP tools allow **agents** to inspect and interact with the running Intent application. These tools provide full visibility into the UI, enabling agents to debug issues, test interactions, and verify changes.
+
+## Quick Start
+
+```bash
+# Start the app with CDP enabled (user runs this in a separate terminal)
+pnpm run dev:cdp
+
+# The CDP MCP server is automatically available to agents
+# Canonical tool names are plain cdp_* names (for example, cdp_hello)
+```
+
+## IMPORTANT: Check Dev Server First
+
+**Before using any CDP tools, always verify the dev server is running:**
+
+1. **Call `cdp_hello()` first** — If it returns a page title like "Intent", CDP is ready
+2. **If CDP fails to connect**: The user needs to run `pnpm dev:cdp` in the Intent directory
+3. **Don't start the dev server yourself** — The user typically runs it in a separate terminal
+
+If `cdp_hello` fails with a connection error, ask the user:
+
+> "CDP tools require the dev server to be running with CDP enabled. Please run `pnpm dev:cdp` in the Intent directory."
+
+## Available Tools
+
+### Inspection Tools
+
+| Tool                         | Description                                        |
+| ---------------------------- | -------------------------------------------------- |
+| `cdp_hello`                  | Test CDP connection, returns page title            |
+| `cdp_get_accessibility_tree` | Get accessibility tree for finding UI elements     |
+| `cdp_get_dom`                | Get raw HTML structure                             |
+| `cdp_get_console_logs`       | Get browser console logs (with filtering)          |
+| `cdp_screenshot`             | Take screenshots (viewport, full page, or element) |
+| `cdp_api_reference`          | Get complete API documentation                     |
+
+### Interaction Tools
+
+| Tool             | Description                                  |
+| ---------------- | -------------------------------------------- |
+| `cdp_run_script` | Execute JavaScript with Playwright-style API |
+| `cdp_reload`     | Reload the page (with optional cache bypass) |
+| `cdp_wait`       | Wait for time or element to appear           |
+
+## Workflow Patterns
+
+### Pattern 1: Inspect → Interact → Verify
+
+```
+1. cdp_get_accessibility_tree  → Find the element
+2. cdp_run_script              → Interact with it
+3. cdp_screenshot              → Verify the result
+```
+
+### Pattern 2: Debug Console Errors
+
+```
+1. cdp_get_console_logs({ types: ['error', 'warn'] })  → Find errors
+2. cdp_get_accessibility_tree                          → Inspect UI state
+3. cdp_run_script                                      → Test fixes
+```
+
+### Pattern 3: Test After Code Changes
+
+```
+1. cdp_reload({ ignoreCache: true })  → Reload with fresh code
+2. cdp_wait({ selector: '.app' })     → Wait for app to load
+3. cdp_screenshot                     → Capture current state
+```
+
+## Playwright-Style API
+
+The `cdp_run_script` tool injects `cdp-mcp-server/cdp-helpers.js`, which exposes a lightweight Playwright-inspired `cdp` global. The current helper surface is:
+
+### Locator creation
+
+- `cdp.getByRole(role, { name?, exact? })`
+- `cdp.getByText(text, { exact? })`
+- `cdp.getByTestId(testId)`
+- `cdp.getByLabel(label, { exact? })`
+- `cdp.getByPlaceholder(placeholder, { exact? })`
+- `cdp.locator(selector)`
+
+`exact` matching defaults to `true` in the current helper implementation.
+
+```javascript
+await cdp.getByRole('button', { name: 'Submit' }).click();
+await cdp.getByText('Welcome').textContent();
+await cdp.getByTestId('status-indicator').isVisible();
+await cdp.getByLabel('Email').fill('user@example.com');
+await cdp.getByPlaceholder('Search...').fill('query');
+await cdp.locator('.my-class').click();
+```
+
+### Locator actions
+
+- `locator.click({ timeout? })`
+- `locator.fill(value, { timeout? })`
+- `locator.clear({ timeout? })`
+
+All locator waits currently default to roughly `5000ms` unless a method documents a smaller timeout.
+
+```javascript
+await cdp.getByRole('textbox', { name: 'Workspace Name' }).fill('Docs QA');
+await cdp.locator('input[name="search"]').clear();
+```
+
+### Waiting helpers
+
+- `locator.waitFor({ state?, timeout? })`
+  - Supported `state` values: `'attached' | 'detached' | 'visible' | 'hidden'`
+- `cdp.waitForURL(pattern, { timeout? })`
+- `cdp.waitForTimeout(milliseconds)`
+
+```javascript
+await cdp.getByRole('dialog').waitFor({ state: 'visible' });
+await cdp.waitForURL(/workspace\/\d+/);
+await cdp.waitForTimeout(250);
+```
+
+### Queries and inspection
+
+- `locator.textContent({ timeout? })`
+- `locator.innerText({ timeout? })`
+- `locator.isVisible({ timeout? })` - uses a shorter `1000ms` default timeout
+- `locator.count()`
+- `locator.getAttribute(name, { timeout? })`
+- `cdp.url()`
+
+```javascript
+const title = await cdp.getByRole('heading').textContent();
+const visible = await cdp.getByTestId('status-indicator').isVisible();
+const href = await cdp.getByRole('link', { name: 'Docs' }).getAttribute('href');
+const currentUrl = cdp.url();
+```
+
+### Chaining API
+
+- `locator.first()`
+- `locator.last()`
+- `locator.nth(index)`
+- `locator.all()`
+
+```javascript
+const firstItem = await cdp.getByRole('listitem').first().textContent();
+const thirdItem = await cdp.locator('li').nth(2).innerText();
+const allButtons = await cdp.getByRole('button').all();
+```
+
+### Storage helpers
+
+- `cdp.storage.getLocal(key)`
+- `cdp.storage.setLocal(key, value)`
+- `cdp.storage.removeLocal(key)`
+- `cdp.storage.clearLocal()`
+- `cdp.storage.keysLocal()`
+
+### Evaluation and unsupported Playwright conveniences
+
+`cdp_run_script` itself is the evaluation primitive: arbitrary JavaScript in the `script` body runs inside the renderer and can `return` structured data. The current helper does **not** expose dedicated `cdp.evaluate()`, `locator.selectOption()`, or `locator.check()` wrappers, so use normal DOM APIs inside the script body when you need those behaviors.
+
+## Architecture
+
+```
+Agent (Auggie/External)
+    |
+    | MCP Protocol (STDIO)
+    v
+CDP MCP Server (cdp-mcp-server/dist/server.cjs)
+    |
+    | Chrome DevTools Protocol
+    v
+Electron App (--remote-debugging-port=9223)
+    |
+    v
+Renderer Process (UI)
+```
+
+## Environment Variables
+
+| Variable           | Description           | Default |
+| ------------------ | --------------------- | ------- |
+| `CDP_PORT`         | CDP debugging port    | 9223    |
+| `ENABLE_CDP_DEBUG` | Enable CDP tools      | false   |
+| `NODE_ENV`         | Must be `development` | -       |
+
+## Troubleshooting
+
+| Issue            | Solution                                      |
+| ---------------- | --------------------------------------------- |
+| Cannot connect   | Ensure app is running with `pnpm run dev:cdp` |
+| CDP disconnected | App was restarted; server will auto-reconnect |
+| Port conflict    | Check `lsof -i :9223` for conflicts           |
+
+## Related Files
+
+| File                                                    | Purpose                          |
+| ------------------------------------------------------- | -------------------------------- |
+| `cdp-mcp-server/server.ts`                              | STDIO MCP server implementation  |
+| `cdp-mcp-server/cdp-helpers.js`                         | Source Playwright-style API helpers injected by `cdp_run_script` |
+| `cdp-mcp-server/dist/cdp-helpers.js`                    | Built copy loaded alongside the compiled server |
+| `src/features/agent/main/instructions/base-system-prompt.ts` | Agent instructions for CDP tools |

--- a/docs/fe/COMPONENTS_DESIGN.md
+++ b/docs/fe/COMPONENTS_DESIGN.md
@@ -1,0 +1,156 @@
+# Component Design Guidelines
+
+Practical rules for structuring and sizing Svelte components in this codebase.
+
+## Component Structure
+
+Every Svelte component's `<script>` block should follow this ordering. Separate the script from the template with a blank line.
+
+1. **Imports** — external packages, then internal modules
+2. **Props** — component prop declarations (`let { ... } = $props()`)
+3. **Variable declarations** — local state, constants
+4. **Selector calls and derived variables** — selector readables via `selectThing()`, `$derived` expressions
+5. **Handler declarations** — event handlers, callbacks
+6. **`onMount` handling** — setup that runs once after first render
+7. **Effects** — `$effect` blocks for reactive side effects
+8. **`onDestroy` handling** — cleanup logic
+
+```svelte
+<script lang="ts">
+  // 1. Imports
+  import { onDestroy, onMount } from 'svelte';
+  import { store as appStore } from '$store/renderer/store';
+  import { someAction } from './some-slice';
+  import { selectSomeItem } from './selectors';
+  import ChildComponent from './ChildComponent.svelte';
+
+  // 2. Props
+  let { id, label } = $props<{ id: string; label: string }>();
+
+  // 3. Variable declarations
+  let localCount = $state(0);
+
+  // 4. Selectors and derived
+  const item$ = selectSomeItem(id);
+  const displayName = $derived($item$?.name ?? label);
+
+  // 5. Handlers
+  function handleClick() {
+    appStore.dispatch(someAction(id));
+  }
+
+  // 6. onMount
+  onMount(() => {
+    console.log('mounted');
+  });
+
+  // 7. Effects
+  $effect(() => {
+    if ($item$?.status === 'ready') {
+      localCount += 1;
+    }
+  });
+
+  // 8. onDestroy
+  onDestroy(() => {
+    console.log('destroyed');
+  });
+</script>
+
+<button onclick={handleClick}>{displayName} ({localCount})</button>
+```
+
+## Breaking Down Large Components
+
+The codebase enforces a **1200-line ESLint `max-lines` rule** per file. Components approaching this limit need to be decomposed. Use the strategies below to keep components focused and small.
+
+### Avoid prop-drilling
+
+Don't thread props through multiple component layers. Instead, have child components read state directly from the Redux store via selectors.
+
+```svelte
+<!-- ❌ Prop-drilling -->
+<Parent {user} {settings} {theme}>
+  <Child {user} {settings} {theme}>
+    <Grandchild {user} {settings} />
+  </Child>
+</Parent>
+
+<!-- ✅ Direct selector access -->
+<Grandchild userId={id} />
+<!-- Grandchild reads user/settings from Redux internally -->
+```
+
+### Move side effects to sagas
+
+Business logic, IPC listeners, and async workflows belong in Redux sagas — not in component `$effect` chains. This shrinks components and makes logic testable in isolation.
+
+```svelte
+<!-- ❌ Complex effect chains in component -->
+$effect(() => {
+  window.api.onSomeEvent((data) => {
+    appStore.dispatch(processData(data));
+    if (data.needsRefresh) {
+      appStore.dispatch(fetchMore());
+    }
+  });
+});
+
+<!-- ✅ One dispatch, saga handles the rest -->
+$effect(() => {
+  appStore.dispatch(subscribeToEvent());
+  return () => appStore.dispatch(unsubscribeFromEvent());
+});
+```
+
+### Use Redux for shared state
+
+Don't pass state through component hierarchies. Connect child components directly to the store so each component owns only what it needs.
+
+### Extract conditional template blocks
+
+Templates inside `{#if}/{:else}` blocks that are substantial (roughly 30+ lines) should become their own components.
+
+```svelte
+<!-- ❌ Large inline conditional -->
+{#if mode === 'edit'}
+  <!-- 50 lines of edit UI -->
+{:else}
+  <!-- 40 lines of view UI -->
+{/if}
+
+<!-- ✅ Extracted -->
+{#if mode === 'edit'}
+  <EditView {id} />
+{:else}
+  <ReadView {id} />
+{/if}
+```
+
+### Extract repeated template patterns
+
+`{#each}` item renderers are natural extraction candidates. If the loop body is more than a few lines, extract it.
+
+```svelte
+<!-- ❌ Large inline loop body -->
+{#each items as item}
+  <!-- 40 lines of item rendering -->
+{/each}
+
+<!-- ✅ Extracted -->
+{#each items as item}
+  <ItemRow {item} />
+{/each}
+```
+
+### Summary checklist
+
+When a component is growing large, ask:
+- Can any props be replaced with direct selector access?
+- Are there `$effect` blocks that should be sagas?
+- Are there `{#if}` branches over 30 lines?
+- Are there `{#each}` bodies over 10 lines?
+- Is shared state being passed down instead of read from the store?
+
+See also: [State Management](./STATE_MANAGEMENT.md)
+

--- a/docs/fe/DEPLOYING.md
+++ b/docs/fe/DEPLOYING.md
@@ -1,0 +1,209 @@
+# Deploying Intent
+
+Intent releases are published to GitHub Releases on the public `intent-hq/cloudlands-releases` repository. The desktop app's auto-updater (electron-updater) pulls from rolling channel tags (`beta`, `stable`) on that repo.
+
+## Release Channels
+
+Intent uses a channel-based update model:
+
+- **`beta`** — Rolling release tag for beta testing; auto-updater pulls from `https://github.com/intent-hq/cloudlands-releases/releases/download/beta/`
+- **`stable`** — Rolling release tag for general availability; auto-updater pulls from `https://github.com/intent-hq/cloudlands-releases/releases/download/stable/`
+
+Each channel carries **four auto-updater feed files**, one per platform/arch:
+
+| Feed file                | Platform      |
+| ------------------------ | ------------- |
+| `latest-mac.yml`         | macOS (arm64) |
+| `latest.yml`             | Windows (x64) |
+| `latest-linux.yml`       | Linux (x64)   |
+| `latest-linux-arm64.yml` | Linux (arm64) |
+
+electron-updater's generic provider points at the channel download URL and requests the feed file for the running platform/arch automatically.
+
+Each release also creates an immutable versioned release (`v{version}`) for archival and rollback.
+
+## Versioning — release-please Release PRs
+
+Version numbers are computed from conventional commits by
+[release-please](https://github.com/googleapis/release-please)
+(`.github/workflows/release-please.yml`, configured via
+`release-please-config.json` + `.release-please-manifest.json`). Nobody types a
+version number by hand.
+
+**Flow:**
+
+1. On every push to `main`, release-please opens (or updates) a **Release PR**
+   that bumps `package.json` and regenerates `CHANGELOG.md` from the
+   conventional commits since the last `v*` tag.
+2. A human merges the Release PR when it's time to ship — that is the release
+   timing gate.
+3. On the merge, release-please creates the `v{version}` tag and a GitHub
+   Release on `cloudlands-fe`. The workflow authenticates with `RELEASE_PAT`
+   (not the default `GITHUB_TOKEN`) so the pushed tag triggers downstream
+   workflows. release-please needs contents, pull-requests, and issues write
+   access (Release-PR labels go through the issues API); the classic
+   `repo`-scoped `RELEASE_PAT` covers all three.
+
+**Version math** (the app is ≥ 1.0, so full semver rules apply):
+
+- `fix:` / `perf:` → patch (e.g. 2.0.13 → 2.0.14)
+- `feat:` → minor (e.g. 2.0.13 → 2.1.0)
+- `type!:` (e.g. `feat!:`) or a `BREAKING CHANGE:` footer → major
+  (e.g. 2.0.13 → 3.0.0)
+- `chore:`, `docs:`, `refactor:`, `style:`, `test:`, `ci:` → no release on
+  their own. These types are marked `"hidden": true` in the config's
+  `changelog-sections`; release-please only opens a Release PR when the
+  rendered release notes are non-empty, so hidden-only pushes neither appear
+  in `CHANGELOG.md` nor trigger a release proposal.
+
+**Conventions:**
+
+- **Breaking changes** must be marked with `!` after the type/scope
+  (`feat!: drop legacy settings migration`) or a `BREAKING CHANGE:` footer, or
+  the major bump will be missed.
+- **intentd sidecar pin bumps** must use `fix(sidecar):` (e.g.
+  `fix(sidecar): bump intentd pin to 0.4.2`) so a new pinned daemon triggers at
+  least a patch release. A plain `chore:` pin bump would not produce a release.
+- **Plain versions only** — no prerelease suffixes (`-beta.N`). Beta vs. stable
+  remains a _promotion_ distinction on `cloudlands-releases`, not a version
+  distinction.
+
+**Why a GitHub Release on `cloudlands-fe` too?** Creating the tag via a GitHub
+Release is how release-please operates, and the release body carries the
+changelog for that version. It does not conflict with the publishing model:
+`cloudlands-fe` is private, so user-facing artifacts live exclusively on the
+public `intent-hq/cloudlands-releases` repo, while the `cloudlands-fe` release
+is the internal changelog anchor for the tag.
+
+**Bootstrap note (historical):** the pre-release-please tag `v2.0.13` points
+at a commit that is not on `main` (the old workflow tagged its own bump commit
+and merged a squashed copy of it), so release-please could not bound the
+commit range from that tag alone. `release-please-config.json` temporarily
+pinned `last-release-sha` to `562af4d2` (the `chore: bump version to 2.0.13`
+commit on `main`) so the first Release PR only considered commits since
+v2.0.13. Once the first release-please release (v2.1.0) was merged and tagged
+on `main`, the pin was removed (#314) — release-please now bounds the range
+from the release tags normally.
+
+## Required GitHub Secrets
+
+Release workflows require the following secrets configured on `intent-hq/cloudlands-fe`:
+
+**macOS signing + notarization:**
+
+- `CLOUDLANDS_MACOS_CERTIFICATE` — base64-encoded p12 certificate
+- `CLOUDLANDS_MACOS_CERTIFICATE_PWD` — certificate password
+- `CLOUDLANDS_KEYCHAIN_PASSWORD` — temporary keychain password
+- `CLOUDLANDS_APPLE_ID` — Apple ID for notarization
+- `CLOUDLANDS_APPLE_APP_SPECIFIC_PASSWORD` — app-specific password from appleid.apple.com
+- `CLOUDLANDS_APPLE_TEAM_ID` — 10-character team ID
+
+**Repository access:**
+
+- `RELEASE_PAT` — Personal access token with `repo` scope on `cloudlands-fe` + `cloudlands-releases` (also used by release-please, which needs contents + pull-requests + issues write; `repo` scope covers all three)
+- `INTENTD_READ_PAT` — Personal access token with read-only access to `intent-hq/intentd` (used to download the pinned intentd release assets while the repo is private)
+
+Windows builds require no signing secrets — they ship **unsigned** (see
+[Platform builds and runners](#platform-builds-and-runners)).
+
+## Beta Release Workflow
+
+The beta release workflow is defined in `.github/workflows/release-beta.yml`.
+
+**Trigger:** Push of a `v*.*.*` tag (created by release-please when its Release PR is merged). A `workflow_dispatch` fallback is available to (re)build an **existing** tag.
+
+**Input (workflow_dispatch fallback only):**
+
+- `tag` — existing tag to (re)build (e.g., `v2.1.0`)
+
+**What it does:**
+
+1. A resolve/validate job resolves the release tag (from the tag push, or the dispatch input), validates its format (supports prerelease suffixes like `v1.2.3-beta.1`), verifies the tag matches the `package.json` version at that commit (guards against tags not created by release-please), and fails if a `v{version}` release already exists on `intent-hq/cloudlands-releases` (duplicate-release protection)
+2. **Per-platform build jobs** run in parallel (see [Platform builds and runners](#platform-builds-and-runners) for runners and artifacts). Each job checks out the release tag, sets up pnpm and Node.js 22, installs frontend dependencies, reads the pinned intentd version from `intentd.version`, fetches the pinned intentd sidecar for its platform/arch via `scripts/fetch-sidecar.cjs` (sha256-verified, staged at `resources/sidecar/`; fails fast if the pinned release or its assets don't exist on `intent-hq/intentd`), then builds and packages the app. The macOS job additionally imports the code signing certificate into a temporary keychain and signs + notarizes the app via the `scripts/notarize.js` afterSign hook (the staged sidecar is signed by the `scripts/sign-sidecar.js` afterPack hook); Windows and Linux artifacts are unsigned
+3. A **publish job** runs only after **every** build job succeeds — any platform build failure fails the whole release; there is no partial publish. It generates release notes from the fe commit range (the intentd section lists the intentd commit delta from the previous release's pin, recovered from the previous release's `release-manifest.json` asset — falling back to a pin-only reference when the previous pin can't be recovered, or to the pin line + compare link without a commit list when the intentd compare API is unavailable) and publishes all platforms' artifacts to `intent-hq/cloudlands-releases`:
+   - Creates immutable versioned release: `v{version}`
+   - Updates rolling `beta` release tag (clobbers existing assets)
+4. Posts workflow summary with download URLs
+
+The workflow no longer bumps `package.json`, creates tags, or opens version-bump PRs — release-please owns versioning and tagging (no tags are pushed to `intent-hq/intentd` — it releases on its own cycle).
+
+**Output:**
+
+- Versioned release on `cloudlands-releases`: `https://github.com/intent-hq/cloudlands-releases/releases/tag/v{version}`
+- Rolling beta channel: `https://github.com/intent-hq/cloudlands-releases/releases/tag/beta`
+- Auto-updater feeds: `https://github.com/intent-hq/cloudlands-releases/releases/download/beta/` (`latest-mac.yml`, `latest.yml`, `latest-linux.yml`, `latest-linux-arm64.yml`)
+
+## Promote-to-Stable Workflow
+
+**Workflow:** `.github/workflows/release-stable.yml` (manual `workflow_dispatch` with a `version` input)
+
+The promote-to-stable workflow:
+
+1. Validates the version and verifies the versioned release exists on `intent-hq/cloudlands-releases`
+2. Reads the previous stable version from the stable channel's `latest-mac.yml` (tolerates a first promotion)
+3. Copies all artifacts from the versioned release to the `stable` rolling release tag — all feed files (`latest-mac.yml`, `latest.yml`, `latest-linux.yml`, `latest-linux-arm64.yml`) are uploaded **last** for an atomic feed switch — then deletes superseded assets and verifies each promoted feed's `sha512`. Promoting an older mac-only release still works: missing platform feeds produce warnings, not failures
+4. Builds aggregated release notes for the range `(prevStable, VERSION]`: a leading summary section (promoted version, previous stable, and a consolidated intentd pin delta recovered from the releases' `release-manifest.json` files and rendered from the intentd compare API via `scripts/generate-stable-summary.mjs`), followed by each version's release body
+5. Updates the `stable` release body with the aggregated notes
+
+The summary/notes enrichment is fail-soft — missing manifests, pins, or compare-API failures degrade the summary (down to omitting it entirely) without failing the promotion.
+
+See [RELEASING.md](./RELEASING.md#promoting-to-stable) for the operator runbook.
+
+## Rollback Workflow
+
+_(Not yet implemented — planned as a separate workflow)_
+
+The rollback workflow will restore a previous versioned release to a channel's rolling tag.
+
+## Platform Builds and Runners
+
+Each release ships four platform builds, produced by parallel jobs in `release-beta.yml`:
+
+| Platform      | Runner                                                         | Artifacts                                           | Feed file                |
+| ------------- | -------------------------------------------------------------- | --------------------------------------------------- | ------------------------ |
+| macOS (arm64) | `macos-15-xlarge` (GitHub-hosted)                              | `.dmg`, `.zip` (+ blockmaps)                        | `latest-mac.yml`         |
+| Windows (x64) | `gh-windows-16x` (org-hosted, Windows Server 2022 image)       | NSIS installer `.exe`, portable `.exe` (+ blockmap) | `latest.yml`             |
+| Linux (x64)   | self-hosted `tinybox` (`[self-hosted, Linux, X64, tinybox]`)   | AppImage, `.deb`                                    | `latest-linux.yml`       |
+| Linux (arm64) | self-hosted `comfy` (`[self-hosted, Linux, ARM64, comfy]`)     | AppImage only (`deb:arm64` temporarily disabled)    | `latest-linux-arm64.yml` |
+
+Notes:
+
+- **Self-hosted runner dependency**: both Linux jobs require their self-hosted runners (`tinybox` for x64 — monorepo#1340, `comfy` for arm64) to be online; a release run queues (and eventually fails) if one is unavailable. macOS uses a GitHub-hosted runner and Windows an org-hosted runner.
+- **Linux arm64 temporarily ships AppImage-only**: electron-builder's bundled fpm fails to spawn on the arm64 runner, so `deb:arm64` is disabled until the runner issue is resolved (monorepo#1286).
+- **Windows builds are unsigned** (first iteration). The `scripts/windows-sign.cjs` sign hook silently skips signing when `INTENT_WINDOWS_ENABLE_INTEGRATED_SIGNING` is unset; DigiCert integrated signing in releases is a follow-up. Expect SmartScreen warnings on install.
+- **Linux packages are unsigned** (standard for AppImage/deb distributed outside a package repository). Snap is not built or published.
+- macOS remains signed + notarized as before.
+
+## Manual Local Build (Development / Testing)
+
+To build the app locally for manual testing with the pinned intentd release:
+
+```bash
+# Fetch the pinned intentd sidecar (see intentd.version); set INTENTD_READ_PAT
+# (or GH_TOKEN/GITHUB_TOKEN) while the intentd repo is private
+node scripts/fetch-sidecar.cjs
+
+# Build the frontend and package (point INTENTD_BIN at the staged sidecar)
+pnpm run build
+INTENTD_BIN="$(pwd)/resources/sidecar/intentd" pnpm run dist:mac
+```
+
+On Windows or Linux, use `pnpm run dist:win` or `pnpm run dist:linux` instead
+(the staged sidecar binary is `intentd.exe` on Windows).
+
+To build against a locally built intentd instead, point `INTENTD_BIN` at your
+`cargo build --release` output (or omit it in the monorepo, where
+`scripts/copy-sidecar.cjs` defaults to `packages/intentd/target/release`).
+
+The packaged artifacts (`.dmg`/`.zip`, `.exe`, AppImage/`.deb`) will be in `dist-electron/`.
+
+**Note:** Local builds will not be signed or notarized unless you configure the signing environment variables locally (`CLOUDLANDS_APPLE_ID`, `CLOUDLANDS_APPLE_APP_SPECIFIC_PASSWORD`, `CLOUDLANDS_APPLE_TEAM_ID`, or legacy `APPLE_*` equivalents).
+
+## Operational Notes
+
+- All release workflows run on GitHub Actions; there are no manual upload scripts
+- Secrets are configured at the repository level and referenced in workflow YAML
+- Release artifacts are public on `intent-hq/cloudlands-releases`
+- The auto-updater uses the rolling channel tags (`beta`, `stable`) to find updates
+- Versioned releases (`v{version}`) provide immutable archives for rollback
+- Keep PATs and certificate passwords out of logs and transcripts

--- a/docs/fe/DEVELOPER_GUIDE.md
+++ b/docs/fe/DEVELOPER_GUIDE.md
@@ -1,0 +1,208 @@
+# Developer Guide
+
+This guide reflects the current Intent repository layout and APIs as of package version `2.22.0`.
+
+## Getting Started
+
+### Prerequisites
+
+- Node.js 18+
+- `pnpm`
+- Git
+- Auggie CLI for the default ACP provider workflow
+
+### Install and Run
+
+```bash
+pnpm install
+
+# Start the Electron app with the Chrome DevTools Protocol flow enabled
+pnpm run dev:cdp
+```
+
+### Common Commands
+
+```bash
+pnpm run dev           # Standard development launcher
+pnpm run dev:cdp       # Development launcher with CDP support
+pnpm run build         # Production build
+pnpm run check         # Svelte + TypeScript checks
+pnpm run lint          # ESLint
+pnpm run format        # Prettier write pass
+pnpm run test:unit     # Vitest suite
+pnpm run test:playwright
+```
+
+## Project Structure
+
+The codebase is split across renderer features, Electron process code, shared types/utilities, and operational scripts.
+
+```text
+.
+├── docs/                     # Product and engineering documentation
+├── scripts/                  # Build, release, migration, and tooling scripts
+├── src/
+│   ├── features/             # Feature-first renderer modules
+│   │   ├── agent/            # Agent lifecycle, orchestration, background tasks
+│   │   ├── browser/          # Embedded browser tabs and browser tooling
+│   │   ├── cdp/              # Chrome DevTools Protocol integration
+│   │   ├── layout/           # Panel layout system and tab routing
+│   │   ├── rules/            # User rules and rules IPC services
+│   │   └── ...               # Many other product features
+│   ├── lib/                  # Shared renderer utilities, services, stores, components
+│   ├── main/                 # Electron main-process entry points and services
+│   ├── preload/              # Electron preload bridge
+│   ├── routes/               # SvelteKit routes and test pages
+│   ├── shared/               # Cross-process config, types, constants, IPC contracts
+│   └── test/                 # Test helpers, factories, and mocks
+└── package.json              # Scripts, dependencies, and version metadata
+```
+
+When updating docs or adding features, verify which side of the app owns the behavior:
+
+- `src/features/` for renderer-facing product logic
+- `src/main/` for Electron and system integration
+- `src/shared/` for contracts used by both sides
+- `scripts/` for operational workflows such as release packaging and uploads
+
+## Agent Creation and Integration
+
+Use `agentFactory.createAgent(...)` for agent creation. The factory is the supported public entry point and normalizes agent config before backend creation.
+
+```typescript
+import { agentFactory } from '$features/agent/services/agent-factory';
+
+const result = await agentFactory.createAgent(workspace, {
+  name: 'Review Changes',
+  agentType: 'task-loop',
+  model: 'haiku4.5',
+  initialMessage: 'Review the current diff and summarize the risks.',
+  source: 'workspace-initializer',
+});
+```
+
+Important notes:
+
+- Pass `agentType` so the backend can build the correct instructions.
+- `CreateAgentOptions.systemPrompt` is deprecated; do not use it for new code.
+- Valid `AgentTypeId` values include `chat`, `task-loop`, `workspace-agent`, `code-review`, `commit-message`, and `pr-description`.
+
+## Panel Layout System
+
+The workspace UI is driven by the `panel-layout` Redux slice (`src/store/renderer/slices/panel-layout/`), with `src/features/layout/panel-layout-adapter.ts` bridging layout operations for feature code.
+
+Core ideas:
+
+- Each workspace has its own layout state in the slice.
+- Layouts are trees of panel nodes and split nodes.
+- Split nodes can be horizontal or vertical.
+- Each panel can host multiple tabs, with one active tab at a time.
+- State includes focus tracking, pending focus, recently closed tabs, layout history, and focus history.
+- Layout state is persisted so reopened workspaces restore their previous arrangement.
+
+The main data model centers on:
+
+- `WorkspacePanelLayout` for the full layout state
+- `PanelState` for the tabs inside one panel
+- `PanelTab` for the content metadata a tab needs to render
+
+`PanelTab` carries type-specific identifiers such as `noteId`, `filePath`, `agentId`, `terminalId`, `diffPath`, and `browserUrl`, which let the UI route a tab to the correct feature component.
+
+## Tab Types and Content Routing
+
+The tab system is split into two layers:
+
+1. `PanelTabType` in the panel-layout types (`src/store/renderer/slices/panel-layout/panel-layout-types.ts`) defines the allowed tab kinds.
+2. `tabTypeRegistry` in `src/features/layout/tab-types/registry.ts` maps a tab type to its renderer component and UI metadata.
+
+Each registered tab type provides:
+
+- `type`
+- `component`
+- `icon`
+- `defaultTitle`
+- `categoryLabel`
+- optional `sidebarTabId`
+- optional `renameable`
+
+`registerAllTabTypes()` currently registers the main built-in tabs used by the workspace UI:
+
+- `browser`
+- `terminal`
+- `code-review`
+- `agent-overview`
+- `agent`
+- `note`
+- `file`
+- `diff`
+- `changes`
+- `local-changes`
+- `chat-changes`
+- `activity-changes`
+- `settings`
+- `overview`
+
+The broader `PanelTabType` union also includes workflow-oriented types such as `activity`, which are part of the routing model even when a specific registry entry is managed elsewhere or added later.
+
+## Background Agents
+
+Background tasks such as commit-message generation, PR description generation, and code review run through the `background-agent-executor` Redux slice (`src/store/renderer/slices/background-agent-executor/`) and its sagas.
+
+Executor state tracked per run includes:
+
+- `status`
+- `messages`
+- `result`
+- `error`
+- `progress`
+- `agentId`
+
+Background model selection is provider-aware. The `background-agent-settings` Redux slice (`src/store/renderer/slices/background-agent-settings/`) keeps:
+
+- a default background-agent model
+- per-type overrides for `commit`, `pr`, `review`, and `fast`
+
+That allows the app to preserve different background-agent model preferences for different ACP providers.
+
+## Provider System
+
+ACP provider metadata is served by the daemon's `providers.catalog` RPC (monorepo `docs/PROTOCOL.md` §5.38) — the single source of truth for provider identity, display names, CLI commands, default models, model tiers, and env-var/feature-code gating. There is no static provider table in the renderer.
+
+At connect time the catalog is hydrated into the `providerCatalog` Redux slice (`src/store/renderer/slices/provider-catalog/`); renderer code reads it through the slice's selectors. Main-process call sites that cannot import the renderer store use the cached catalog accessor in `src/main/utils/provider-catalog-accessor.ts`.
+
+Compound model ids (`provider:model`) are parsed with the pure helpers in `src/shared/utils/compound-model-id.ts`, with the catalog's default provider threaded in explicitly for bare ids.
+
+The active provider is tracked in the `providerSettings` Redux slice; it starts empty and adopts the registry default when the catalog hydrates. When you add or update provider-sensitive UI, read the active provider and provider metadata from the store selectors rather than assuming Auggie is always selected.
+
+## Testing and Validation
+
+Use `pnpm` for all documented test commands.
+
+```bash
+pnpm run test:unit
+pnpm run test:unit -- src/features/agent/__tests__/agent.test.ts
+pnpm run test:unit:watch
+pnpm run check
+pnpm run lint
+```
+
+Tests and test helpers are spread across several areas of the repo:
+
+- feature-level `__tests__` folders under `src/features/`
+- Electron main-process tests under `src/main/__tests__/`
+- shared tests under `src/shared/__tests__/`
+- reusable mocks/factories under `src/test/`
+
+## Debugging Notes
+
+- `pnpm run dev:cdp` is the best default when working on browser/CDP features.
+- Renderer-only issues usually live in `src/features/`, `src/lib/`, or `src/routes/`.
+- IPC and desktop integration issues usually involve `src/main/`, `src/preload/`, and `src/shared/ipc` contracts.
+- Release or packaging issues usually trace back to `scripts/` and `package.json` script wiring.
+
+## Contribution Tips
+
+1. Verify the owning feature area before editing code.
+2. Use the existing store/service patterns instead of creating parallel abstractions.
+3. Prefer extending typed contracts in `src/shared/` when behavior spans renderer and main.
+4. Run the smallest relevant validation command before sending a change for review.

--- a/docs/fe/ERROR_HANDLING_SYSTEM.md
+++ b/docs/fe/ERROR_HANDLING_SYSTEM.md
@@ -1,0 +1,268 @@
+# Enhanced Error Handling System
+
+## Overview
+
+The Intent app now features a comprehensive error handling system designed to make debugging easier and enable seamless integration with AI agents for troubleshooting.
+
+## Key Features
+
+### 1. Error Console (Removed)
+
+The floating Error Console UI (previously toggled with `Ctrl+Shift+E`) has been removed; `Mod+Shift+E` is now bound to Focus Explorer. Errors surface through toast notifications and the error handler's subscription API described below.
+
+### 2. Enhanced Error Notifications
+
+- **Quick Actions**:
+  - **Copy**: Formats error for debugging
+  - **Agent**: Sends error directly to AI agent
+  - **Retry**: Attempts automatic recovery (if recoverable)
+- **Auto-dismiss**: Info messages disappear after 5 seconds
+- **Smart Suppression**: Filters out non-critical errors (ResizeObserver warnings, Monaco disposal/rejection noise, bits-ui cleanup errors, and Svelte effect depth errors)
+
+### 3. Error Reporter Utility
+
+- **Comprehensive Context Collection**:
+  - Browser information (name, version, platform)
+  - Performance metrics (memory usage, uptime)
+  - Recent user actions (clicks, navigation, form submissions)
+  - Current route and workspace information
+- **Multiple Output Formats**:
+  - Markdown (for documentation)
+  - JSON (for telemetry)
+  - Agent-optimized prompts
+
+### 4. Agent Integration
+
+- **Direct Error Submission**: Send errors to agents with one click
+- **Contextual Prompts**: Automatically generates helpful prompts including:
+  - Error details and stack trace
+  - Recent user actions
+  - Environment information
+  - Specific help requests
+- **Metadata Tracking**: Errors sent to agents include source tracking
+
+## Usage Guide
+
+### For Users
+
+#### Copying Errors for Debugging
+
+1. Click the "Copy" button on any error notification
+2. The error will be formatted as markdown with full context
+
+#### Sending Errors to Agents
+
+1. Click the "Agent" button on the error toast
+2. An agent will be launched with:
+   - Pre-filled error context
+   - Recent actions leading to the error
+   - Automatic submission enabled
+
+### For Developers
+
+#### Error Tracking
+
+```typescript
+import { errorHandler } from '$lib/utils/error-handler.svelte';
+
+// Handle an error
+errorHandler.handleError(error, {
+  component: 'MyComponent',
+  action: 'fetchData',
+  userId: currentUser.id,
+});
+
+// Handle a warning
+errorHandler.handleWarning('API rate limit approaching');
+
+// Handle info
+errorHandler.handleInfo('Data sync completed');
+```
+
+#### Reactive subscription model
+
+- `ErrorHandler` no longer uses Svelte `$state` runes internally.
+- It keeps plain internal arrays and notifies UI subscribers via `subscribe(callback)`.
+- This callback-based pattern avoids creating reactive dependencies during module initialization, which helps prevent `effect_update_depth_exceeded` loops.
+
+#### Svelte error resolution
+
+When an error message contains a Svelte docs URL (for example `https://svelte.dev/e/...`), the error handler uses `svelte-error-resolver.ts` to turn it into a richer, developer-friendly message.
+
+- `isSvelteErrorUrl(message)` detects Svelte error URLs.
+- `resolveSvelteError(message)` returns structured `SvelteErrorInfo` metadata.
+- `formatSvelteError(message)` builds the expanded display text shown in the UI.
+- Toast notifications are rendered via `showErrorToast()` from `error-toast.ts`.
+
+#### Custom Error Reports
+
+```typescript
+import { errorReporter } from '$lib/utils/error-reporter';
+
+// Generate a custom report
+const report = errorReporter.generateReport(error, {
+  workspaceId: 'ws-123',
+  agentId: 'agent-456',
+  recentActions: [{ action: 'save_file', timestamp: '2024-01-01T12:00:00Z' }],
+});
+
+// Use different formats
+console.log(report.markdown); // For documentation
+console.log(report.json); // For telemetry
+console.log(report.agentPrompt); // For AI assistance
+```
+
+#### Action Tracking
+
+```typescript
+import { errorReporter } from '$lib/utils/error-reporter';
+
+// Track custom actions
+errorReporter.trackAction('custom_action', {
+  details: 'User performed custom action',
+  metadata: { key: 'value' },
+});
+```
+
+## Error Categories
+
+The system automatically categorizes errors:
+
+- **Network Error**: Connection issues, fetch failures
+- **Authentication Error**: Auth failures, unauthorized access
+- **Permission Denied**: Access control issues
+- **File System Error**: File/directory operations
+- **Connection Error**: SSH, WebSocket issues
+- **API Error**: Endpoint failures
+- **Application Error**: General application errors
+
+## Suppressed Errors
+
+The following errors are automatically suppressed to reduce noise:
+
+1. **ResizeObserver**: "ResizeObserver loop completed with undelivered notifications"
+2. **Svelte Effects**: `effect_update_depth_exceeded` / `svelte.dev/e/effect_update_depth_exceeded`
+3. **Monaco Editor**: disposal, cancellation, and related unhandled rejection noise handled by `shouldSuppressMonacoUnhandledRejection()`
+4. **bits-ui cleanup**: component-unmount cleanup errors such as `.current is not a function` and minified `*.call is not a function` variants
+
+## Enhanced Context
+
+Each error includes:
+
+### Browser Information
+
+- User agent
+- Browser name and version
+- Platform
+- Online status
+
+### Performance Metrics
+
+- Memory usage (used/total/limit)
+- Time since page load
+- Application uptime
+
+### Recent Actions
+
+- Last 20 user interactions
+- Navigation events
+- Button clicks
+- Form submissions
+
+### Stack Trace Enhancement
+
+- Highlights Svelte components
+- Marks dependency code
+- Improves readability
+
+## Best Practices
+
+### For Error Handling
+
+1. Always provide context when handling errors
+2. Use appropriate error types (error, warning, info)
+3. Mark errors as recoverable when automatic retry is possible
+4. Include component names for easier debugging
+
+### For Agent Integration
+
+1. Errors sent to agents include full context automatically
+2. Agents receive formatted markdown for better parsing
+3. Recent actions help agents understand user flow
+4. Stack traces are limited to relevant portions
+
+### For Production
+
+1. Telemetry integration ready (sendTelemetry method)
+2. Error logs are capped at 100 entries to prevent memory issues
+3. Sensitive information should be filtered from context
+4. Production builds suppress console logging
+
+## Architecture
+
+### Components
+
+- `src/lib/utils/error-handler.svelte.ts`: Core error handling logic (`handleError`/`handleWarning`/`handleInfo`) and callback-based subscriptions
+- `src/lib/utils/error-reporter.ts`: Report generation and formatting
+- `src/lib/utils/error-toast.ts`: Toast UI used for interactive error notifications
+- `src/lib/utils/monaco-error-suppression.ts`: Utility for suppressing known Monaco disposal/rejection noise
+- `src/lib/utils/svelte-error-resolver.ts`: Resolves Svelte error URLs into structured `SvelteErrorInfo` output
+
+### Data Flow
+
+1. Error occurs → Global handlers capture it
+2. Error is enhanced with context
+3. Error is categorized and stored
+4. UI components react to error state
+5. User can interact (copy, send to agent, retry)
+
+## Testing Errors
+
+To test the error handling system:
+
+```javascript
+// In browser console
+throw new Error('Test error message');
+
+// Or trigger through the app
+errorHandler.handleError(new Error('Test error'), {
+  test: true,
+  component: 'TestComponent',
+});
+```
+
+## Future Enhancements
+
+- [ ] Error grouping by similarity
+- [ ] Persistent error storage across sessions
+- [ ] Error frequency analysis
+- [ ] Automatic error reporting to backend
+- [ ] Integration with monitoring services
+- [ ] Smart error recovery suggestions
+- [ ] Error replay functionality
+
+## Troubleshooting
+
+### Errors Not Captured
+
+- Verify global handlers are set up
+- Check if error is being suppressed
+- Ensure error handler is initialized
+
+### Agent Integration Issues
+
+- Verify agentLauncher is available
+- Check workspace context is set
+- Ensure agent service is running
+
+## Summary
+
+The enhanced error handling system provides:
+
+1. **Better Visibility**: Toast notifications and subscription-based error tracking
+2. **Easy Sharing**: One-click copy/send to agents
+3. **Rich Context**: Comprehensive error information
+4. **Smart Features**: Auto-suppression, categorization, recovery
+5. **Agent Ready**: Optimized for AI debugging assistance
+
+This system significantly improves the debugging experience and makes it easier to get help from AI agents when issues occur.

--- a/docs/fe/EVENT_SYSTEM.md
+++ b/docs/fe/EVENT_SYSTEM.md
@@ -1,0 +1,280 @@
+# Event System Architecture
+
+**Version**: 3.0
+**Date**: 2026-03-25
+**Purpose**: Comprehensive guide to the Redux-based event system
+
+## Overview
+
+The Intent app uses a **Redux-based event system** for all workspace events. Events are managed through Redux slices and sagas in the main process, with IPC channels for renderer communication.
+
+1. **WorkspaceEvents**: Full-featured events managed by `workspace-events` Redux slice with persistence, filtering, and query support
+
+> **Note**: The legacy EventBus singletons (UnifiedEventBus, WorkspaceEventBus, WorkspaceEventService) have been removed, as have the DomainEvents broadcast layer (`domain-events` actions/sagas) and the main-process Redux store. All event state is now managed through renderer Redux.
+
+## Architecture Diagram
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                     Renderer Process                             │
+├─────────────────────────────────────────────────────────────────┤
+│  Components              Redux Store              Selectors     │
+│  ┌─────────┐         ┌──────────────────┐    ┌─────────────┐   │
+│  │ UI      │◄────────│ workspace-events │◄───│ Reactive    │   │
+│  │ Layer   │────────►│ slice (synced)   │───►│ Selectors   │   │
+│  └─────────┘         └────────┬─────────┘    └─────────────┘   │
+└──────────────────────────────┼──────────────────────────────────┘
+                               │ IPC (Redux sync)
+                               ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                      Main Process                                │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                  │
+│  ┌─────────────────────────────────────────────────────────┐    │
+│  │              Redux Store (Main)                          │    │
+│  │                                                          │    │
+│  │  • workspace-events slice — event state + persistence   │    │
+│  │  • agent-subscriptions slice — agent event filters      │    │
+│  └────────────────────────┬────────────────────────────────┘    │
+│                           │                                      │
+│                           ▼                                     │
+│                  ┌──────────────┐                               │
+│                  │ Sagas        │                               │
+│                  │ (side fx)    │                               │
+│                  └──────────────┘                               │
+│                                                                  │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## Event Types
+
+### WorkspaceEvents (Full Events)
+
+Used for file changes, agent actions, git operations. Features:
+- Unique ID and timestamp
+- Actor attribution (user, agent, system)
+- Workspace scoping
+
+Persistence and historical queries are daemon-owned (intentd); the frontend keeps no local event store.
+
+```typescript
+interface WorkspaceEvent {
+  id: string;
+  type: WorkspaceEventType;
+  timestamp: string;
+  workspaceId?: string;
+  actor?: EventActor;
+  data: Record<string, unknown>;
+}
+```
+
+### DomainEvents (Removed)
+
+The DomainEvents broadcast layer (`domain-events` actions and sagas under `src/store/main/slices/domain-events/`, including `domainEventEmitted`) has been removed along with the main-process Redux store. Real-time updates now flow from the daemon to the renderer via the daemon events bridge.
+
+## Key Components
+
+| Component | Location | Responsibility |
+|-----------|----------|----------------|
+| workspace-events slice | `store/main/slices/workspace-events/` | Event state management |
+| agent-subscriptions slice | `store/main/slices/agent-subscriptions/` | Agent event filter state |
+| EventFilterEngine | `features/events/event-filter-engine.ts` | Pure filter matching logic |
+| agent-subscription-ops | `features/events/main/agent-subscription-ops.ts` | Agent subscription operations |
+
+## Emitting Events
+
+Main-process event emission via `mainDispatch` no longer does anything: `src/store/main/redux-store-bridge.ts` is neutralized (the main-process Redux store was removed; `mainDispatch` is a no-op that returns the action unchanged). Events originate from the intentd daemon and reach the renderer through the daemon events bridge (`src/features/events/daemon-events-bridge.client.ts`).
+
+## IPC Channels
+
+All event IPC channels are defined in `src/shared/ipc-registry.ts`:
+
+| Channel | Purpose |
+|---------|---------|
+| `events:emit` | Emit event from renderer |
+| `events:subscribe` | Subscribe to events |
+| `events:unsubscribe` | Unsubscribe from events |
+| `events:query` | Query events with filters |
+| `events:getLastEvent` | Get last event of type |
+| `events:getStatistics` | Get event statistics |
+
+## Data Flow: File Change Event
+
+Change detection is daemon-owned (the FE change-tracking subsystem — ChangeDetector, ChangeProcessor, EventCoordinator — has been removed):
+
+```
+1. File changed on disk
+   ↓
+2. intentd daemon detects the change and emits a WorkspaceEvent
+   ↓
+3. The daemon events bridge delivers the event to the renderer
+   ↓
+4. workspace-events slice accepts event (with deduplication)
+   ↓
+5. UI components update via Redux selectors
+```
+
+## Best Practices
+
+1. **Import pure utilities from features/events**: EventFilterEngine
+2. **Use EventFilterBuilder**: For type-safe filter construction
+
+## Configuration
+
+Event-system timing configuration (`src/features/file-tracking/tracking.config.ts`) was removed along with the FE change-tracking subsystem — change detection and event persistence are daemon-owned.
+
+## Deprecated Channels
+
+The legacy `activity-log:*` channels (`activity-log:get-entries`, `activity-log:add-entry`, `activity-log:clear`) have been removed entirely — they are no longer defined in `ipc-registry.ts`. Use the `events:*` channels instead.
+
+---
+
+## IPC Event Handling in the Renderer
+
+### Event Emission Patterns
+
+Events can arrive in the renderer via two different emission patterns:
+
+#### Pattern A: Direct IPC (Flat Data)
+```typescript
+// Main process emits:
+window.webContents.send('agent:renamed', { agentId, workspaceId, name });
+
+// Renderer receives via listenSync:
+// { payload: { agentId, workspaceId, name } }
+```
+
+#### Pattern B: Wrapped WorkspaceEvent
+```typescript
+// Main process sends the full event object to renderer windows:
+window.webContents.send('agent:deleted', event);
+
+// Renderer receives via listenSync:
+// { payload: { type: 'agent:deleted', id: '...', data: { agentId, agentName } } }
+```
+(Historically these events were dispatched through the main-process Redux store via `mainDispatch(emitWorkspaceEvent(...))`; that store has been removed and `mainDispatch` is now a no-op.)
+
+### The `listenSync` Wrapping
+
+The `listenSync` function in `electron-bridge.ts` always wraps incoming data:
+
+```typescript
+const listener = (data: T) => {
+  handler({ payload: data });  // Always wraps in { payload: data }
+};
+```
+
+### Using `extractEventData()` Helper
+
+To safely handle both patterns, use the `extractEventData()` helper from `$lib/electron-bridge`:
+
+```typescript
+import { listenSync, extractEventData } from '$lib/electron-bridge';
+import type { AgentDeletedPayload } from '$features/events/types';
+
+// Extract a specific field (works for both patterns)
+listenSync('agent:deleted', (event: any) => {
+  const agentId = extractEventData<string>(event, 'agentId');
+  if (typeof agentId === 'string') {
+    handleAgentDeleted(agentId);
+  } else {
+    logger.warn('Received agent:deleted with invalid agentId', { event });
+  }
+});
+
+// Extract the full data object
+listenSync('agent:renamed', (event: any) => {
+  const data = extractEventData<AgentRenamedPayload>(event);
+  if (data && typeof data.agentId === 'string') {
+    handleAgentRenamed(data);
+  }
+});
+```
+
+### Best Practices for Event Handlers
+
+1. **Always use `extractEventData()`** for new handlers - it handles both emission patterns
+2. **Add validation** - Always verify the extracted data has the expected shape:
+   ```typescript
+   const agentId = extractEventData<string>(event, 'agentId');
+   if (typeof agentId !== 'string') {
+     logger.warn('Unexpected event format', { event });
+     return;
+   }
+   ```
+3. **Use TypeScript types** - Import payload types from `$features/events/types`:
+   ```typescript
+   import type { AgentDeletedPayload, AgentRenamedPayload } from '$features/events/types';
+   ```
+4. **Log unexpected formats** - Don't silently fail when data extraction fails
+5. **Prefer Redux `emitWorkspaceEvent` for new events** - It provides consistent structure and better observability
+
+### Common Pitfalls
+
+❌ **DON'T** assume the event format without checking:
+```typescript
+// BAD: Assumes flat format - breaks with Redux WorkspaceEvent objects
+listenSync('agent:deleted', (event) => {
+  const agentId = event.payload;  // Could be a WorkspaceEvent object!
+  agents = agents.filter(a => a.id !== agentId);  // String vs Object comparison always true
+});
+```
+
+✅ **DO** use `extractEventData()` and validate:
+```typescript
+// GOOD: Handles both patterns and validates
+listenSync('agent:deleted', (event) => {
+  const agentId = extractEventData<string>(event, 'agentId');
+  if (typeof agentId === 'string') {
+    agents = agents.filter(a => a.id !== agentId);
+  }
+});
+```
+
+### IPC Payload Type Definitions
+
+Type definitions for IPC event payloads are available in `src/features/events/types.ts`:
+
+| Type | Event Channel | Description |
+|------|---------------|-------------|
+| `AgentDeletedPayload` | `agent:deleted` | Agent deletion data |
+| `AgentRenamedPayload` | `agent:renamed` | Agent rename data |
+| `AgentCreatedPayload` | `agent:created` | Agent creation data |
+| `AgentSubscribedPayload` | `agent:subscribed` | Agent subscription data |
+| `AgentUnsubscribedPayload` | `agent:unsubscribed` | Agent unsubscription data |
+| `AgentIdlePayload` | `agent:idle` | Agent idle state data |
+| `AgentStatusChangedPayload` | `agent:status-changed` | Agent status change data |
+| `NoteCreatedPayload` | `note:created` | Note creation data |
+| `NoteUpdatedPayload` | `note:updated` | Note update data |
+| `NoteDeletedPayload` | `note:deleted` | Note deletion data |
+| `TaskStatusChangedPayload` | `task:status-changed` | Task status change data |
+| `IpcEventWrapper<T>` | (any) | Wrapper for listenSync events |
+
+### Debugging Event Issues
+
+If events aren't being handled correctly:
+
+1. **Log the raw event** to see its actual structure:
+   ```typescript
+   listenSync('event-name', (event) => {
+     console.log('Raw event:', JSON.stringify(event, null, 2));
+   });
+   ```
+
+2. **Check the emission source** - Is it using direct IPC or Redux events?
+   - Search for `webContents.send('event-name'` for direct IPC
+   - Search for `emitWorkspaceEvent(` for Redux-based events
+
+3. **Use `isWorkspaceEvent()` type guard** to understand the format:
+   ```typescript
+   import { isWorkspaceEvent } from '$lib/electron-bridge';
+
+   listenSync('event-name', (event) => {
+     const payload = event.payload;
+     if (isWorkspaceEvent(payload)) {
+       console.log('WorkspaceEvent format, data:', payload.data);
+     } else {
+       console.log('Flat format:', payload);
+     }
+   });
+   ```

--- a/docs/fe/EVENT_SYSTEM.md
+++ b/docs/fe/EVENT_SYSTEM.md
@@ -6,9 +6,9 @@
 
 ## Overview
 
-The Intent app uses a **Redux-based event system** for all workspace events. Events are managed through Redux slices and sagas in the main process, with IPC channels for renderer communication.
+The Intent app uses a **Redux-based event system** for all workspace events. Events originate from the intentd daemon and are routed into the renderer Redux store by the daemon events bridge; renderer slices and sagas manage event state.
 
-1. **WorkspaceEvents**: Full-featured events managed by `workspace-events` Redux slice with persistence, filtering, and query support
+1. **WorkspaceEvents**: Full-featured events managed by the renderer `workspace-events` Redux slice with filtering and query support (persistence is daemon-owned)
 
 > **Note**: The legacy EventBus singletons (UnifiedEventBus, WorkspaceEventBus, WorkspaceEventService) have been removed, as have the DomainEvents broadcast layer (`domain-events` actions/sagas) and the main-process Redux store. All event state is now managed through renderer Redux.
 
@@ -21,28 +21,20 @@ The Intent app uses a **Redux-based event system** for all workspace events. Eve
 │  Components              Redux Store              Selectors     │
 │  ┌─────────┐         ┌──────────────────┐    ┌─────────────┐   │
 │  │ UI      │◄────────│ workspace-events │◄───│ Reactive    │   │
-│  │ Layer   │────────►│ slice (synced)   │───►│ Selectors   │   │
-│  └─────────┘         └────────┬─────────┘    └─────────────┘   │
+│  │ Layer   │────────►│ slice + sagas    │───►│ Selectors   │   │
+│  └─────────┘         └────────▲─────────┘    └─────────────┘   │
+│                               │                                  │
+│              ┌────────────────┴────────────────┐                │
+│              │  Daemon Events Bridge            │                │
+│              │  (daemon-events-bridge.client)   │                │
+│              └────────────────▲────────────────┘                │
 └──────────────────────────────┼──────────────────────────────────┘
-                               │ IPC (Redux sync)
-                               ▼
-┌─────────────────────────────────────────────────────────────────┐
-│                      Main Process                                │
-├─────────────────────────────────────────────────────────────────┤
-│                                                                  │
-│  ┌─────────────────────────────────────────────────────────┐    │
-│  │              Redux Store (Main)                          │    │
-│  │                                                          │    │
-│  │  • workspace-events slice — event state + persistence   │    │
-│  │  • agent-subscriptions slice — agent event filters      │    │
-│  └────────────────────────┬────────────────────────────────┘    │
-│                           │                                      │
-│                           ▼                                     │
-│                  ┌──────────────┐                               │
-│                  │ Sagas        │                               │
-│                  │ (side fx)    │                               │
-│                  └──────────────┘                               │
-│                                                                  │
+                               │ event subscription (JSON-RPC)
+                               │
+┌──────────────────────────────┴──────────────────────────────────┐
+│                    intentd Daemon                                │
+│   • emits workspace/agent/git/note events                       │
+│   • owns event persistence and historical queries               │
 └─────────────────────────────────────────────────────────────────┘
 ```
 
@@ -76,8 +68,9 @@ The DomainEvents broadcast layer (`domain-events` actions and sagas under `src/s
 
 | Component | Location | Responsibility |
 |-----------|----------|----------------|
-| workspace-events slice | `store/main/slices/workspace-events/` | Event state management |
-| agent-subscriptions slice | `store/main/slices/agent-subscriptions/` | Agent event filter state |
+| Daemon events bridge | `features/events/daemon-events-bridge.client.ts` | Routes daemon events into renderer Redux |
+| workspace-events slice | `store/renderer/slices/workspace-events/` | Event state management |
+| agent-subscription-ui slice | `store/renderer/slices/agent-subscription-ui/` | Agent event filter state |
 | EventFilterEngine | `features/events/event-filter-engine.ts` | Pure filter matching logic |
 | agent-subscription-ops | `features/events/main/agent-subscription-ops.ts` | Agent subscription operations |
 

--- a/docs/fe/IPC_DEBUG_GUIDE.md
+++ b/docs/fe/IPC_DEBUG_GUIDE.md
@@ -1,0 +1,188 @@
+# IPC Debug Guide for AI Agents
+
+## Overview
+
+The Intent app now includes comprehensive IPC (Inter-Process Communication) debugging to help identify and fix missing handlers and validation errors. This system automatically tracks all IPC calls and writes debug information to files that agents can analyze.
+
+## Quick Start
+
+### Check for IPC Issues
+```bash
+# Show summary of all IPC debug data
+pnpm ipc:debug:summary
+
+# List missing handlers with suggestions
+pnpm ipc:debug:missing
+
+# Show validation errors
+pnpm ipc:debug:errors
+
+# Show file paths
+pnpm ipc:debug:path
+
+# Clear debug data
+pnpm ipc:debug:clear
+```
+
+## Debug Files Location
+
+The system writes debug data to:
+- **Debug Log**: `.augment/ipc-debug/ipc-debug.json` - All IPC calls and results
+- **Missing Handlers**: `.augment/ipc-debug/missing-handlers.json` - List of unregistered channels
+- **Registered Handlers**: `.augment/ipc-debug/registered-handlers.json` - All registered handlers (created on app startup)
+
+## How It Works
+
+### 1. Automatic Tracking
+- Every IPC call is automatically tracked
+- Validation errors are logged with full details
+- Missing handlers are detected and recorded
+- Success/failure status is tracked for each call
+
+### 2. Debug Information Structure
+
+#### Missing Handlers File
+```json
+{
+  "timestamp": "2024-11-20T15:30:00.000Z",
+  "count": 3,
+  "channels": [
+    "workspace:pr:generate",
+    "ssh:test_connection",
+    "vscode:open"
+  ],
+  "suggestions": {
+    "workspace:pr:generate": "Check src/features/workspace/main/workspace.ipc.ts",
+    "ssh:test_connection": "Check src/features/ssh/main/ssh.ipc.ts",
+    "vscode:open": "Check src/features/ide/main/ide.ipc.ts"
+  }
+}
+```
+
+#### Debug Log Entry
+```json
+{
+  "timestamp": "2024-11-20T15:30:00.000Z",
+  "channel": "workspace:create",
+  "type": "validation_error",
+  "data": { "name": 123 },
+  "error": "Expected string, received number",
+  "stack": "..."
+}
+```
+
+## Common Issues and Fixes
+
+### 1. Missing Handler
+**Error**: `No handler registered for channel 'workspace:pr:generate'`
+
+**Fix**:
+1. Create handler file: `src/features/workspace/main/workspace-pr.ipc.ts`
+2. Register handler in the file
+3. Import and call setup function in `src/main/index.ts`
+
+### 2. Validation Error
+**Error**: `Expected object, received string`
+
+**Fix**:
+1. Check the channel's schema in the handler file
+2. Update schema to accept the correct data type
+3. Or fix the caller to send correct data format
+
+### 3. Handler Not Being Called
+**Debug Steps**:
+1. Check if handler is registered: `pnpm ipc:debug:missing`
+2. Check for validation errors: `pnpm ipc:debug:errors`
+3. Verify handler is imported in `src/main/index.ts`
+
+## Creating New IPC Handlers
+
+### Step 1: Create Handler File
+```typescript
+// src/features/myfeature/main/myfeature.ipc.ts
+import { ipcMain } from 'electron';
+import { z } from 'zod';
+import { createValidatedHandler } from '../../../main/ipc-validation-middleware';
+
+const MyRequestSchema = z.object({
+  workspaceId: z.string(),
+  data: z.string()
+});
+
+export function setupMyFeatureIPC() {
+  ipcMain.handle(
+    'myfeature:action',
+    createValidatedHandler(MyRequestSchema, async (event, data) => {
+      // Handler logic here
+      return { success: true };
+    }, 'myfeature:action') // Pass channel name for debugging
+  );
+}
+```
+
+### Step 2: Register in Main Process
+```typescript
+// src/main/index.ts
+import { setupMyFeatureIPC } from '../features/myfeature/main/myfeature.ipc';
+
+// In app.whenReady()
+setupMyFeatureIPC();
+```
+
+### Step 3: Regenerate the Preload Allowlist
+
+The preload channel allowlist (`ALLOWED_CHANNELS` in `src/preload/index.ts`) is generated — do not hand-edit it. After registering the channel, regenerate:
+
+```bash
+pnpm run generate:ipc-channels
+```
+
+## Debugging Workflow
+
+1. **Run the app** with debug mode:
+   ```bash
+   pnpm dev:cdp
+   ```
+
+2. **Trigger the problematic action** in the UI
+
+3. **Check for issues**:
+   ```bash
+   pnpm ipc:debug:summary
+   ```
+
+4. **Fix missing handlers**:
+   ```bash
+   pnpm ipc:debug:missing
+   ```
+   Follow the suggestions to create/register handlers
+
+5. **Fix validation errors**:
+   ```bash
+   pnpm ipc:debug:errors
+   ```
+   Update schemas or fix data format
+
+6. **Verify fixes**:
+   - Restart the app
+   - Trigger the action again
+   - Check debug summary
+
+## Tips for AI Agents
+
+1. **Always check IPC debug first** when encountering IPC-related errors
+2. **Use the suggestions** in missing-handlers.json to locate where to add handlers
+3. **Check validation errors** for data format mismatches
+4. **Clear debug data** periodically to avoid confusion with old errors
+5. **Export handler info** is created on app startup in development mode
+6. **Track patterns** - similar channel names usually go in the same feature directory
+
+## Integration with Error Tracking
+
+IPC errors are also tracked in the main error tracking system:
+```bash
+# Check general errors including IPC
+pnpm run agent-errors summary
+```
+
+This provides additional context and stack traces for debugging.

--- a/docs/fe/KEYBINDINGS.md
+++ b/docs/fe/KEYBINDINGS.md
@@ -1,0 +1,304 @@
+# Workspaces App Keyboard Shortcuts Reference
+
+> **Legend:** `Cmd` = ⌘ on Mac, `Ctrl` on Windows/Linux. `Mod` means either depending on platform.
+
+---
+
+## 🌐 Global / App-Wide
+
+| Shortcut | Action | Context |
+|----------|--------|---------|
+| `Mod+K` | Open Command Palette | Anywhere (not in terminal) |
+| `Mod+T` | New Tab (creates new agent) | In workspace |
+| `Mod+P` | Quick Open (file picker) | Anywhere (not in terminal) |
+| `Mod+Shift+P` | Open Command Palette | Anywhere (not in terminal) |
+| `Mod+,` | Open Settings | Anywhere |
+| `Mod+O` | Toggle All Spaces | Anywhere |
+| `Mod+N` | New Agent | Anywhere (not in inputs) |
+| `Mod+?` | Toggle Keyboard Shortcuts | Anywhere |
+| `Mod+F` | Search | Focused searchable panel |
+| `Ctrl+Tab` | Next Space | Anywhere in workspace |
+| `Ctrl+Shift+Tab` | Previous Space | Anywhere in workspace |
+| `Alt+Z` | Toggle Word Wrap | In editor |
+| `Mod+J` | Toggle Quake Terminal Overlay | Anywhere |
+| `Ctrl+\`` | Toggle Quake Terminal Overlay | Anywhere (always Ctrl, even Mac) |
+| `Ctrl+Shift+\`` | Create New Terminal | Anywhere (always Ctrl, even Mac) |
+| `Escape` | Close modal/dialog/cancel | Various contexts |
+
+---
+
+## 🗂️ Tabs & Panels
+
+| Shortcut | Action | Context |
+|----------|--------|---------|
+| `Mod+W` | Close Current Tab | In panel |
+| `Mod+Shift+T` | Reopen Last Closed Tab | In panel |
+| `Mod+1-9` | Switch to Tab by Index | In panel (1 = first tab; `Mod+1/2/3` may be preempted by focus navigation) |
+| `Mod+\` | Split Panel Horizontally | In panel |
+| `Mod+Shift+\` | Split Panel Vertically | In panel |
+| `Mod+[` | Go Back in Panel History | In panel |
+| `Mod+]` | Go Forward in Panel History | In panel |
+| `Mod+Shift+[` | Select Previous Tab | In panel (also terminal tabs) |
+| `Mod+Shift+]` | Select Next Tab | In panel (also terminal tabs) |
+| `Mod+Shift+M` | Toggle Panel Zoom/Maximize | In panel |
+
+---
+
+## 📍 Focus Navigation (VS Code-style)
+
+| Shortcut | Action | Context |
+|----------|--------|---------|
+| `Mod+1` | Focus Main Content | Anywhere |
+| `Mod+2` | Focus Drawer (sidebar panels) | Anywhere |
+| `Mod+3` | Focus Dock (agents/terminals) | Anywhere |
+| `Mod+B` | Toggle Workspace Sidebar | Anywhere |
+| `Mod+O` | Toggle Spaces Overlay | Anywhere |
+| `Mod+Shift+D` | Open Agent Overview | Anywhere |
+| `Mod+Shift+E` | Focus File Explorer Tab | Anywhere |
+| `Mod+Shift+G` | Focus Git Changes Tab | Anywhere |
+| `Mod+Shift+N` | *(reserved)* New Window — handled by native menu; not bound in-app | — |
+| `Mod+Shift+A` | Focus Activity Tab | Anywhere |
+
+`Mod+1/2/3` are registered globally for main-content, drawer, and dock focus. Panel-level numeric tab switching still exists, but those focus shortcuts can take precedence depending on where the event is handled.
+
+---
+
+## 🎨 Layout Presets
+
+| Shortcut | Action | Context |
+|----------|--------|---------|
+| `Mod+Alt+1` | Focus Mode (single panel) | Anywhere |
+| `Mod+Alt+2` | Split View | Anywhere |
+| `Mod+Alt+3` | Full Layout | Anywhere |
+| `Mod+Alt+=` | Equalize Panel Sizes | Multi-panel layout |
+| `Mod+Alt+←` | Shrink Panel | Multi-panel layout |
+| `Mod+Alt+→` | Grow Panel | Multi-panel layout |
+
+---
+
+## 🔤 Leader Key System (tmux/vim-style)
+
+> **Leader Key:** `Mod+;` — Press once, then press action key within 2 seconds
+
+| Key after Leader | Action | Notes |
+|------------------|--------|-------|
+| `h` | Navigate Panel Left | vim-style |
+| `j` | Navigate Panel Down | vim-style |
+| `k` | Navigate Panel Up | vim-style |
+| `l` | Navigate Panel Right | vim-style |
+| `Shift+H` | Resize Panel Left | Key is mapped; action handler still TODO |
+| `Shift+J` | Resize Panel Down | Key is mapped; action handler still TODO |
+| `Shift+K` | Resize Panel Up | Key is mapped; action handler still TODO |
+| `Shift+L` | Resize Panel Right | Key is mapped; action handler still TODO |
+| `o` | Cycle to Next Panel | tmux-style |
+| `p` | Cycle to Previous Panel | tmux-style |
+| `%` | Split Right | tmux-style |
+| `"` | Split Down | tmux-style |
+| `z` | Toggle Panel Zoom | |
+| `x` | Close Panel | |
+| `=` | Equalize All Panel Sizes | |
+| `q` | Show Panel Numbers | For quick jump |
+| `1-9` | Jump to Panel by Number | After `q` |
+| `m` | Move Tab to Other Panel | |
+| `Space` | Cycle Layout Presets | |
+
+---
+
+## 💬 Chat / Agent
+
+| Shortcut | Action | Context |
+|----------|--------|---------|
+| `Enter` | Send Message | In chat input |
+| `Mod+Enter` | Send Message (force/interrupt) | In chat input |
+| `Shift+Enter` | Insert New Line | In chat input |
+| `Escape` | Stop Agent Generation | During agent response |
+| `/` | Focus Chat Input | Not in editable element |
+| `Mod+/` | Enhance Prompt | Chat inputs / prompt editors |
+| `Mod+↑` | Navigate to Previous Message | Not in inputs |
+| `Mod+↓` | Navigate to Next Message | Not in inputs |
+
+---
+
+## 👁️ Follow Mode
+
+| Shortcut | Action | Context |
+|----------|--------|---------|
+| `Mod+Shift+F` | Toggle Follow Mode | Anywhere |
+| `Mod+Shift+→` | Follow Next Agent | In follow mode |
+| `Mod+Shift+←` | Follow Previous Agent | In follow mode |
+| `Escape` | Exit Follow Mode | In follow mode |
+
+---
+
+## 🔍 Dock Navigation
+
+| Shortcut | Action | Context |
+|----------|--------|---------|
+| `Alt+↑` | Previous Dock Item (agent/terminal) | Not in editable element |
+| `Alt+↓` | Next Dock Item (agent/terminal) | Not in editable element |
+| `Alt+←` | Go Back (main panel history) | Not in editable element |
+| `Alt+→` | Go Forward (main panel history) | Not in editable element |
+
+---
+
+## 🌐 Web Browser Panel
+
+| Shortcut | Action | Context |
+|----------|--------|---------|
+| `Alt+←` | Go Back | In browser panel |
+| `Alt+→` | Go Forward | In browser panel |
+| `F5` / `Mod+R` | Refresh Page | In browser panel |
+| `Escape` | Close Browser | In browser panel |
+
+---
+
+## 📁 File Explorer / Editor
+
+| Shortcut | Action | Context |
+|----------|--------|---------|
+| `Mod+S` | Save File | In file editor |
+| `Mod+Z` | Undo | In editor |
+| `Mod+Shift+Z` | Redo | In editor |
+| `F12` | Go to Definition | In code editor (when focused) |
+| `/` | Open Search | In repo visualizer (not in input) |
+| `n` / `N` | Navigate Siblings (next/prev) | In repo visualizer |
+| `Escape` | Zoom Out One Level | In repo visualizer (when zoomed) |
+
+---
+
+## 🖥️ Terminal Overlay
+
+| Shortcut | Action | Context |
+|----------|--------|---------|
+| `Ctrl+\`` | Toggle Terminal Overlay | Anywhere (always Ctrl, even Mac) |
+| `Mod+J` | Toggle Terminal Overlay | Anywhere (alternate) |
+| `Ctrl+Shift+\`` | Create New Terminal Tab | Anywhere |
+| `Mod+Shift+]` | Next Terminal Tab | In terminal overlay |
+| `Mod+Shift+[` | Previous Terminal Tab | In terminal overlay |
+
+> ⚠️ **`Cmd+\`` is intentionally NOT used** — it is a reserved macOS shortcut for cycling between application windows.
+
+---
+
+## 📝 Command Palette Navigation
+
+| Shortcut | Action | Context |
+|----------|--------|---------|
+| `↑` / `↓` | Navigate Items | In command palette |
+| `Enter` | Select Item | In command palette |
+| `Mod+Enter` | Open in Adjacent Panel | In command palette |
+| `Escape` | Clear Search / Close | In command palette |
+
+---
+
+# ⚠️ Audit Notes & Issues
+
+## Potential Conflicts
+
+1. **`Mod+Shift+N`** - Reserved for New Window (handled by the native menu); do not bind it in-app. Use `Ctrl+Shift+\`` for new terminal.
+
+2. **`Mod+Shift+[/]`** - Used for both "Select Previous/Next Tab" AND "Previous/Next Terminal Tab"
+   - Context-dependent: panel tabs vs terminal tabs
+   - Recommendation: This is acceptable since they're in different contexts
+
+3. **`Escape`** - Overloaded for many purposes (close modal, stop agent, exit follow, zoom out)
+   - This is standard behavior and acceptable
+
+4. **`Mod+J`** vs `Ctrl+\`` for terminal** - Duplicate functionality
+   - Recommendation: Keep both for discoverability (`Mod+J` is easier, `Ctrl+\`` matches VS Code)
+
+## Reserved OS Shortcuts (DO NOT OVERRIDE)
+
+These shortcuts are reserved by the operating system and **must not** be intercepted by the app.
+The `KeyboardShortcutManager` will warn in dev mode if any of these are registered.
+
+| Shortcut | OS | Purpose |
+|----------|-----|---------|
+| `Cmd+\`` | macOS | Cycle through application windows |
+| `Cmd+Tab` | macOS | Application switcher |
+| `Cmd+H` | macOS | Hide application |
+| `Cmd+Q` | macOS | Quit application |
+| `Cmd+Space` | macOS | Spotlight search |
+| `Cmd+Shift+3/4/5` | macOS | Screenshots |
+| `Ctrl+Tab` | Windows | Task switcher (handled by OS, but safe in Electron) |
+
+## Inconsistencies
+
+1. **Leader key shortcuts are only partially implemented** - Resize actions (`Shift+H/J/K/L`) are parsed by the leader-key mapper, but the handler still logs a TODO instead of resizing panels; swap actions (`{` / `}`) are also still only suggested/TODO.
+
+2. ~~**`Mod+T`** opened the wrong action~~ ✅ **FIXED** - It now dispatches `workspace:new-tab`, which creates a new agent tab.
+
+---
+
+# 💡 Suggested New Keybindings
+
+> **Note**: This section and "Implementation Priority" below are proposals/wishlist items, not reference material for implemented bindings.
+
+## For Developer Familiarity (VS Code-style)
+
+| Shortcut | Suggested Action | Rationale |
+|----------|-----------------|-----------|
+| `Mod+Shift+O` | Go to Symbol | VS Code standard |
+| `Mod+G` | Go to Line | Universal IDE shortcut |
+| `Mod+D` | Add Selection to Next Match | VS Code multi-cursor |
+| `Mod+Shift+L` | Select All Occurrences | VS Code multi-cursor |
+| `F2` | Rename Symbol | Universal IDE shortcut |
+| ~~`F12`~~ | ~~Go to Definition~~ | ✅ **Implemented** |
+| `Shift+F12` | Find All References | VS Code standard |
+| `Mod+.` | Quick Fix / Code Actions | VS Code standard |
+| `Mod+/` | Toggle Line Comment | Universal IDE shortcut |
+| `Mod+Shift+/` | Toggle Block Comment | Universal IDE shortcut |
+
+## For Power Users (vim/tmux-style)
+
+| Shortcut | Suggested Action | Rationale |
+|----------|-----------------|-----------|
+| `Mod+Shift+P` → `:` | Open command-line mode | vim-style command entry |
+| Leader + `c` | Create new panel | tmux-style (currently missing) |
+| Leader + `n` | Next window | tmux-style (alt to `o`) |
+| Leader + `&` | Kill panel (with confirmation) | tmux-style |
+| Leader + `{` / `}` | Swap panel position | tmux-style (marked TODO) |
+| Leader + `[` | Enter copy/scroll mode | tmux-style |
+
+## Quality of Life
+
+| Shortcut | Suggested Action | Rationale |
+|----------|-----------------|-----------|
+| `Mod+Shift+C` | Copy Full Conversation | Quick export |
+| `Mod+Shift+X` | Clear Conversation | Quick reset |
+| `Mod+Alt+C` | Copy Last Code Block | Common need |
+| `Mod+'` | Toggle Focus Mode | Quick distraction-free mode |
+| `Mod+0` | Close All Panels | Clear workspace |
+| `Mod+Shift+W` | Close All Tabs in Panel | Batch close |
+| `Mod+L` | Clear Terminal | Standard terminal shortcut |
+| `Mod+Shift+R` | Restart Agent | Quick reset |
+
+## Agent-Specific
+
+| Shortcut | Suggested Action | Rationale |
+|----------|-----------------|-----------|
+| `Mod+Shift+Enter` | Send & Keep Focus | Continue typing immediately |
+| `Alt+Enter` | Send as Code | Wrap in code block |
+| `Mod+Shift+.` | Retry Last Action | Quick iteration |
+| `Mod+Shift+,` | Undo Agent Change | Revert file changes |
+| `Mod+U` | Show Undo/Redo History | See agent actions |
+
+---
+
+# 📋 Implementation Priority
+
+## High Priority (Missing basics)
+- [x] ~~`Mod+G` - Go to line~~ ✅ **Implemented**
+- [ ] Toggle comment shortcut (currently unassigned)
+- [ ] `Mod+L` - Clear terminal (pass through to xterm)
+
+## Medium Priority (Power user)
+- [ ] Complete leader key resize shortcuts (`Shift+H/J/K/L`) — keys are mapped, but the action handler still logs a TODO
+- [ ] Complete leader key swap shortcuts (`{` / `}`)
+- [x] ~~`F12` - Go to definition~~ ✅ **Implemented**
+- [ ] `Shift+F12` - Find all references
+
+## Low Priority (Nice to have)
+- [ ] Multi-cursor shortcuts (`Mod+D`, `Mod+Shift+L`)
+- [ ] Copy conversation shortcuts
+- [ ] Agent-specific shortcuts

--- a/docs/fe/MODULE_BOUNDARY_GUIDE.md
+++ b/docs/fe/MODULE_BOUNDARY_GUIDE.md
@@ -1,0 +1,125 @@
+# Module Boundary Guide
+
+How to place utility and helper modules in the Intent codebase so they don't create unintended cross-process coupling.
+
+## Why This Matters
+
+Intent is an Electron app with three distinct process contexts:
+
+- **Main process** (`src/main/`, feature `main/` subtrees) — Node.js, has filesystem/OS access
+- **Renderer process** (`src/lib/`, `src/routes/`, feature root/component files) — browser context, Svelte UI
+- **Preload** (`src/preload/`) — bridge between main and renderer
+
+When a renderer module imports a helper that lives inside a feature's `main/` subtree, the bundler pulls the entire main-process dependency chain into the renderer bundle. This causes:
+
+- Larger renderer bundles with dead Node.js code
+- Potential runtime errors from Node.js APIs in the browser
+- Tight coupling between features that should be independent
+
+The same problem occurs in reverse: main-process code importing from renderer-only feature paths can pull in Svelte/browser dependencies.
+
+## Directory Roles
+
+| Directory | Process | Purpose | When to use |
+|-----------|---------|---------|-------------|
+| `src/shared/` | Any | Pure helpers with **active main + renderer consumers** | Cross-process utilities (ID generators, validators, type guards) |
+| `src/lib/utils/` | Renderer | Browser-safe helpers reused across renderer features | Serializers, formatters, URL helpers used by multiple UI features |
+| `src/main/utils/` | Main | Main-process helpers shared across features or IPC handlers | Validation, sanitization, path helpers used by multiple main services |
+| `src/features/<name>/utils/` | Varies | Helpers clearly owned by one feature | Feature-local extraction from a mixed module |
+| `src/features/<name>/main/` | Main | Feature's main-process code | Business logic, IPC handlers, services |
+| `src/features/<name>/` (root) | Renderer | Feature's renderer code | Stores, components, client modules |
+
+### Decision Flowchart
+
+When you have a utility function that needs a home:
+
+1. **Is it used by both main and renderer code?** → `src/shared/`
+2. **Is it main-process only, used by multiple features?** → `src/main/utils/`
+3. **Is it renderer only, used by multiple features?** → `src/lib/utils/`
+4. **Is it used by only one feature?** → `src/features/<name>/utils/`
+5. **Is it tightly coupled to a service or orchestration module?** → Leave it in place, it's not a utility
+
+## Rules for New Code
+
+### DO
+
+- **Place new shared utilities in the correct process-safe directory** from the start. Don't put a cross-feature helper in a feature root and plan to move it later.
+- **Use feature-local `utils/` directories** when a helper is clearly owned by one feature. This is better than prematurely promoting to `src/shared/`.
+- **Keep utility modules dependency-light.** A utility should not import stores, services, or orchestration modules. If it needs those, it's not a utility — it's a service.
+- **Prefer pure functions.** Utilities should take inputs and return outputs without side effects. This makes them safe to import from any process context.
+- **Co-locate related utilities.** `generateCommentId()` and `isValidCommentId()` belong in the same file, not scattered across directories.
+
+### DON'T
+
+- **Don't export utility functions from orchestration modules.** If `workspace.client.ts` has a `normalizeWorkspacePaths()` helper, extract it to `utils/` rather than making callers import the entire client module.
+- **Don't import from a feature's `main/` subtree in renderer code** (or vice versa). This is the primary boundary violation this guide prevents.
+- **Don't put renderer-only helpers in `src/shared/`.** If only renderer code uses it, `src/lib/utils/` is the right home. `src/shared/` should be reserved for genuinely cross-process code.
+- **Don't duplicate helpers across directories.** If you find yourself writing `isGitHubUrl()` in two places, extract it to the appropriate shared location instead.
+
+## Recognizing Mixed Modules
+
+A "mixed module" exports both:
+- **Utility functions** — pure, dependency-light, reusable (e.g., `isAuthUrl()`, `normalizeWorkspacePaths()`)
+- **Orchestration code** — stateful, side-effectful, feature-specific (e.g., `handleLink()`, API client methods)
+
+Mixed modules are the most common source of boundary violations because importing the utility also pulls in the orchestration code and all its dependencies.
+
+### How to Split a Mixed Module
+
+1. **Identify the utility exports** — functions that are pure, take simple inputs, return simple outputs, and don't import stores/services
+2. **Create a `utils/` file** in the appropriate directory (feature-local or shared)
+3. **Move the utility functions** to the new file
+4. **Add a temporary re-export** from the original file to avoid breaking all callers at once:
+   ```typescript
+   // Old file — temporary shim during migration
+   export { isAuthUrl, isGitHubUrl } from '$lib/utils/link-url-utils';
+   ```
+5. **Repoint direct consumers** to the new path in the same PR
+6. **Remove the re-export** once all consumers are migrated (can be a follow-up PR)
+
+## Refactoring Existing Code
+
+When you encounter a boundary violation during feature work:
+
+1. **Don't fix it inline** if it's not directly related to your change. File a separate issue or note it for a future refactor.
+2. **If you must fix it**, follow the batch approach:
+   - Move/split one module at a time
+   - Preserve all existing export names and signatures
+   - Use temporary re-exports to minimize import churn
+   - Run targeted tests + typechecks before moving to the next module
+3. **Verify after each move:**
+   ```bash
+   # Targeted tests for touched features
+   npx vitest run <test-files-for-touched-features>
+   
+   # All three typecheck targets
+   npx tsc -p tsconfig.json --noEmit        # renderer
+   npx tsc -p tsconfig.main.json --noEmit   # main process
+   npx tsc -p tsconfig.preload.json --noEmit # preload
+   ```
+
+## Current State
+
+The following moves were completed as part of the initial refactor:
+
+| Module | Old Location | New Location | Status |
+|--------|-------------|--------------|--------|
+| `comment-id-generator.ts` | `src/features/comments/` | `src/shared/utils/` | ✅ Moved, old-path shim removed |
+| `notes-primitives-serializer.ts` | `src/features/notes/` | `src/lib/utils/` | ✅ Moved, old-path shim removed |
+| `workspace-validation.ts` | `src/features/workspace/main/` | `src/main/utils/` | ✅ Moved, old-path shim removed |
+
+The temporary re-export shims at the old paths have all been removed; consumers import the new locations directly.
+
+### Remaining planned work
+
+| Module | Action | Target |
+|--------|--------|--------|
+| `ipc-validation.ts` | Split | `src/main/utils/` (generic IPC validators vs workspace-specific) |
+| `link-handler.ts` | Split | Extract `isAuthUrl()`/`isGitHubUrl()` from `src/features/navigation/link-handler.ts` → `src/lib/utils/link-url-utils.ts` (not yet done) |
+
+Note: `workspace.client.ts` now lives at `src/store/renderer/slices/workspace/utils/` and still holds `normalizeWorkspacePaths()`.
+
+## Related Documentation
+
+- [Developer Guide](./DEVELOPER_GUIDE.md) — project setup and structure overview
+- [Type System Guide](./TYPE_SYSTEM_GUIDE.md) — type conventions

--- a/docs/fe/MULTI_BACKEND_CONNECT.md
+++ b/docs/fe/MULTI_BACKEND_CONNECT.md
@@ -1,0 +1,125 @@
+# Multi-backend connect (FE)
+
+How cloudlands-fe connects to a **remote intentd** (another machine) alongside
+the local sidecar, and how the active backend is switched at runtime.
+
+> **Scope: FE-only.** This is entirely a cloudlands-fe capability. intentd
+> already serves WSS + a self-signed-cert fingerprint + a bearer token; there
+> is **no daemon/protocol change**. The daemon-side wire contract this rides on
+> is the canonical monorepo doc `docs/PROTOCOL.md` **§1.1–2.3** (Connection URL,
+> TLS & fingerprint pinning, message size, bearer token on upgrade, origin
+> allow-list, where the token lives). Read that for the transport; this doc
+> covers only the FE side.
+
+## What it does
+
+The **daemon-status dropdown** (`DaemonStatusIndicator.svelte`) gains a
+"Connect to another intentd" action and a past-connections list:
+
+- The list's first, non-forgettable entry is **"This machine (local)"** (the UDS
+  sidecar, which always keeps running). Remote connections are added after it.
+- Adding a remote is manual **IP:port + token** entry with **trust-on-first-use**
+  (TOFU) self-signed-cert confirmation: the FE dials the remote once, shows the
+  presented certificate fingerprint, and only pins it once the user confirms.
+- Switching the active backend is a **clean full teardown + reload** that is
+  **multi-backend aware** for window/session state — the old daemon is fully
+  disconnected before the new one connects, and each backend restores its own
+  window layout.
+
+## Pieces
+
+### Transport (main)
+
+`features/backend/main/backend-connection.ts` resolves a `BackendConnectionConfig`
+(`uds` | `ws` | `tcp` | `wss`). The new work is the **pinned `wss` client**:
+
+- `captureFingerprint(...)` — the TOFU probe. Opens the remote's TLS WebSocket,
+  reads the presented cert's SHA-256 fingerprint (PROTOCOL §1.2 canonical
+  colon-hex uppercase, via `normalizeFingerprint`), and closes. Returns a
+  structured `{ ok: false, code }` on timeout / connect-failed / no-certificate.
+- The pinned `wss` transport compares the presented fingerprint against the
+  stored pin on **every** (re)connect. A mismatch throws `PinMismatchError`
+  (`{ expected, actual }`) rather than silently re-trusting a changed cert.
+
+### Connections store (main)
+
+`features/backend/main/connections-store.ts` persists remotes + the active
+selection to `backend-connections.json` under `app.getPath('userData')`
+(separate from `local-prefs.json`). Each remote's bearer token is encrypted at
+rest with Electron **`safeStorage`** when `isEncryptionAvailable()`, with an
+explicit **plaintext fallback** (`encrypted: false`) when it is not. The local
+sidecar is **not** a persisted record — a synthetic, non-forgettable
+"This machine (local)" entry (id `local`) is always synthesized as the first
+item of `list()`, and `activeId` defaults to `local`. Tokens never leave the
+main process on a returned record shape.
+
+### Switch orchestration + IPC (main)
+
+`features/backend/main/backend.ipc.ts` owns the `connections:*` IPC channels
+(`list`, `capture-fingerprint`, `add`, `forget`, `switch`; plus the main→renderer
+push events `connections:changed` and `connections:cert-mismatch`) and the
+`switchBackend(id)` orchestration:
+
+1. **Resolve + validate the target first** (`buildConfigForConnection`) — a bad
+   id or missing token throws _before_ any teardown, leaving the live backend
+   untouched.
+2. **Capture + close** the outgoing backend's windows while they are still live
+   (T4 hook `captureAndCloseWindowsForBackendSwitch`).
+3. **Dispose** the previous JSON-RPC client and all its subscriptions **before**
+   the new target connects — no leaked socket/timers/listeners.
+4. **Flip** the persisted active id and **build + start** the new client from
+   the pinned config (or the local/env default for a switch back to local).
+5. **Restore** the incoming backend's windows (T4 hook
+   `restoreWindowsForBackend`), then broadcast the changed list.
+
+`forget` of the _active_ remote falls back to a full switch to local rather than
+stranding the FE. At boot, `reconcileActiveConnectionOnBoot()` resets a stale
+persisted remote `activeId` to `local` (the live client is always built from the
+local default at startup, and a remote may be unreachable).
+
+**Stable forwarders (T8/T9).** Long-lived main-process services (terminal
+registry, script manager, notification/app-settings services, ACP terminal)
+attach their reconnect / notification / status listeners **exactly once** via
+`onBackendReconnected` / `onBackendNotification` / `onBackendStatus`. These
+attach to persistent `EventEmitter` forwarders that **outlive every client
+swap** — not to the live client instance — so a post-switch daemon event still
+drives terminal output/exit, script state, `agent:idle`, and `settings:changed`.
+Each freshly built client's events are piped into the forwarders, and
+`switchBackend` nudges the reconnect forwarder once so services resubscribe
+against the new target. Without this, a service's listener would strand on the
+disposed client and its events would be silently dropped for the rest of the
+session.
+
+### Backend-keyed window sessions (main)
+
+`main/window.ts` stores `window-sessions.json` as a **backend-keyed map**
+(`Record<backendId, WindowSession[]>`) instead of a single global array, so each
+backend restores its own window layout on switch. A legacy top-level array is
+lazily migrated into the `local` bucket. `saveWindowSessions(backendId)` /
+`loadWindowSessions(backendId)` default to `local`; the switch hooks
+(`captureAndCloseWindowsForBackendSwitch` / `restoreWindowsForBackend`) persist
+the outgoing bucket and restore the incoming one (or open a fresh window).
+
+### Renderer (store + UI)
+
+- `store/renderer/slices/connections/` — the connections slice, selectors, and
+  types (list + active selection + pairing/switch UI state).
+- `store/renderer/slices/connections/sagas/connections-saga.ts` — bridges the
+  slice to the `connections:*` IPC channels and folds `connections:changed` /
+  `connections:cert-mismatch` push events back into the store.
+- `store/renderer/seeders/connections-bridge-seeder.ts` — seeds the initial list.
+- `lib/components/layout/ConnectBackendModal.svelte` — the add-remote /
+  TOFU-confirm flow. `CertMismatchModal.svelte` — the blocking failure modal
+  raised on `connections:cert-mismatch`. Both hang off
+  `DaemonStatusIndicator.svelte`.
+
+## Tests
+
+- `features/backend/main/__tests__/multi-backend-connect.integration.test.ts` —
+  the end-to-end journey (add → confirm → switch → back → mismatch → failure
+  modal) through the real store, plus the T9 notification-survival guard.
+- `backend-ipc-connections.test.ts`, `backend-ipc-switch-robustness.test.ts` —
+  switch teardown ordering, boot reconciliation, and the stable forwarders.
+- `connections-store.test.ts` — encrypted/plaintext token round-trips.
+- `main/__tests__/window-sessions-multibackend.test.ts` — backend-keyed window
+  save/restore + switch hooks.

--- a/docs/fe/PANEL_TAB_UX_SPEC.md
+++ b/docs/fe/PANEL_TAB_UX_SPEC.md
@@ -1,0 +1,410 @@
+# Panel & Tab System UX Specification
+
+A comprehensive guide to implementing a powerful, intuitive panel and tab management system.
+
+---
+
+## Core Concepts
+
+### Layout Model
+- **Panels**: Containers that hold one or more tabs
+- **Tabs**: Individual content views within a panel
+- **Splits**: Hierarchical divisions (horizontal/vertical) between panels
+- **Layout Tree**: Recursive structure where each node is either a panel or a split with children
+
+---
+
+## Tab Interactions
+
+### 1. Tab Selection
+| Action | Behavior |
+|--------|----------|
+| Click tab | Activate tab in current panel |
+| Middle-click tab | Close tab |
+| Cmd/Ctrl+click | Keep current tab, open in background (if applicable) |
+
+### 2. Tab Reordering (Within Panel)
+| Action | Behavior |
+|--------|----------|
+| Drag tab left/right | Reorder within tab bar |
+| Visual feedback | Drop indicator line between tabs |
+| Animation | Smooth slide of adjacent tabs |
+
+### 3. Tab Movement (Across Panels)
+| Action | Behavior |
+|--------|----------|
+| Drag tab to another panel's tab bar | Move tab to that panel |
+| Drag tab to panel center | Move tab to that panel (same as above) |
+| Drag tab to panel edge | Create new split, place tab in new panel |
+
+### 4. Tab Close Behaviors
+| Action | Behavior |
+|--------|----------|
+| Close button / Middle-click | Close single tab |
+| Close tab with unsaved changes | Prompt to save/discard |
+| Close last tab in panel | Close panel |
+| Right-click → "Close Others" | Close all tabs except this one |
+| Right-click → "Close to the Right" | Close all tabs to the right |
+| Right-click → "Close All" | Close all tabs in panel |
+
+---
+
+## Panel Splitting
+
+### 5. Split Creation Methods
+
+#### Via Drag-to-Edge
+When dragging a tab near a panel edge, show the relevant drop zone:
+
+```
+┌─────────────────────────────┐
+│           TOP               │  ← Drop here: vertical split, new panel above
+├──────┬─────────────┬────────┤
+│      │             │        │
+│ LEFT │   CENTER    │ RIGHT  │  ← Left/Right: horizontal split
+│      │             │        │
+├──────┴─────────────┴────────┤
+│          BOTTOM             │  ← Drop here: vertical split, new panel below
+└─────────────────────────────┘
+```
+
+- **Edge zones**: ~20% of panel width/height from each edge. left/right drop zones override top/bottom zones
+- **Center zone**: Move tab to this panel (no split)
+- **Visual feedback**: Highlight the target zone with overlay. animate the overlay between states.
+
+#### Via Panel Menu
+- "Split Right" → Horizontal split, empty panel on right
+- "Split Down" → Vertical split, empty panel below
+- "Duplicate Tab in Split" → Split + clone current tab
+
+#### Via Keyboard
+See [Keyboard Shortcuts Reference](#keyboard-shortcuts-reference) below.
+
+---
+
+## Panel Resizing
+
+### 6. Resize Handle Behavior
+| Interaction | Behavior |
+|-------------|----------|
+| Drag handle | Resize adjacent panels proportionally |
+| Double-click handle | Reset to 50/50 split |
+| Drag while holding Shift | Snap to increments (25%, 33%, 50%, etc.) |
+| Minimum size | Panels cannot shrink below ~100px |
+| Collapse threshold | If panel shrinks below minimum, offer to close it |
+
+### 7. Resize Visual Feedback
+- Handle highlights on hover
+- During drag: show size overlay (e.g., "35% / 65%")
+- Cursor changes to `col-resize` or `row-resize`
+
+---
+
+## Panel Navigation
+
+### 8. Focus Management
+See [Keyboard Shortcuts Reference](#keyboard-shortcuts-reference) below for navigation shortcuts.
+
+### 9. Visual Focus Indicators
+- Focused panel: subtle border highlight or header emphasis
+- Unfocused panels: slightly dimmed or neutral styling
+- Active tab within focused panel: clear visual distinction
+
+---
+
+## Advanced Features
+
+### 11. Panel Maximization
+| Action | Behavior |
+|--------|----------|
+| Double-click panel header | Toggle maximize (shrink other panels to minimum size) |
+| `Cmd+Shift+M` | Maximize/restore focused panel |
+| Click outside maximized panel | Restore all panels |
+
+### 13. Layout Presets & Memory
+- Save current layout as a preset ("Code Review", "Writing", "Debugging")
+- Quick switch between presets via menu or keyboard
+- Remember last layout per workspace
+- Reset to default layout option
+- Have some hard-coded presets like "Initial", "Code Review", "Debugging" that are auto-saved and can be switched between quickly.
+- add a top bar above the panels that also has a prompt box that sends a message asking an agent for a layout recommendation. The agent will look at the current context and suggest a layout. We can use it like we use an agent for code review or generating a commit message. We should tell it the syntax to use, tell it to end its response with <layout> tag, and we should parse its response to get the layout. TFigure out hte idea ui & ux.
+
+---
+
+## Drag & Drop Affordances
+
+### 15. Drag States & Feedback
+
+| State | Visual |
+|-------|--------|
+| Drag start | Tab becomes semi-transparent, cursor shows drag icon |
+| Over tab bar | Gap opens between tabs at drop position |
+| Over drop zone | Zone highlights, preview of resulting split |
+| Invalid drop | Cursor shows "no drop" indicator |
+| Drag end (success) | Smooth animation to final position |
+| Drag end (cancel) | Tab animates back to original position |
+
+### 16. External Drag Sources
+- Drag file from sidebar → Creates file tab in target panel
+- Drag note from sidebar → Creates note tab in target panel
+- Drag agent from sidebar → Opens agent in target panel
+- Drag from OS file explorer → Opens file (if applicable)
+
+---
+
+## Edge Cases & Behaviors
+
+### 17. Empty Panels
+| Scenario | Behavior |
+|----------|----------|
+| Close last tab | Close panel |
+| Drag to empty panel | Tab becomes only tab in panel |
+
+### 18. Single Panel Mode
+- When only one panel exists, hide split handles
+- Dragging tab to edges still creates new splits
+- Maximized panel hides all chrome
+
+### 19. Deep Nesting Protection
+- Limit split nesting depth (e.g., max 4-5 levels)
+- When limit reached, move to nearest valid location
+- Warn user if layout becomes too complex
+
+### 20. Layout Persistence
+- Auto-save layout on every change (debounced)
+- Store tab content identifiers, not content itself
+- Handle missing content gracefully (show "Tab content not found")
+- Migrate layout versions across app updates
+
+---
+
+## Accessibility
+
+### 21. Keyboard Navigation
+See [Keyboard Shortcuts Reference](#keyboard-shortcuts-reference) for complete bindings.
+
+Basic accessibility navigation:
+| Key | Action |
+|-----|--------|
+| `Tab` | Move focus between major regions |
+| `Arrow keys` | Navigate within focused region |
+| `Enter` | Activate focused element |
+| `Escape` | Cancel current operation |
+| `F6` | Cycle through panel regions |
+
+### 22. Screen Reader Support
+- Panels: `role="region"` with `aria-label`
+- Tabs: `role="tablist"` / `role="tab"` with proper labels
+- Announce: "Panel 1 of 3", "Tab 2 of 5, active"
+- Resize handles: `role="separator"` with `aria-orientation`
+
+### 23. Reduced Motion
+- Respect `prefers-reduced-motion`
+- Skip animations, use instant transitions
+- Keep visual feedback for drop zones (no animation needed)
+
+---
+
+## Implementation Priority
+
+Current implementation note: `PanelTabBar.svelte` already supports inline rename on double-click in addition to the completed checklist items below.
+
+### Phase 1: Foundation
+1. ✅ Basic tab bar with click-to-activate
+2. ✅ Panel split/resize with handles
+3. ✅ Tab reordering within panel (drag)
+4. ✅ Tab close button + middle-click
+
+### Phase 2: Cross-Panel
+5. ✅ Drag tab to another panel's tab bar
+6. ⬜ Drag tab to panel edge → create split
+7. ✅ Drop zone visualization
+8. ✅ Panel focus management + keyboard nav (implemented in `src/features/layout/panel-keyboard-shortcuts.svelte.ts`; panel swap is still a TODO in code)
+
+### Phase 3: Polish
+9. ✅ Panel maximize/restore
+10. ✅ Tab context menu (Close Others, etc.)
+11. ⬜ Layout presets
+12. ⬜ Accessibility audit + screen reader testing
+
+### Phase 4: Advanced
+13. ⬜ Tab groups / multi-select
+14. ⬜ Panel pinning
+15. ⬜ External drag sources
+16. ⬜ Touch/mobile support
+
+---
+
+## Keyboard Shortcuts Reference
+
+Designed to feel familiar to developers who use tmux, vim, VS Code, and terminal emulators.
+
+### Design Principles
+1. **Prefix-based for power users** — Like tmux's `Ctrl+B` prefix, we use `Cmd+;` as a leader key for panel operations (tmux-style; avoids conflict with the `Cmd+K` command palette)
+2. **Vim-style directional** — `h/j/k/l` for navigation when in panel mode
+3. **VS Code compatibility** — Common shortcuts like `Cmd+\` and `Cmd+W` work as expected
+4. **Discoverability** — Single-key shortcuts after prefix, shown in command palette
+
+### Leader Key: `Cmd+;` (Mac) / `Ctrl+;` (Windows/Linux)
+Like tmux's `Ctrl+B`, entering the leader key activates "panel mode" for the next keypress.
+
+> **Note:** [KEYBINDINGS.md](./KEYBINDINGS.md) is the authoritative reference for what is actually bound today; the tables below are the design spec.
+
+---
+
+### Panel Navigation
+
+| Shortcut | Action | Inspired By |
+|----------|--------|-------------|
+| `Cmd+; h` | Focus panel to the left | vim `Ctrl+W h` |
+| `Cmd+; j` | Focus panel below | vim `Ctrl+W j` |
+| `Cmd+; k` | Focus panel above | vim `Ctrl+W k` |
+| `Cmd+; l` | Focus panel to the right | vim `Ctrl+W l` |
+| `Cmd+; Cmd+;` | Toggle between last two focused panels | tmux `Ctrl+B ;` |
+| `Cmd+; o` | Cycle to next panel | tmux `Ctrl+B o` |
+| `Cmd+; 1-9` | Focus panel by index | tmux `Ctrl+B 0-9` |
+| `Cmd+Option+←/→` | Focus prev/next panel (quick) | VS Code |
+
+### Panel Splitting
+
+| Shortcut | Action | Inspired By |
+|----------|--------|-------------|
+| `Cmd+\` | Split right (horizontal) | VS Code |
+| `Cmd+; Cmd+\` | Split down (vertical) | VS Code |
+| `Cmd+; %` | Split right | tmux `Ctrl+B %` |
+| `Cmd+; "` | Split down | tmux `Ctrl+B "` |
+| `Cmd+; !` | Move current tab to new panel | tmux `Ctrl+B !` (pane→window) |
+
+### Panel Resizing
+
+| Shortcut | Action | Inspired By |
+|----------|--------|-------------|
+| `Cmd+; H` | Resize panel left (shrink right edge) | vim `Ctrl+W <` |
+| `Cmd+; J` | Resize panel down (grow bottom edge) | vim `Ctrl+W +` |
+| `Cmd+; K` | Resize panel up (shrink bottom edge) | vim `Ctrl+W -` |
+| `Cmd+; L` | Resize panel right (grow right edge) | vim `Ctrl+W >` |
+| `Cmd+; =` | Equalize all panel sizes | vim `Ctrl+W =` |
+| `Cmd+; _` | Maximize panel height | vim `Ctrl+W _` |
+| `Cmd+; \|` | Maximize panel width | vim `Ctrl+W \|` |
+
+### Panel Zoom/Maximize
+
+| Shortcut | Action | Inspired By |
+|----------|--------|-------------|
+| `Cmd+; z` | Toggle zoom (maximize/restore) | tmux `Ctrl+B z` |
+| `Cmd+Shift+M` | Toggle maximize focused panel | VS Code |
+| `Escape` | Exit zoom mode | — |
+
+### Panel Management
+
+| Shortcut | Action | Inspired By |
+|----------|--------|-------------|
+| `Cmd+; x` | Close current panel | tmux `Ctrl+B x` |
+| `Cmd+; {` | Swap panel with previous (TODO in code) | tmux `Ctrl+B {` |
+| `Cmd+; }` | Swap panel with next (TODO in code) | tmux `Ctrl+B }` |
+| `Cmd+; Space` | Cycle through layout presets | tmux `Ctrl+B Space` |
+| `Cmd+; q` | Show panel numbers (press 1-9 to jump) | tmux `Ctrl+B q` |
+
+---
+
+### Tab Navigation
+
+| Shortcut | Action | Inspired By |
+|----------|--------|-------------|
+| `Cmd+Shift+]` | Next tab in panel | VS Code / Chrome |
+| `Cmd+Shift+[` | Previous tab in panel | VS Code / Chrome |
+| `Cmd+Option+→` | Next tab | Chrome |
+| `Cmd+Option+←` | Previous tab | Chrome |
+| `Ctrl+Tab` | Next tab (cycle) | Browser standard |
+| `Ctrl+Shift+Tab` | Previous tab (cycle) | Browser standard |
+| `Cmd+1-9` | Jump to tab by index | Chrome / VS Code |
+
+### Tab Management
+
+| Shortcut | Action | Inspired By |
+|----------|--------|-------------|
+| `Cmd+W` | Close current tab | Universal |
+| `Cmd+Shift+W` | Close all tabs in panel | — |
+| `Cmd+Shift+T` | Reopen last closed tab | Chrome |
+| `Cmd+; Cmd+W` | Close all other tabs | VS Code |
+| `Cmd+; w` | Close tabs to the right | VS Code |
+
+### Tab Movement
+
+| Shortcut | Action | Inspired By |
+|----------|--------|-------------|
+| `Cmd+; m` | Move tab to next panel | — |
+| `Cmd+; Shift+M` | Move tab to previous panel | — |
+| `Cmd+; ←/→` | Move tab left/right within panel | — |
+| `Cmd+; Shift+←` | Move tab to panel on left | — |
+| `Cmd+; Shift+→` | Move tab to panel on right | — |
+
+---
+
+### Quick Reference Card
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  PANEL SYSTEM SHORTCUTS (Leader: Cmd+;)                         │
+├─────────────────────────────────────────────────────────────────┤
+│  NAVIGATE          SPLIT             RESIZE          TABS       │
+│  ─────────         ─────             ──────          ────       │
+│  h/j/k/l  focus    Cmd+\   right     H/J/K/L  edges  Cmd+1-9    │
+│  o        cycle    Cmd+; \ down      =        equal  Cmd+Shift+]│
+│  1-9      index    %       right     z        zoom   Cmd+W close│
+│  Cmd+;    last     "       down      _/|      max    Cmd+Shift+T│
+│                                                       reopen    │
+├─────────────────────────────────────────────────────────────────┤
+│  x  close panel    {/}  swap    Space  cycle layouts    q  show#│
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+### Comparison with Familiar Tools
+
+| Operation | tmux | vim | VS Code | Our App |
+|-----------|------|-----|---------|---------|
+| **Prefix/Leader** | `Ctrl+B` | `Ctrl+W` | — | `Cmd+;` |
+| **Split horizontal** | `Ctrl+B %` | `:vsplit` | `Cmd+\` | `Cmd+\` or `Cmd+; %` |
+| **Split vertical** | `Ctrl+B "` | `:split` | `Cmd+K Cmd+\` | `Cmd+; "` |
+| **Navigate left** | `Ctrl+B ←` | `Ctrl+W h` | `Cmd+K ←` | `Cmd+; h` |
+| **Navigate right** | `Ctrl+B →` | `Ctrl+W l` | `Cmd+K →` | `Cmd+; l` |
+| **Navigate up** | `Ctrl+B ↑` | `Ctrl+W k` | `Cmd+K ↑` | `Cmd+; k` |
+| **Navigate down** | `Ctrl+B ↓` | `Ctrl+W j` | `Cmd+K ↓` | `Cmd+; j` |
+| **Zoom/maximize** | `Ctrl+B z` | — | — | `Cmd+; z` |
+| **Close pane** | `Ctrl+B x` | `:q` | — | `Cmd+; x` |
+| **Next pane** | `Ctrl+B o` | `Ctrl+W w` | — | `Cmd+; o` |
+| **Last pane** | `Ctrl+B ;` | `Ctrl+W p` | — | `Cmd+; Cmd+;` |
+| **Equalize sizes** | — | `Ctrl+W =` | — | `Cmd+; =` |
+| **Close tab** | — | `:bd` | `Cmd+W` | `Cmd+W` |
+| **Next tab** | `Ctrl+B n` | `:bn` | `Cmd+Shift+]` | `Cmd+Shift+]` |
+| **Prev tab** | `Ctrl+B p` | `:bp` | `Cmd+Shift+[` | `Cmd+Shift+[` |
+
+---
+
+### iTerm2-Style Shortcuts (Alternative Bindings)
+
+For users who prefer iTerm2's approach:
+
+| Shortcut | Action |
+|----------|--------|
+| `Cmd+D` | Split right |
+| `Cmd+Shift+D` | Split down |
+| `Cmd+]` | Next panel |
+| `Cmd+[` | Previous panel |
+| `Cmd+Option+Arrow` | Navigate to panel in direction |
+| `Cmd+Shift+Enter` | Maximize/restore panel |
+
+---
+
+## Reference Implementations
+
+Study these for inspiration:
+- **tmux**: Prefix-based workflow, session/window/pane hierarchy, zoom with `Ctrl+B z`
+- **vim**: `Ctrl+W` prefix for window commands, `h/j/k/l` navigation, powerful splits
+- **VS Code**: `Cmd+K` chord system, excellent discoverability, smooth animations
+- **iTerm2**: `Cmd+D` splits, `Cmd+]`/`[` navigation, simple and memorable
+- **Figma**: Excellent drag feedback and split creation
+- **JetBrains IDEs**: "Goto Next Splitter" action, configurable keymaps
+- **Arc Browser**: Creative tab organization (spaces, pinning, split view)

--- a/docs/fe/PR_DESCRIPTION_GUIDE.md
+++ b/docs/fe/PR_DESCRIPTION_GUIDE.md
@@ -1,0 +1,88 @@
+# PR Description Guide
+
+## 1. Purpose
+
+PR descriptions are the primary artifact for reviewers to understand scope, risk, and verification.
+
+## 2. Required Sections
+
+All sections below are required unless noted as optional.
+
+### Summary
+
+Write one paragraph explaining what the PR does and why it exists. Include the diff stats line in this section: `**N files changed, +X / −Y**`.
+
+### Results (optional)
+
+Use a before/after metrics table when the PR has measurable impact, such as line counts, IPC call counts, render counts, or bundle size changes. Omit this section when there is no meaningful metric to report.
+
+### What Changed
+
+List all changes grouped by category: new files, modified files, deleted files, renamed files, new slices, new modules, new components, migrations, and docs updates. Be specific: name every new module, slice, component, utility, or handler and give each a one-line description.
+
+### Architecture
+
+Explain how the changes fit into the existing architecture, ownership boundaries, and data flow. Link to relevant docs in `docs/` when they help reviewers understand the design.
+
+### Testing
+
+List exactly what you verified and how: typechecks, unit tests, builds, manual scenarios, and any targeted commands. Use exact command names and note manual validation steps when applicable.
+
+### What's NOT Changed
+
+Call out what is intentionally out of scope. This sets reviewer expectations and prevents assumptions about adjacent systems.
+
+## 3. Risk Analysis Rule
+
+**Every PR description MUST include a risk analysis section.** This section identifies features and code paths that could break due to the changes, organized by risk level.
+
+```markdown
+## Risk Analysis
+
+### 🔴 P0 — Critical (core user flows affected)
+- **Feature name** — what changed and why it's risky
+  - [ ] Test: specific manual test step
+
+### 🟠 P1 — High (important flows affected)
+- ...
+
+### 🟡 P2 — Medium (secondary flows affected)
+- ...
+
+### 🟢 P3 — Low (minor/cosmetic changes)
+- ...
+```
+
+End each risk analysis with a summary table:
+
+| Risk Level | Areas | Items |
+| --- | --- | --- |
+| P0 | Core flows | N |
+| ... | ... | ... |
+
+Rules for risk analysis:
+
+- Every modified component, IPC handler, or state migration must be mapped to a user-facing feature.
+- Each risk item must have at least one concrete test step, manual or automated.
+- P0 items must be tested before the PR is marked ready for review.
+- Include a summary table at the bottom: `| Risk Level | Areas | Items |`.
+- If a PR touches more than 20 files, full risk analysis is mandatory.
+- If a PR touches fewer than 20 files, a simplified version that lists affected features is acceptable.
+
+Place the risk analysis in the PR description body. For very large PRs (50+ files) where the risk analysis exceeds ~100 lines, post it as a separate pinned PR comment instead and add a link from the description: `See [Risk Analysis](#issuecomment-XXXX)`.
+
+## 4. Style Rules
+
+- Use exact numbers, not approximations; run `git diff --stat` to get real counts.
+- List every new file, module, slice, component, and utility by name.
+- Use tables for before/after comparisons.
+- Keep bullet points to one line each.
+- Use code formatting for file paths, function names, and commands.
+
+## 5. Anti-patterns
+
+- ❌ `Various improvements and fixes` — be specific.
+- ❌ Approximate numbers like `~200 files` — use exact counts.
+- ❌ Missing `What's NOT Changed` — reviewers need scope boundaries.
+- ❌ No risk analysis on large PRs — always assess what could break.
+- ❌ `All tests pass` without listing commands — specify the exact verification steps.

--- a/docs/fe/RELEASING.md
+++ b/docs/fe/RELEASING.md
@@ -203,16 +203,33 @@ If the automated **Release Stable** workflow fails and cannot be fixed by re-run
 
 2. **Replace assets on the rolling stable release**
 
-   ```bash
-   # Delete old assets from stable
-   gh release view stable --repo intent-hq/cloudlands-releases --json assets --jq '.assets[].name' | \
-     xargs -I {} gh release delete-asset stable {} --repo intent-hq/cloudlands-releases --yes
+   Upload first (with `--clobber`), feed files last, so the current stable
+   assets keep serving until each one is overwritten in place — never delete
+   the old assets before their replacements are up.
 
-   # Upload new assets to stable (all feed files last for atomic switch)
-   gh release upload stable --repo intent-hq/cloudlands-releases --clobber \
-     *.dmg *.zip *.exe *.AppImage *.deb *.blockmap release-manifest.json
-   gh release upload stable --repo intent-hq/cloudlands-releases --clobber \
-     latest-mac.yml latest.yml latest-linux.yml latest-linux-arm64.yml
+   ```bash
+   cd /tmp/release-assets
+
+   # Upload binaries/manifests first (everything except the feed files)
+   for f in *; do
+     case "$f" in
+       latest*.yml) ;;  # feeds go last
+       *) gh release upload stable "$f" --repo intent-hq/cloudlands-releases --clobber ;;
+     esac
+   done
+
+   # Upload feed files last for the atomic switch (loop tolerates
+   # older releases that don't have all four platforms)
+   for f in latest-mac.yml latest.yml latest-linux.yml latest-linux-arm64.yml; do
+     [ -e "$f" ] && gh release upload stable "$f" --repo intent-hq/cloudlands-releases --clobber
+   done
+
+   # Finally, remove any stale assets left over from the previous stable
+   # that are not part of the new release
+   gh release view stable --repo intent-hq/cloudlands-releases --json assets --jq '.assets[].name' | \
+     while read -r name; do
+       [ -e "$name" ] || gh release delete-asset stable "$name" --repo intent-hq/cloudlands-releases --yes
+     done
    ```
 
 3. **Verify sha512 hash**

--- a/docs/fe/RELEASING.md
+++ b/docs/fe/RELEASING.md
@@ -1,0 +1,248 @@
+# Release Process
+
+This document describes the end-to-end release process for Intent (cloudlands-fe).
+
+## Overview
+
+Releases are built and published by the **Release Beta** workflow in GitHub Actions. The `intentd` sidecar is **not built from source** — it is downloaded from the pinned `intent-hq/intentd` GitHub Release recorded in the `intentd.version` file (intentd releases on its own cycle). The workflow:
+
+1. Reads the pinned intentd version from `intentd.version` and fetches the matching release asset via `scripts/fetch-sidecar.cjs` (sha256-verified, staged at `resources/sidecar/intentd`); it fails fast if the pinned release or its assets don't exist
+2. Builds the app for all four platforms in parallel jobs — macOS (arm64), Windows (x64), Linux (x64), Linux (arm64) — each with its staged `intentd` sidecar
+3. Signs and notarizes the macOS app using Apple Developer ID certificates (Windows and Linux artifacts are unsigned)
+4. Generates release notes from the `cloudlands-fe` commit range; the intentd section lists the intentd commit delta between the previous release's pin (recovered from the previous release's `release-manifest.json` asset) and the current pin — falling back to a pin-only link when the previous pin can't be recovered, or to the pin line + compare link without a commit list when the intentd compare API is unavailable
+5. Publishes artifacts to `intent-hq/cloudlands-releases` on GitHub, including:
+   - macOS DMG installer + ZIP archive (+ blockmaps), Windows NSIS + portable `.exe` (+ blockmap), Linux AppImage/`.deb`
+   - Four auto-updater feed files: `latest-mac.yml`, `latest.yml`, `latest-linux.yml`, `latest-linux-arm64.yml`
+   - `release-manifest.json` — metadata capturing the fe tag/SHA and the pinned `intentdVersion`
+
+The workflow is triggered by a `v*.*.*` tag push (created by release-please when its Release PR is merged) — it does not bump versions, create tags, or open version-bump PRs itself.
+
+No tags are pushed to `intent-hq/intentd`. To ship a newer intentd, update the `intentd.version` pin on `main` via a normal PR before cutting the release.
+
+## Prerequisites
+
+### Required Secrets
+
+The following secrets must be configured in the `intent-hq/cloudlands-fe` repository settings. For the canonical secret inventory and setup details, see [DEPLOYING.md § Required GitHub Secrets](./DEPLOYING.md#required-github-secrets). Quick reference:
+
+- **`CLOUDLANDS_MACOS_CERTIFICATE`** - Base64-encoded .p12 Developer ID Application certificate
+- **`CLOUDLANDS_MACOS_CERTIFICATE_PWD`** - Password for the .p12 certificate
+- **`CLOUDLANDS_KEYCHAIN_PASSWORD`** - Temporary keychain password for the build runner
+- **`CLOUDLANDS_APPLE_ID`** - Apple ID email for notarization
+- **`CLOUDLANDS_APPLE_APP_SPECIFIC_PASSWORD`** - App-specific password for notarization
+- **`CLOUDLANDS_APPLE_TEAM_ID`** - Apple Developer Team ID (e.g., `6947A73B2N`)
+- **`RELEASE_PAT`** - Personal Access Token (classic or fine-grained) with:
+  - Classic: `repo` scope on `intent-hq/cloudlands-fe` and `intent-hq/cloudlands-releases`
+  - Fine-grained: `Contents: Read and write`, with repository access to `cloudlands-fe` (tag checkout) and `cloudlands-releases` (publishing)
+- **`INTENTD_READ_PAT`** - Personal Access Token used by `scripts/fetch-sidecar.cjs` to download the pinned intentd release assets while the repo is private:
+  - Fine-grained (preferred): `Contents: Read-only` with repository access to `intent-hq/intentd`
+  - Classic: `repo` scope (classic scopes are write-capable; only read access is exercised — prefer fine-grained)
+
+**Important:** If `INTENTD_READ_PAT` is invalid or expired, the workflow fails at the "Fetch pinned intentd sidecar" step — either with "Release v{X.Y.Z} not found" (GitHub returns 404 for private repos the token cannot read) or with "GitHub API error fetching release … HTTP 401/403" for bad credentials.
+
+## Cutting a Beta Release
+
+1. **Merge the release-please Release PR**
+
+   The **Release Beta** workflow triggers automatically when a `v*.*.*` tag is pushed. Tags are created by release-please when its Release PR (which bumps `package.json` and updates the changelog) is merged — releasing is a matter of merging that PR, not typing a version.
+
+   The workflow validates the tag format, verifies the tag matches the `package.json` version at the tagged commit, and fails if a `v{version}` release already exists on `intent-hq/cloudlands-releases`.
+
+   To rebuild an **existing** tag (e.g., after a transient build failure), use the `workflow_dispatch` fallback: go to [Actions > Release Beta](https://github.com/intent-hq/cloudlands-fe/actions/workflows/release-beta.yml), click "Run workflow", and enter the existing tag (e.g., `v2.1.0`). Note the duplicate-release guard: delete the failed `v{version}` release on `cloudlands-releases` first if it was partially published.
+
+   The bundled intentd version comes from the `intentd.version` pin at the tagged commit — there are no intentd-related workflow inputs. Make sure the pinned release exists on `intent-hq/intentd` (with assets for the build targets) before releasing, or the workflow will fail fast at the fetch step.
+
+2. **Wait for the build**
+
+   The workflow takes approximately 15-20 minutes. Monitor progress at:
+   ```
+   https://github.com/intent-hq/cloudlands-fe/actions
+   ```
+
+3. **Verify the versioned release**
+
+   Once the workflow completes successfully:
+
+   ```bash
+   VERSION="<version>"
+
+   # View the release
+   gh release view "v${VERSION}" --repo intent-hq/cloudlands-releases
+
+   # Check assets (should include the macOS DMG/ZIP + blockmaps, Windows .exe installers + blockmap,
+   # Linux AppImage/.deb, the four feed files — latest-mac.yml, latest.yml, latest-linux.yml,
+   # latest-linux-arm64.yml — and release-manifest.json)
+   gh release view "v${VERSION}" --repo intent-hq/cloudlands-releases --json assets --jq '.assets[].name'
+
+   # Verify the version in each feed file (latest-mac.yml shown; repeat for
+   # latest.yml, latest-linux.yml, latest-linux-arm64.yml)
+   curl -sL "https://github.com/intent-hq/cloudlands-releases/releases/download/v${VERSION}/latest-mac.yml" | grep version
+
+   # Inspect the release manifest (captures fe tag/SHA and the pinned intentdVersion)
+   curl -sL "https://github.com/intent-hq/cloudlands-releases/releases/download/v${VERSION}/release-manifest.json" | jq .
+   ```
+
+4. **Verify the rolling beta channel**
+   
+   The workflow also updates the rolling `beta` release tag:
+   
+   ```bash
+   # Check the beta feeds (latest-mac.yml shown; repeat for latest.yml,
+   # latest-linux.yml, latest-linux-arm64.yml)
+   curl -sL https://github.com/intent-hq/cloudlands-releases/releases/download/beta/latest-mac.yml | grep version
+   ```
+
+## Promoting to Stable
+
+After verifying a beta release, promote it to the stable channel using the **Release Stable** workflow:
+
+1. **Trigger the workflow**
+
+   Go to [Actions > Release Stable](https://github.com/intent-hq/cloudlands-fe/actions/workflows/release-stable.yml) and click "Run workflow".
+
+   Enter the version number to promote (e.g., `2.0.7`). The version must:
+   - Exist as a published versioned release (`v{VERSION}`) on `intent-hq/cloudlands-releases`
+   - Use stable semver format (`X.Y.Z` only — no prerelease or build suffixes)
+   - Be greater than the current stable version (or be the first promotion)
+
+2. **What the workflow does**
+
+   The workflow automatically:
+   - Downloads all assets from the versioned release `v{VERSION}`
+   - Uploads new assets to the rolling `stable` release tag with `--clobber` (versioned assets first, then `latest-mac.yml` last for atomic feed switch)
+   - Deletes old versioned assets from the previous stable promotion (only after new assets are uploaded and live)
+   - Verifies the `sha512` hash in `latest-mac.yml` matches the versioned release (with retries for CDN propagation)
+   - Generates a leading summary section (`scripts/generate-stable-summary.mjs`): promoted version, previous stable, and a consolidated intentd delta spanning the previous stable's pin → the promoted version's pin (pins recovered from each release's `release-manifest.json`, commit list from the intentd compare API via `INTENTD_READ_PAT`)
+   - Aggregates release notes from all versions in the range `(prevStable, VERSION]`, prefixed by the summary section
+   - Updates the stable release body with the aggregated notes
+
+   The summary section is **fail-soft**: missing manifests or pins degrade it to pin line(s), a failed compare fetch falls back to the pin line + compare link, and any summary failure just drops the section — a notes problem never blocks a promotion.
+
+   The workflow is **idempotent** — re-running with the same version is safe and updates assets/notes to match.
+
+3. **Verify the stable feed**
+
+   ```bash
+   VERSION="<version>"
+
+   # Check version (latest-mac.yml shown; repeat for latest.yml,
+   # latest-linux.yml, latest-linux-arm64.yml)
+   curl -sL https://github.com/intent-hq/cloudlands-releases/releases/download/stable/latest-mac.yml | grep version
+
+   # Verify the ZIP sha512 matches the versioned release
+   VERSIONED_SHA=$(curl -sL "https://github.com/intent-hq/cloudlands-releases/releases/download/v${VERSION}/latest-mac.yml" | awk '/^sha512:/{print $2; exit}')
+   STABLE_SHA=$(curl -sL "https://github.com/intent-hq/cloudlands-releases/releases/download/stable/latest-mac.yml" | awk '/^sha512:/{print $2; exit}')
+
+   if [ "$VERSIONED_SHA" = "$STABLE_SHA" ]; then
+     echo "✓ Stable feed matches versioned release"
+   else
+     echo "✗ Mismatch detected"
+   fi
+
+   # View aggregated release notes
+   gh release view stable --repo intent-hq/cloudlands-releases
+   ```
+
+## Troubleshooting
+
+### Pinned intentd Release Fetch Fails
+
+**Symptom:** "Fetch pinned intentd sidecar" step fails with one of:
+- "Release v{X.Y.Z} not found in intent-hq/intentd" — the pinned release doesn't exist, **or** the token cannot read the private repo (GitHub returns 404 in both cases)
+- "GitHub API error fetching release … HTTP 401/403" — invalid or expired credentials
+- A missing-asset / missing-checksum error — the release exists but lacks the per-target binary or sha256 assets
+
+**Fix:** For a genuinely missing release or assets, publish the pinned intentd release (with per-target binary + sha256 assets), or update the `intentd.version` pin to an existing release via a PR to main. For token issues (401/403, or 404 on a release that does exist), regenerate a fine-grained Personal Access Token with `Contents: Read-only` on `intent-hq/intentd` and update the `INTENTD_READ_PAT` secret in repository settings.
+
+### RELEASE_PAT Permissions
+
+**Symptom:** The "Checkout release tag" or a publish step fails with a permissions error (e.g., "Publish to GitHub Releases").
+
+**Fix:** The `RELEASE_PAT` is missing required permissions:
+- For the cloudlands-fe tag checkout: `Contents: Read` (fine-grained) or `repo` scope (classic) on `intent-hq/cloudlands-fe`
+- For cloudlands-releases publishing: `Contents: Read and write` (fine-grained) or `repo` scope (classic) on `intent-hq/cloudlands-releases`
+
+Update the token's permissions in GitHub settings.
+
+### Build Fails During Notarization
+
+**Symptom:** "Error: Notarization failed" in the build logs.
+
+**Fix:** Check that `CLOUDLANDS_APPLE_ID` and `CLOUDLANDS_APPLE_APP_SPECIFIC_PASSWORD` are correct. The app-specific password must be generated in your Apple ID account settings.
+
+### Duplicate Release
+
+**Symptom:** "Release v<version> already exists on intent-hq/cloudlands-releases" error.
+
+**Fix:** The tag was already built and published. To rebuild it (e.g., after a partial publish), delete the `v{version}` release on `intent-hq/cloudlands-releases` first, then re-run via the `workflow_dispatch` fallback with the existing tag.
+
+### Release Notes Generation Fails
+
+**Symptom:** Workflow fails with "No previous versioned release found on cloudlands-releases. Cannot generate release notes."
+
+**Fix:** The workflow could not find a previous `vX.Y.Z` release on `intent-hq/cloudlands-releases` to use as the base of the fe commit range. Verify that previous versioned releases exist and that `RELEASE_PAT` can read `intent-hq/cloudlands-releases`.
+
+### Stable Promotion SHA Mismatch
+
+**Symptom:** "sha512 mismatch after N retries" error in the stable promotion workflow.
+
+**Fix:** This typically indicates CDN propagation delay or incomplete asset upload. Wait a few minutes and re-run the workflow (it's idempotent). If the issue persists, verify the versioned release assets are intact and use the manual fallback procedure below.
+
+## Manual Fallback — Stable Promotion
+
+If the automated **Release Stable** workflow fails and cannot be fixed by re-running, you can promote manually:
+
+1. **Download the versioned release assets**
+
+   ```bash
+   VERSION="<version>"
+   mkdir -p /tmp/release-assets
+   cd /tmp/release-assets
+   gh release download "v${VERSION}" --repo intent-hq/cloudlands-releases
+   ```
+
+2. **Replace assets on the rolling stable release**
+
+   ```bash
+   # Delete old assets from stable
+   gh release view stable --repo intent-hq/cloudlands-releases --json assets --jq '.assets[].name' | \
+     xargs -I {} gh release delete-asset stable {} --repo intent-hq/cloudlands-releases --yes
+
+   # Upload new assets to stable (all feed files last for atomic switch)
+   gh release upload stable --repo intent-hq/cloudlands-releases --clobber \
+     *.dmg *.zip *.exe *.AppImage *.deb *.blockmap release-manifest.json
+   gh release upload stable --repo intent-hq/cloudlands-releases --clobber \
+     latest-mac.yml latest.yml latest-linux.yml latest-linux-arm64.yml
+   ```
+
+3. **Verify sha512 hash**
+
+   ```bash
+   VERSIONED_SHA=$(curl -sL "https://github.com/intent-hq/cloudlands-releases/releases/download/v${VERSION}/latest-mac.yml" | awk '/^sha512:/{print $2; exit}')
+   STABLE_SHA=$(curl -sL "https://github.com/intent-hq/cloudlands-releases/releases/download/stable/latest-mac.yml" | awk '/^sha512:/{print $2; exit}')
+
+   if [ "$VERSIONED_SHA" = "$STABLE_SHA" ]; then
+     echo "✓ Stable feed matches versioned release"
+   else
+     echo "✗ Mismatch detected — wait for CDN propagation or check assets"
+   fi
+   ```
+
+4. **Update stable release notes manually (optional)**
+
+   Download release notes from each version in the range and concatenate them, then:
+   ```bash
+   gh release edit stable --repo intent-hq/cloudlands-releases --notes-file aggregated-notes.md
+   ```
+
+## Channel Switching in the App
+
+Users can switch between beta and stable update channels in the app's Settings screen. The toggle writes to `local-prefs.json` and calls `autoUpdater.setFeedURL` to point to the appropriate rolling release tag (`beta` or `stable`).
+
+## Release History
+
+For the full release history and changelogs, see:
+
+- [cloudlands-releases repository](https://github.com/intent-hq/cloudlands-releases/releases)
+- the `release-manifest.json` asset on each versioned release (records the fe tag/SHA and the pinned `intentdVersion`)
+- [CHANGELOG.md](../../packages/cloudlands-fe/CHANGELOG.md) (points to GitHub Releases for 2.x)

--- a/docs/fe/RULES_SYSTEM.md
+++ b/docs/fe/RULES_SYSTEM.md
@@ -1,0 +1,175 @@
+# Rules System Architecture
+
+The rules system is assembled in the backend by `InstructionService` and sourced from TypeScript instruction modules, end-user overrides, workspace overrides, project rule files, and optional skills catalogs.
+
+## System Prompt Layers
+
+`buildSystemPrompt()` assembles **9 layers** in this order:
+
+| Order | Layer | Source | Notes |
+|------|-------|--------|-------|
+| 1 | Base system prompt | `base-system-prompt.ts` + end-user base override | Identity and tool guidance for interactive agents |
+| 2 | Specialization rules | `getSpecializationRules()` | `common` + `workspace` + specific instruction ID |
+| 3 | User rules | `CLAUDE.md`, `AGENTS.md`, `.augment/guidelines.md`, `.augment/rules/*.md` | Project conventions from the workspace |
+| 4 | Skills catalog | skills loaders | `.agents/skills`, `.augment/skills`, `~/.claude/skills` |
+| 5 | Behavior prompt | `behaviorPrompt` parameter | Specialist-specific behavior text |
+| 6 | Parent-only orchestration | team/knobs/specialists/branch preference helpers | Skipped for sub-agents |
+| 7 | Workspace context | `workspaceContext` parameter | Open panels + linked references; skipped for sub-agents |
+| 8 | Runtime context | `contextReferences` parameter | Per-launch dynamic context |
+| 9 | Mandatory footer | `getMandatoryActionsFooter()` | Keeps role reminder at the end for recency |
+
+Sub-agents skip the parent-only orchestration layers and workspace-context layer to keep delegated prompts lighter.
+
+## Prompt Builder Inputs
+
+### Public `buildSystemPrompt()` config fields
+
+- `agentType`
+- `workspacePath`
+- `contextReferences`
+- `behaviorPrompt`
+- `specialistName`
+- `roleReminder`
+- `workspaceContext`
+- `workspaceTitle`
+- `isInitialAgent`
+- `isSubAgent`
+
+### Internal controls that also affect the final prompt
+
+- `prefetchedSkillsCatalog` - internal prefetch/cache optimization used when hashing prompt cache keys
+
+## Specialization Resolution
+
+`getSpecializationRules()` uses a 3-tier fallback:
+
+1. **End-user overrides** from `EndUserRulesManager` (`electron-store`)
+2. **Workspace overrides** from `.augment/agent-rules/{agentType}.md`
+3. **Bundled TypeScript instructions** via `getInstructionWithCommon()`
+
+## What `getInstructionWithCommon()` Actually Returns
+
+| Instruction kind | Result |
+|------|--------|
+| `common` | `common` only |
+| `workspace` | `common + workspace` |
+| Regular interactive/task/workspace instruction | `common + workspace + specific` |
+| Non-interactive background instruction (`code-review`, `code-walkthrough`, `commit-message`, `pr-description`) | specific instruction only |
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `src/features/agent/main/instruction-service.ts` | Builds complete prompts, manages caches, and assembles prompt layers |
+| `src/features/agent/main/instructions/index.ts` | Source of truth for instruction IDs, aliases, and helper exports |
+| `src/features/agent/main/instructions/common.ts` | Shared instruction layer prepended to most agents |
+| `src/features/agent/main/instructions/workspace.ts` | Shared workspace-operating guidance |
+| `src/features/agent/main/instructions/base-system-prompt.ts` | Base system prompt content |
+| `src/features/agent/main/rules-loader.ts` | Loads project rule files from the workspace |
+| `src/features/rules/user-rules.service.ts` | Stores end-user rule overrides by type |
+
+## Exported Helpers from `instructions/index.ts`
+
+- `getInstructionById()`
+- `getInstructionWithCommon()`
+- `getAvailableInstructionIds()`
+- `getAgentTypesWithMetadata()`
+- `isUtilityAgent()`
+
+## Current Instruction IDs
+
+These are the IDs returned by `getAvailableInstructionIds()` or exported from `instructions/index.ts`.
+
+### Interactive and shared instructions
+
+| ID | Purpose |
+|----|---------|
+| `chat` | Conversational agent for Q&A and general discussion |
+| `common` | Shared instruction layer used during specialization assembly |
+| `debug` | General debugging and error investigation |
+| `workspace` | Shared workspace-operating guidance |
+| `setup-script-generator` | Generates worktree/setup scripts |
+| `task-breakdown` | Breaks large tasks into smaller steps |
+| `task-debug` | Debugging agent for task flows |
+| `task-focused` | Focused on one assigned task |
+| `task-loop` | Iterative task agent using a task note |
+| `ralph-loop` | Coordinator-style planning/delegation loop |
+| `workspace-agent` | Manages workspace operations via MCP |
+| `notes-system-guide` | Documentation-oriented instruction about the notes system |
+
+### Background instruction IDs
+
+| ID | Purpose |
+|----|---------|
+| `code-review` | Background review of code changes |
+| `code-walkthrough` | Background narrated walkthrough of staged changes |
+| `commit-message` | Background conventional commit generation |
+| `pr-description` | Background PR description generation |
+
+## Typed Agent IDs
+
+`src/shared/types/agent.types.ts` currently defines these runtime-validated `AgentTypeId` values:
+
+- `chat`
+- `code-walkthrough`
+- `common`
+- `debug`
+- `workspace`
+- `setup-script-generator`
+- `task-breakdown`
+- `task-debug`
+- `task-focused`
+- `task-loop`
+- `ralph-loop`
+- `workspace-agent`
+- `code-review`
+- `commit-message`
+- `pr-description`
+
+## Aliases
+
+`getInstructionById()` currently supports these aliases:
+
+- `fix` → `debug`
+- `review` → `code-review`
+- `walkthrough` → `code-walkthrough`
+
+## Workspace Rule Loading
+
+`loadUserRules()` checks project rule sources in this order:
+
+1. optional custom rules path
+2. `CLAUDE.md`
+3. `AGENTS.md`
+4. `.augment/guidelines.md`
+5. `.augment/rules/*.md` (sorted, concatenated, frontmatter-aware)
+
+Rule files in `.augment/rules/` may declare YAML frontmatter with `type: always_apply` or `type: agent_requested`.
+
+## Customizing Rules
+
+### User-level
+
+- `EndUserRulesManager` stores rules per type in `electron-store`
+- Rule types include `base-system-prompt` and instruction-specific IDs
+- Legacy imports using `system` are migrated internally
+
+### Workspace-level
+
+- Create `.augment/agent-rules/{agentType}.md` to override bundled specialization rules for a workspace
+
+### Project-level
+
+- Add `CLAUDE.md`, `AGENTS.md`, `.augment/guidelines.md`, or `.augment/rules/*.md`
+
+## Caching
+
+`InstructionService` maintains multiple caches:
+
+| Cache | TTL / Limit | Purpose |
+|-------|-------------|---------|
+| Specialization rules cache | 5 minutes, max 100 entries (LRU) | Caches resolved specialization content per agent type/workspace |
+| Full system prompt cache | 30 seconds, max 20 entries | Reuses fully assembled prompts for repeated launches |
+| File watchers | invalidates on change | Clears workspace-derived specialization entries when watched files change |
+
+Prompt caching is disabled when runtime context or workspace context is present, and the cache key also incorporates behavior prompt, role reminder, workspace-title status, sub-agent state, and the hashed skills catalog content.

--- a/docs/fe/STATE_MANAGEMENT.md
+++ b/docs/fe/STATE_MANAGEMENT.md
@@ -1,0 +1,84 @@
+# State Management Guide
+
+> **Architecture update — the renderer uses the published Themis runtime.**
+> `@augmentcode/themis` provides the Store, actions, reducers, selectors, and
+> collection utilities. Themis initializes its saga middleware during
+> `Store.init()`, and the root layout starts the app-owned saga registry with
+> `store.runSaga(sagaFn)`.
+
+This is the project entrypoint for state-management orientation. The store API
+surface is the installed `@augmentcode/themis` package; app-specific companion
+notes live under `src/store/renderer/docs/`.
+
+If this doc conflicts with the installed Themis runtime, follow the runtime and
+report the drift.
+
+## Repository orientation
+
+Renderer shared/domain state lives under `src/store/renderer/` and uses the
+configured `Store` from `@augmentcode/themis`. Svelte store modules
+(`*.store.svelte.ts`) are deprecated migration targets; do not create new ones or
+expand existing ones.
+
+Electron main-process shared/domain state lives under `src/store/main/` and
+previously used a configured `StreamingStore` (since removed). The remaining
+modules there are neutralized no-op shims kept for type compatibility; do not
+add new main-process store state.
+
+The current app-specific map is:
+
+- `src/store/renderer/store.ts` — configured app `Store`, app state type inference,
+  and app reducer registration.
+- `src/store/renderer/sagas.ts` — positional `sagas` array plus
+  `startAllAppSagas(store)`, which starts each saga with `store.runSaga(sagaFn)`.
+- `src/routes/+layout.svelte` — root Store initialization and explicit app saga
+  startup via `startAllAppSagas(appStore)`.
+- `src/store/renderer/slices/**` — app-owned slice state, actions, selectors, and
+  sagas.
+- `src/store/renderer/utils/` — app-local helpers that are not package-owned exports,
+  such as workspace scoping, IPC channels, and safe localStorage saga helpers.
+- `src/store/main/slices/**` — historical main-process slice state, actions, and
+  selectors (the main-process store itself has been removed).
+- `src/store/main/redux-store-bridge.ts` — neutralized no-op bridge retained so
+  main-process services continue to type-check.
+
+## Side-effect ownership
+
+Renderer business side effects belong to root-owned Themis/Redux sagas. API and
+IPC calls, persistence, timers, subscriptions, navigation, and toasts must not
+be introduced through Store middleware or a new renderer bridge.
+
+`src/store/renderer/middleware.ts` contains exactly five approved infrastructure
+and diagnostic categories: store guards, action batching, logging, state-reference
+checks, and structured-clone checks. Existing web/mock IPC bridge installers may
+adapt Electron-shaped channels, but must not become alternate business workflows.
+`pnpm validate:architecture` enforces these boundaries.
+
+## Local rules worth remembering
+
+- Redux owns shared, persisted, async-driven, or cross-feature state.
+- Component-local state is for ephemeral view details only, such as hover,
+  focus, transient open/closed state, or one component's draft field.
+- Components create selector readables during component initialization, render
+  `$selector$` values, and dispatch through the configured app Store.
+- Event handlers and non-component services use one-shot reads from the
+  configured Store, e.g. `selectThing.select(store.state, id)`, then dispatch
+  explicit actions with `store.dispatch(action)`.
+- The main-process store has been removed; `src/store/main/redux-store-bridge.ts`
+  exports no-ops (`initMainStoreBridge` does nothing, `mainDispatch` returns the
+  action unchanged). Do not add main-process store state. Renderer code must not
+  import `src/store/main/**`, and main-process code must not import renderer
+  Store setup.
+- Tests, services, and selector composition should use `.select(state, ...args)`
+  for synchronous reads; sagas should use `.effect(...args)`.
+- Side effects that matter beyond one component belong in sagas. Component
+  `$effect` should stay limited to DOM-local concerns.
+- App-local safe localStorage helpers remain in `src/store/renderer/utils/` because
+  the package skills describe them as app-owned examples rather than public
+  package exports.
+
+## Companion docs
+
+Use [`src/store/renderer/docs/readme.md`](../../packages/cloudlands-fe/src/store/renderer/docs/readme.md) as the
+index for retained app-specific Redux notes. Those docs are concise companions;
+use the skills above for current API and architecture rules.

--- a/docs/fe/TROUBLESHOOTING_GUIDE.md
+++ b/docs/fe/TROUBLESHOOTING_GUIDE.md
@@ -237,7 +237,7 @@ logger.debug('Agent operation', { agentId, operation });
 ### Problem: State not reactive
 
 **Symptom**: UI not updating
-**Solution**: Use Svelte 5 runes for component-local state, or Redux selectors/actions for shared application state (see `docs/STATE_MANAGEMENT.md`).
+**Solution**: Use Svelte 5 runes for component-local state, or Redux selectors/actions for shared application state (see [STATE_MANAGEMENT.md](./STATE_MANAGEMENT.md)).
 
 ### Problem: Manager singleton issues
 

--- a/docs/fe/TROUBLESHOOTING_GUIDE.md
+++ b/docs/fe/TROUBLESHOOTING_GUIDE.md
@@ -1,0 +1,273 @@
+# Troubleshooting Guide
+
+**Version**: 2.0.0
+**Last Updated**: November 19, 2025
+**Status**: Post-Refactor Architecture
+
+## Table of Contents
+
+1. [Agent Creation Issues](#agent-creation-issues)
+2. [Streaming Issues](#streaming-issues)
+3. [Manager Issues](#manager-issues)
+4. [Memory and Performance](#memory-and-performance)
+5. [Test Issues](#test-issues)
+6. [TypeScript Issues](#typescript-issues)
+7. [Migration Issues](#migration-issues)
+
+## Common Issues and Solutions
+
+### Agent Creation Issues
+
+#### Problem: User rules not being loaded
+
+**Symptom**: Agent doesn't follow workspace-specific rules
+**Cause**: Direct orchestrator call bypassing factory
+**Solution**:
+
+```typescript
+// ❌ WRONG - Bypasses rules
+const agent = await orchestrator.createAgent(workspace, config);
+
+// ✅ CORRECT - Guarantees rules
+import { agentFactory } from '$features/agent/services/agent-factory';
+const agent = await agentFactory.createAgent(workspace, config);
+```
+
+#### Problem: Agent creation fails silently
+
+**Symptom**: No agent appears, no error message
+**Check**:
+
+1. Verify workspace has valid ID
+2. Check browser console for errors
+3. Ensure Auggie is installed and running
+4. Check IPC communication
+
+**Debug**:
+
+```typescript
+try {
+  const agent = await agentFactory.createAgent(workspace, config);
+  console.log('Agent created:', agent);
+} catch (error) {
+  console.error('Agent creation failed:', error);
+  // Check error.code for specific issue
+}
+```
+
+### Streaming Issues
+
+#### Problem: Messages appear all at once instead of streaming
+
+**Cause**: The UI is not rendering incremental chunks, or another handler is delaying updates
+**Solution**: `streamManager` processes chunks immediately. Inspect the streaming callbacks and emitted events instead of waiting for a batch flush.
+
+```typescript
+streamManager.on('stream:chunk', (event) => {
+  console.log('Chunk received:', event.chunk.text);
+});
+```
+
+#### Problem: Streaming stops unexpectedly
+
+**Check**:
+
+1. Agent process still running
+2. No memory limits exceeded
+3. Stream session not timed out
+
+### Test Issues
+
+#### Problem: Tests hanging indefinitely
+
+**Cause**: The test is waiting on the wrong async boundary
+**Solution**: Direct streaming does not have a batch-flush step. Await the real completion point instead, such as stream completion or the specific event your test expects.
+
+```typescript
+const result = await streamManager.completeStream(streamId);
+expect(result.success).toBe(true);
+```
+
+#### Problem: "Cannot find module" errors in tests
+
+**Cause**: Path aliases not configured
+**Solution**: Check `vitest.config.ts`:
+
+```typescript
+export default {
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+      $lib: path.resolve(__dirname, './src/lib'),
+    },
+  },
+};
+```
+
+### TypeScript Issues
+
+#### Problem: Branded ID type errors
+
+**Symptom**: "Type 'string' is not assignable to type 'AgentId'"
+**Solution**:
+
+```typescript
+// ❌ WRONG
+const agentId: AgentId = 'some-id';
+
+// ✅ CORRECT - Get from factory/backend
+const result = await agentFactory.createAgent(workspace, config);
+const agentId = result.agentId; // Already branded
+```
+
+#### Problem: Missing error codes
+
+**Symptom**: "Property 'X' does not exist on type 'AgentErrorCode'"
+**Solution**: Add to the relevant error enum:
+
+```typescript
+// src/features/agent/errors/agent-errors.ts
+export enum AgentErrorCode {
+  // ... existing codes
+  YOUR_NEW_ERROR = 'YOUR_NEW_ERROR',
+}
+```
+
+### Performance Issues
+
+#### Problem: High memory usage with multiple agents
+
+**Check**:
+
+1. Agents being properly cleaned up
+2. Stream sessions ending correctly
+3. Memory cleanup intervals running
+
+#### Problem: Slow agent responses
+
+**Check**:
+
+1. Network latency to Auggie
+2. System prompt complexity
+3. Number of concurrent agents
+
+### IPC Communication Issues
+
+#### Problem: "IPC channel not found" errors
+
+**Cause**: Handler not registered or wrong channel name
+**Solution**: Verify handler registration:
+
+```typescript
+// main-process handler registration
+ipcMain.handle('agent:create', async (event, data) => {
+  // ... create the agent
+});
+```
+
+#### Problem: IPC timeout errors
+
+**Cause**: Long-running operations blocking main process
+**Solution**: Use streaming or break into smaller operations
+
+### Build Issues
+
+#### Problem: Build fails with module errors
+
+**Solution**:
+
+```bash
+# Clean and rebuild
+rm -rf node_modules dist
+pnpm install
+pnpm run build
+```
+
+#### Problem: "Cannot find module electron" in production
+
+**Cause**: Electron not bundled correctly
+**Solution**: Check `electron-builder.yml` configuration
+
+#### Problem: Stale or corrupt Vite dep-optimization cache in dev
+
+**Symptoms**: Missing-dependency errors or `504 (Outdated Optimize Dep)` in the renderer after `pnpm run dev`
+**Cause**: `node_modules/.vite` (the Vite dep-optimization cache, reused for fast warm starts) is out of date or corrupt
+**Solution**: Force a one-off re-optimization, then return to normal dev runs:
+
+```bash
+# One-off forced re-optimization (vite dev --force)
+pnpm run dev:renderer:force
+
+# Or simply clear the cache and start dev normally
+rm -rf node_modules/.vite
+pnpm run dev
+```
+
+## Debugging Tools
+
+### Browser DevTools
+
+```javascript
+// Enable verbose logging
+localStorage.setItem('DEBUG', 'agent:*');
+
+// Check agent state
+console.log(agentState.sessions);
+console.log(agentState.streamingSessions);
+```
+
+### Backend Logging
+
+```typescript
+// Enable debug mode
+process.env.DEBUG = 'backend:*';
+
+// Add custom logging
+import { logger } from '@/utils/logger';
+logger.debug('Agent operation', { agentId, operation });
+```
+
+## Migration Issues
+
+### Problem: IPC channel conflicts
+
+**Symptom**: "Handler already registered"
+**Solution**: Use only AGENT_CHANNELS from '$shared/ipc/channels'
+
+### Problem: State not reactive
+
+**Symptom**: UI not updating
+**Solution**: Use Svelte 5 runes for component-local state, or Redux selectors/actions for shared application state (see `docs/STATE_MANAGEMENT.md`).
+
+### Problem: Manager singleton issues
+
+**Symptom**: Different manager instances
+**Solution**: Always use getInstance() method
+
+## Quick Debugging Commands
+
+```bash
+# Check TypeScript errors
+pnpm run type-check
+
+# Run tests
+pnpm run test
+
+# Clean and rebuild
+rm -rf node_modules dist && pnpm install && pnpm run build
+```
+
+## Getting Help
+
+1. Check this troubleshooting guide
+2. Search existing issues in the repository
+3. Ask in #agent-system channel with:
+   - Error messages and codes
+   - Steps to reproduce
+   - System information
+   - Relevant code snippets
+   - What you've already tried
+
+---
+
+**Version**: 2.0.0 | **Updated**: November 19, 2025

--- a/docs/fe/TYPE_SYSTEM_GUIDE.md
+++ b/docs/fe/TYPE_SYSTEM_GUIDE.md
@@ -1,0 +1,203 @@
+# Type System Guide for AI Agents
+
+## Overview
+
+The Intent app now has a comprehensive type safety system that prevents type mismatches between backend and frontend. This guide explains how to use it effectively.
+
+## Key Principles
+
+1. **Single Source of Truth**: All shared types are defined in `src/shared/type-system/contracts.ts`
+2. **Runtime Validation**: All IPC calls are validated at runtime
+3. **Compile-time Safety**: TypeScript ensures type safety at compile time
+4. **AI-Friendly Errors**: Errors include clear descriptions and suggested fixes
+
+## Common Tasks
+
+### Adding a New IPC Channel
+
+1. **Define the contract** in `src/shared/type-system/contracts.ts`:
+
+```typescript
+export const IpcContracts = {
+  'your:channel': {
+    request: z.object({
+      field1: z.string(),
+      field2: z.number().optional(),
+    }),
+    response: z.object({
+      result: z.string(),
+      status: z.enum(['success', 'error']),
+    }),
+  },
+  // ... other contracts
+};
+```
+
+2. **Register the handler** in the main process:
+
+```typescript
+import { registerHandler } from '@/shared/type-system/registry';
+import { createValidationMiddleware } from '@/shared/type-system/validation';
+
+registerHandler(
+  'your:channel',
+  createValidationMiddleware('your:channel')(async (event, data) => {
+    // data is already validated and typed
+    return {
+      result: 'processed',
+      status: 'success',
+    };
+  })
+);
+```
+
+3. **Call from renderer** using type-safe client:
+
+```typescript
+import { TypedIpcClient } from '@/shared/generated/ipc-client';
+
+const response = await TypedIpcClient.invoke('your:channel', {
+  field1: 'value',
+  field2: 42,
+});
+// response is typed correctly
+```
+
+### Checking for Type Errors
+
+Run these commands to validate types:
+
+```bash
+# Check all types and handlers
+pnpm run type-check
+
+# Check only type contracts
+pnpm run type-check:validate
+
+# Check handler registration
+pnpm run type-check:handlers
+
+# Generate detailed report
+pnpm run type-check:report
+```
+
+### Debugging Type Mismatches
+
+When you encounter a type mismatch:
+
+1. **Check the error message** - it will tell you exactly what's wrong:
+
+```
+Type validation failed for agent:create.
+
+Errors:
+  - workspaceId: Invalid UUID format (expected: UUID, received: "invalid")
+  - name: Required field missing
+```
+
+2. **Use dev tools** (in development mode):
+
+```javascript
+// In browser console
+TypeSystem.inspect(); // See all contracts and handlers
+TypeSystem.validateHandlers(); // Check registration
+TypeSystem.checkType('agent:create', 'request', data); // Validate data
+```
+
+3. **Check the contract** in `src/shared/type-system/contracts.ts`
+
+### Common Errors and Fixes
+
+#### Error: Handler not registered
+
+```
+IPC handler not registered for channel 'workspace:update'
+```
+
+**Fix**: Register the handler in the appropriate `.ipc.ts` file and ensure it's called from `src/main/index.ts`
+
+#### Error: Type mismatch
+
+```
+Type mismatch in Agent.status: expected string, got number
+```
+
+**Fix**: Update the type in `contracts.ts` to match what's actually being used
+
+#### Error: Unrecognized keys
+
+```
+Unrecognized keys in request: extraField
+```
+
+**Fix**: Either add the field to the contract or remove it from the request
+
+## Type System Components
+
+### 1. Contracts (`src/shared/type-system/contracts.ts`)
+
+- Defines all shared types using Zod schemas
+- Single source of truth for data structures
+- Exports TypeScript types inferred from schemas
+
+### 2. Validation (`src/shared/type-system/validation.ts`)
+
+- Runtime validation functions
+- Detailed error formatting
+- Validation middleware for handlers
+
+### 3. Registry (`src/shared/type-system/registry.ts`)
+
+- Tracks registered IPC handlers
+- Validates all required handlers are registered
+- Provides registration statistics
+
+### 4. Guards (`src/shared/type-system/guards.ts`)
+
+- Type guard functions for runtime type checking
+- Assert functions that throw on invalid types
+- Array and partial type guards
+
+### 5. Errors (`src/shared/type-system/errors.ts`)
+
+- Custom error classes with AI-friendly descriptions
+- Recovery strategies and suggested fixes
+- Detailed error context
+
+### 6. Dev Tools (`src/shared/type-system/dev-tools.ts`)
+
+- Development-time validation tools
+- Browser console API for debugging
+- Type system inspector
+
+## Best Practices
+
+1. **Always define types in contracts.ts** - Never duplicate type definitions
+2. **Use validation middleware** - Always validate IPC data
+3. **Run type checks before committing** - The pre-commit hook will enforce this
+4. **Generate types after changes** - Run `pnpm run generate:ipc-types`
+5. **Check handler registration** - Ensure all channels have handlers
+6. **Use type guards** - Validate data at runtime boundaries
+7. **Handle validation errors gracefully** - Show user-friendly messages
+
+## Automated Tools
+
+The type system includes several automated tools:
+
+- **Pre-commit hook**: Validates types before allowing commits
+- **Build-time validation**: Checks types during build process
+- **Type generator**: Creates type-safe IPC wrappers
+- **Error tracking**: Automatically tracks type-related errors
+
+## For AI Agents
+
+When working with the codebase:
+
+1. **Always check contracts.ts first** when dealing with shared types
+2. **Run type-check after making changes** to ensure consistency
+3. **Use the generated client** for type-safe IPC calls
+4. **Check error tracking** for type-related issues: `pnpm run agent-errors list`
+5. **Validate data before sending** to prevent runtime errors
+6. **Use type guards** when receiving external data
+
+Remember: The type system is your friend! It catches errors early and provides clear guidance on how to fix them.

--- a/docs/fe/agent-message-dedup-and-stream-sagas.md
+++ b/docs/fe/agent-message-dedup-and-stream-sagas.md
@@ -1,0 +1,134 @@
+# Agent Message Deduplication and Stream Saga Architecture
+
+This document explains the approved message deduplication and stream-reconciliation architecture for agent sessions.
+
+## Part 1: Detailed Guide — What Changed and Why
+
+### Problem
+
+Agent chats could show two assistant messages for one logical response. The observed duplicate shape was usually:
+
+- one renderer-created assistant message produced while handling restored/reconnected stream updates, and
+- one backend-finalized assistant message persisted or emitted later with different `id`, `appMessageId`, or timestamp metadata.
+
+The root issue was not just rendering. A missing local stream update target could previously cause the stream lifecycle adapter (then `src/features/agent/agent-stream-lifecycle.ts`, since removed) to synthesize a placeholder from accumulated stream content. Fallback assistant message creation now belongs to the stream saga and only runs after canonical target matching plus bypass-cache refresh still miss. Later, `src/features/agent/main/agent-backend-handler.service.ts` could finish and persist the same logical assistant turn under a different identity. Exact-ID merge paths and prior content fallback rules did not always collapse that pair.
+
+### Changed Areas
+
+#### Canonical dedup utility
+
+`src/shared/utils/message-dedup.ts` is the single owner for agent message duplicate matching and merge policy. It depends on shared content-block helpers such as `src/shared/utils/content-block-helpers.ts`, which keeps the policy usable from renderer reducers/sagas and main-process persistence code.
+
+It handles:
+
+- timestamp normalization,
+- content-block hashing and stable content comparison,
+- assistant-only near-duplicate detection for stream finalization identity mismatches,
+- `appMessageId`, canonical `msg_` id, timestamp, role, and turn-number guards, and
+- merge policy for preserving the preferred identity while keeping the richer/final message content.
+
+The main entry points are:
+
+- `deduplicateAgentMessages(...)`
+- `insertAgentMessageWithDedup(...)`
+- `replaceAgentMessageByIdWithDedup(...)`
+
+Why: duplicate policy must be consistent for full session snapshots, incremental message appends, and id replacement. Keeping this logic in one pure utility prevents drift between ingestion paths.
+
+#### Reducer safety net
+
+`src/store/renderer/slices/agent-session/agent-session-slice.ts` routes session/message ingestion through the dedup utility.
+
+Covered paths include:
+
+- session normalization before storing,
+- single message insertions,
+- message replacement by id,
+- full message replacement,
+- session update payloads containing messages, and
+- workspace-agent cross-slice message replacement.
+
+Why: reducers are the last shared-state boundary before UI rendering. Even if an upstream race or persisted session reintroduces duplicate logical messages, Redux session state should converge to the canonical deduped representation.
+
+#### Thin stream lifecycle adapter
+
+The stream adapter role is now filled by `src/features/events/daemon-events-bridge.client.ts` (the former `src/features/agent/agent-stream-lifecycle.ts` has been removed). It translates daemon stream events into typed Redux actions such as `agentStreamUpdateReceived(...)`.
+
+It should not own Redux-state-dependent decisions such as:
+
+- whether the current session contains an assistant update target,
+- which message should receive a chunk/content-block/complete update,
+- whether a session is stale,
+- whether to refresh from persistence,
+- refresh coalescing or rate limiting, or
+- whether fallback placeholder creation is justified after refresh misses.
+
+Why: service/lifecycle files should be as thin as possible. Shared/domain state and side-effect orchestration belong in Redux and Redux sagas, where selector reads, effects, and tests are explicit.
+
+#### Saga-owned missing-target reconciliation
+
+`src/store/renderer/slices/agent-session/sagas/agent-stream-saga.ts` owns stream update decisions that depend on Redux state.
+
+It handles:
+
+- selecting the current agent session,
+- matching stream updates to canonical assistant targets,
+- applying chunk/content-block/complete/error/timeout updates,
+- detecting missing update targets,
+- refreshing stale sessions from persistence with `{ bypassCache: true }`,
+- coalescing in-flight refreshes and rate-limiting repeated refreshes, and
+- creating a fallback assistant message only after refresh still cannot find a target.
+
+Why: missing-target refresh is a side effect and an orchestration workflow. Sagas are the correct layer for reads from Redux state, persistence calls, retry/rate-limit behavior, and follow-up dispatches.
+
+### Verification Approach
+
+The implementation was verified with focused coverage for:
+
+- message dedup utility behavior and false-positive guards,
+- agent-session reducer ingestion paths,
+- restored and sendMessage stream lifecycle regressions,
+- agent-session stream sagas, including missing-target refresh and saga-owned fallback behavior,
+- renderer TypeScript checks, and
+- `git diff --check` whitespace checks.
+
+## Part 2: New Architecture
+
+### Ownership Model
+
+| Layer                      | Owns                                                                                                     | Must Not Own                                                             |
+| -------------------------- | -------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| UI components              | Rendering, component-local UI state, dispatching user intent                                             | Shared/domain state or app workflows                                     |
+| Service/lifecycle adapters | IPC/stream subscriptions, raw event translation, payload construction, compatibility window events       | Redux-state target lookup, refresh/reconcile orchestration, dedup policy |
+| Redux slices/reducers      | Serializable shared/domain state and pure canonical state transitions                                    | Side effects, async work, timers, persistence calls                      |
+| Selectors                  | Reusable state reads and derived state                                                                   | Side effects or state mutation                                           |
+| Redux sagas                | Side effects, IPC/persistence calls, retries, debounce/rate-limit/coalescing, cross-domain orchestration | Rendering or reducer mutations                                           |
+| Dedup utility              | Pure message duplicate matching and merge policy                                                         | Persistence, dispatching, or UI updates                                  |
+
+### Stream Update Flow
+
+1. Backend emits stream events for an agent response.
+2. `daemon-events-bridge.client.ts` receives stream callbacks and dispatches raw Redux stream actions with IDs, content, content blocks, `appMessageId`, and stream metadata.
+3. `agent-stream-saga.ts` reads Redux state through selectors and tries to apply the update to the current canonical assistant target.
+4. If no target exists, the saga treats the session as stale, performs a bypass-cache persistence refresh, and retries the update against the refreshed session.
+5. If refresh still cannot supply a target, the saga may create a fallback assistant message. This is the exception path, not the default reconciliation strategy.
+6. `agent-session-slice.ts` applies the update and runs canonical message deduplication so snapshot replacement and incremental insertion converge to the same result.
+7. UI reads deduped session state and renders one logical assistant response.
+
+### Architectural Rules Going Forward
+
+- Keep service and lifecycle files as thin as possible. They can translate external events into typed actions, but should not make Redux-state-dependent domain decisions.
+- Put shared/domain state in Redux slices under `src/store/renderer/`.
+- Put side-effect orchestration in Redux sagas: IPC, persistence, refresh/reconcile, timers, retries, coalescing, rate limiting, and cross-slice workflows.
+- Keep duplicate matching and merge rules in `message-dedup.ts`; do not reimplement near-duplicate policy in services, sagas, components, or persistence code.
+- Preserve false-positive guards for legitimate repeated assistant messages, especially different explicit turns.
+
+### Key References
+
+- `src/shared/utils/message-dedup.ts`
+- `src/shared/utils/content-block-helpers.ts`
+- `src/store/renderer/slices/agent-session/agent-session-slice.ts`
+- `src/features/events/daemon-events-bridge.client.ts`
+- `src/store/renderer/slices/workspace-agents/workspace-agents-slice.ts`
+- `src/store/renderer/slices/agent-session/sagas/agent-stream-saga.ts`
+- `src/store/renderer/slices/agent-session/sagas/agent-stream-saga.test.ts`

--- a/docs/fe/code-review-ui.md
+++ b/docs/fe/code-review-ui.md
@@ -1,0 +1,288 @@
+# Code Review UI Design
+
+## Overview
+
+AI-powered code review for staged changes, integrated into the change timeline and main panel.
+
+---
+
+## Entry Point
+
+**Location:** Change timeline local changes header (next to "View all" button)
+
+**Trigger:** "Review staged" button with magic wand icon
+- Clicking initiates review and opens main panel view
+- Button transforms into a status pill showing review state:
+  - `🔄 Reviewing...` (while streaming)
+  - `✓ 3 comments` (completed, shows count)
+  - `⚠️ 2 issues` (if critical/important issues found)
+  - `✓ Looks good` (no issues)
+
+**Pill behavior:**
+- Click to open/focus the review panel
+- Shows severity badge if critical issues exist
+- Subtle pulse animation while reviewing
+
+---
+
+## Main Panel View
+
+### Layout (top to bottom)
+
+```
+┌─────────────────────────────────────────────────┐
+│  Header: "Code Review" + status + actions       │
+├─────────────────────────────────────────────────┤
+│  Change Visualization (same as chat panel)      │
+│  [file tree or diff summary graphic]            │
+├─────────────────────────────────────────────────┤
+│  Summary Card (streams in)                      │
+│  "Overall: Looking good with minor suggestions" │
+├─────────────────────────────────────────────────┤
+│  Comments List, stream in                       │
+│  ┌─────────────────────────────────────────┐   │
+│  │ 🔴 Critical: SQL injection risk          │   │
+│  │    file.ts:42 • Security                 │   │
+│  │    [View] [Pin] [Dismiss]                │   │
+│  └─────────────────────────────────────────┘   │
+│  ┌─────────────────────────────────────────┐   │
+│  │ 🟡 Important: Missing null check         │   │
+│  │    utils.ts:15 • Bug                     │   │
+│  └─────────────────────────────────────────┘   │
+├─────────────────────────────────────────────────┤
+│  Diff View (scrollable, with inline markers)   │
+└─────────────────────────────────────────────────┘
+```
+
+### Header Bar
+
+- Title: "Code Review"
+- Status indicator (reviewing/complete/stale)
+- Actions:
+  - **Stop** (during review) - stops streaming
+  - **Re-run** (after complete) - fresh review
+  - **Close** - returns to previous panel content
+
+### Loading State
+
+While streaming:
+- Summary card shows skeleton with subtle shimmer
+- Status text: "Reviewing your changes..." with typing indicator
+- Comments appear one-by-one as they stream in (nice staggered animation), skeleton with 3 when loading
+- Stop button prominently visible
+
+---
+
+## Summary Card
+
+**Content:**
+- Overall assessment (1-2 sentences)
+- Quick stats: `3 files reviewed • 2 issues • 1 suggestion`
+- Confidence indicator (optional): "High confidence review"
+
+**States:**
+- Loading: Skeleton with shimmer
+- Streaming: Text appears word-by-word
+- Complete: Full summary visible
+- Stale: Dimmed with "Review may be outdated" badge
+
+---
+
+## Comments List
+
+### Comment Card Structure
+
+```
+┌──────────────────────────────────────────────────┐
+│ 🔴 Critical                              Security │
+│ ─────────────────────────────────────────────────│
+│ SQL injection vulnerability in user input        │
+│                                                  │
+│ The query string is concatenated directly...     │
+│                                                  │
+│ 📍 src/api/users.ts:42                          │
+│                                                  │
+│ [View in diff] [Pin to chat] [Dismiss]          │
+└──────────────────────────────────────────────────┘
+```
+
+### Severity Levels (visual distinction)
+
+- **🔴 Critical** - Red accent, prominent
+- **🟡 Important** - Yellow/amber accent
+- **🔵 Minor** - Blue/subtle accent
+
+### Comment Actions
+
+1. **View in diff** - Scrolls to and highlights the relevant code
+2. **Pin to chat** - Adds to agent context (appears in input header)
+3. **Dismiss** - Hides comment (can undo), persisted locally
+
+### Filtering
+
+- Filter pills at top: `All (5)` `Critical (1)` `Important (2)` `Minor (2)`
+- Dismissed comments hidden by default, toggle to show
+
+---
+
+## Agent Integration
+
+### Pinning Comments
+
+When user pins comment(s):
+- Badge appears in chat input header: `📌 2 review comments`
+- Clicking badge shows list of pinned comments
+- Can unpin from there
+
+### Sending to Agent
+
+When user sends message with pinned comments:
+- Full review context included (summary + all comments)
+- Pinned comments highlighted in context
+- Agent can reference specific comments by location
+
+### Auto-context
+
+If agent drawer is open when review completes:
+- Show toast: "Review complete - 3 comments found"
+- Don't auto-add to context (user must pin explicitly)
+
+
+---
+
+## Diff View Integration
+
+### Inline Comment Markers
+
+In the diff view below the comments list:
+- Gutter markers at lines with comments
+- Click marker to jump to comment in list above
+- Hover shows comment preview tooltip
+
+### Code Highlighting
+
+When "View in diff" clicked:
+- Smooth scroll to the file/line
+- Highlight the relevant lines (yellow flash, then subtle background)
+- Comment card stays visible (split view consideration?)
+
+---
+
+## Edge Cases
+
+### No Issues Found
+
+- Summary: "✓ No issues found - your code looks good!"
+- Comments section: Empty state with checkmark illustration
+- Consider: "Would you like a more thorough review?" option
+
+### Many Comments (>10)
+
+- Virtualized list for performance
+- "Show more" pagination
+- Consider collapsing by file
+
+### Review Errors
+
+- Network failure: Retry button, cached partial results if any
+- Timeout: "Review took too long" with partial results
+- Invalid diff: Clear error message
+
+### Empty Staged Changes
+
+- Disable review button
+- Tooltip: "Stage changes to review"
+
+---
+
+## Streaming Behavior
+
+### Order of Output
+
+1. Summary streams first (gives immediate feedback)
+2. Comments stream one-by-one after summary complete
+3. Each comment animates in with subtle slide-up
+
+### Chunk Handling
+
+- Parse streaming output for complete comment blocks
+- Don't show partial comments (buffer until complete)
+- Summary can show partial (word-by-word streaming)
+
+---
+
+## Data Model
+
+```typescript
+interface CodeReview {
+  id: string;
+  workspaceId: string;
+  timestamp: Date;
+  status: 'running' | 'complete' | 'error' | 'stale';
+
+  // Snapshot of what was reviewed
+  snapshot: {
+    stagedFiles: string[];
+    commitHashes?: string[];
+    baseRef?: string;
+  };
+
+  // Results
+  summary?: string;
+  comments: ReviewComment[];
+
+  // Metadata
+  duration?: number;
+  agentId?: string;
+}
+
+interface ReviewComment {
+  id: string;
+  severity: 'critical' | 'important' | 'minor';
+  category: 'bug' | 'security' | 'api' | 'documentation' | 'other';
+  title: string;
+  description: string;
+  location?: {
+    file: string;
+    startLine: number;
+    endLine?: number;
+  };
+  confidence: number; // 0-1
+
+  // UI state (local, not from agent)
+  dismissed?: boolean;
+  pinned?: boolean;
+}
+```
+
+---
+
+## Implementation Phases
+
+### Phase 1: Core Flow (implemented)
+- [x] Review button in change timeline
+- [x] Main panel view with loading state
+- [x] Stream summary and comments
+- [x] Basic comment list UI
+
+### Phase 2: Interactions (implemented)
+- [x] View in diff (scroll + highlight)
+- [x] Pin to chat functionality
+- [x] Dismiss comments
+- [x] Filter by severity
+
+### Phase 3: Polish
+- [ ] Staleness detection
+- [ ] Review history/archives
+- [ ] Inline diff markers
+- [ ] Keyboard navigation
+
+---
+
+## Open Questions
+
+1. **Should inline diff markers be clickable to add new comments?** (human review feature)
+2. **Do we want a "Fix this" button that auto-creates an agent task?**
+3. **Should we support reviewing specific files vs all staged?**
+4. **What about reviewing commits (not just staged changes)?**
+5. **Integration with GitHub PR reviews - sync comments?**

--- a/docs/fe/panel-system-refactoring.md
+++ b/docs/fe/panel-system-refactoring.md
@@ -1,0 +1,141 @@
+# Panel System Refactoring
+
+## Overview
+
+This document describes the panel system refactoring work completed to improve code organization, fix bugs, and lay groundwork for future features.
+
+## What Was Built
+
+### 1. Tab Type Registry System
+
+**Problem**: `PanelContentRenderer.svelte` was a 1800+ line file with a massive if/else chain handling the app's 14 registered tab types. This made it hard to maintain, test, and extend.
+
+**Solution**: Created a registry-based architecture where each tab type is a standalone component.
+
+**Files Created**:
+- `src/features/layout/tab-types/registry.ts` - Registry infrastructure
+- `src/features/layout/tab-types/register-all.ts` - Registers all tab types at app startup
+- 14 registered tab type components in `src/features/layout/tab-types/`:
+  - `AgentTabType.svelte` - Chat panel with agent conversations
+  - `NoteTabType.svelte` - Note editor with version history
+  - `FileTabType.svelte` - Code editor with auto-save
+  - `DiffTabType.svelte` - Diff viewer for file changes
+  - `ChangesTabType.svelte` - Commit changeset viewer
+  - `LocalChangesTabType.svelte` - Local git changes
+  - `ChatChangesTabType.svelte` - Changes from agent turns
+  - `ActivityChangesTabType.svelte` - Activity event diffs
+  - `BrowserTabType.svelte` - Embedded browser
+  - `TerminalTabType.svelte` - Terminal emulator
+  - `CodeReviewTabType.svelte` - Code review panel
+  - `AgentOverviewTabType.svelte` - Agent overview
+  - `SettingsTabType.svelte` - Settings panel
+  - `OverviewTabType.svelte` - Workspace overview
+
+**How It Works**:
+```typescript
+// Each tab type is registered with its component, icon, and metadata
+tabTypeRegistry.register({
+  type: 'agent',
+  component: AgentTabType,
+  icon: faComment,
+  defaultTitle: 'Agent',
+  categoryLabel: 'Agents',
+  sidebarTabId: 'agents',
+  renameable: true,
+});
+
+// PanelContentRenderer now just looks up and renders
+const TabComponent = tabTypeRegistry.get(tab.type)?.component;
+<TabComponent {tab} {workspaceId} {isActive} {isPanelFocused} {onFocus} />
+```
+
+### 2. Modifier Key Support (Cmd+Click) — historical
+
+> Historical changelog: describes a one-off fix pass; the specific call sites and `layoutManager` API have since evolved (layout is now the Redux `panel-layout` slice).
+
+Cmd+clicking (or Ctrl+clicking) links and items opens them in an adjacent panel; a codebase-wide pass fixed locations where modifier key support was missing.
+
+### 3. Layout Persistence Fixes — historical
+
+> Historical changelog: default-layout persistence was fixed, and intentional spec-note closes were tracked (the `userClosedSpecNote` flag no longer exists in code).
+
+### 4. Architectural Hooks
+
+**Added for future features** (not currently used):
+
+```typescript
+// In WorkspacePanelLayout interface
+detachedPanels?: Record<string, {
+  panelId: string;
+  windowId: string;
+  alwaysOnTop: boolean;
+  bounds?: { x: number; y: number; width: number; height: number };
+}>;
+```
+
+This enables future pop-out panel functionality.
+
+## Architecture
+
+### Tab Type Component Interface
+
+All tab type components implement this interface:
+
+```typescript
+interface TabTypeComponentProps {
+  tab: PanelTab;
+  workspaceId: string;
+  isActive: boolean;
+  isPanelFocused: boolean;
+  onFocus?: () => void;
+}
+```
+
+### Registry metadata
+
+Each tab type definition now includes:
+
+- `type` - unique tab type key
+- `component` - Svelte component for rendering
+- `icon` - icon shown in tab bars and headers
+- `defaultTitle` - title used when creating new tabs of this type
+- `categoryLabel` - grouping label used by the panel system
+- `sidebarTabId?` - optional sidebar target for “Reveal in Sidebar”
+- `renameable?` - whether users can rename tabs of this type
+
+### Header Actions
+
+Each tab type registers its own header actions via the panel header context:
+
+```typescript
+const headerContext = getPanelHeaderContext();
+
+$effect(() => {
+  if (!headerContext || !isActive) return;
+  headerContext.registerActions(myActionsSnippet);
+  headerContext.registerState({ subtitle: 'My subtitle' });
+});
+```
+
+## Files Modified
+
+### Core Panel System
+- `src/lib/components/layout/panel-system/PanelContentRenderer.svelte` - Simplified to use registry
+- `src/lib/components/layout/panel-system/PanelTabBar.svelte` - Uses registry for tab display
+
+### Layout Management
+- Layout state now lives in the Redux `panel-layout` slice (`src/store/renderer/slices/panel-layout/`), bridged by `src/features/layout/panel-layout-adapter.ts`; `detachedPanels` is defined in `panel-layout-types.ts`. (The former `panel-layout-manager.svelte.ts` has been removed.)
+
+## Testing
+
+After these changes, verify:
+1. All 14 tab types render correctly
+2. Cmd+click opens items in adjacent panels
+3. Layout persists across page reloads
+4. Closing spec note stays closed until manually reopened
+5. Header actions appear correctly for each tab type
+
+## Future Work
+
+1. **Pop-out panels** - Use detachedPanels infrastructure to enable floating windows
+2. **TweetDeck layouts** - Multi-column layouts with independent scrolling

--- a/docs/fe/tasks-block-syntax.md
+++ b/docs/fe/tasks-block-syntax.md
@@ -1,0 +1,179 @@
+# Task Block Syntax
+
+This document explains the expected syntax for proposing tasks in the workspace spec, and compares it with what agents sometimes produce incorrectly.
+
+## Target Syntax: `@@@task` Block (Singular)
+
+When an agent wants to propose tasks that should become nested Task Notes, it should use **separate** `@@@task` blocks (singular, not `@@@tasks`).
+
+### Why `@@@task` instead of ` ```task`?
+
+The new `@@@task` syntax avoids conflicts with nested code blocks in task content. When task descriptions contain code examples with triple backticks, the old ` ```task` syntax could cause parsing ambiguities. The `@@@` delimiters are unambiguous and work reliably even with complex nested content.
+
+### Key Rules
+
+1. **One task per block** - Each `@@@task` block contains exactly one task
+2. **First `#` heading is the title** - The first h1 heading becomes the task title
+3. **Everything below is the body** - All content after the title heading becomes the task body
+4. **Multiple tasks = multiple blocks** - For multiple tasks, create multiple `@@@task` blocks
+
+### Correct Format
+
+````markdown
+## Tasks
+
+@@@task
+# Authentication System
+Build JWT-based authentication for the API layer.
+
+## Requirements
+- Login/logout endpoints
+- Session management with refresh tokens
+- Password reset flow
+@@@
+
+@@@task
+# Database Layer
+Set up PostgreSQL with Drizzle ORM.
+
+## Schema
+- Users table
+- Sessions table
+- Migrations setup
+@@@
+````
+
+### How It Works
+
+1. Each `@@@task` block is parsed independently
+2. The first `# Title` heading becomes the task title
+3. Everything after that heading becomes the task body
+4. When the note is saved, the system:
+   - Parses each `@@@task` block
+   - Creates a Task Note with the title and body
+   - Replaces the `@@@task` block with a linked task checkbox
+
+### Expected Output After Conversion
+
+```markdown
+## Tasks
+
+- [ ] [Authentication System](intent://local/task/note-abc123)
+
+- [ ] [Database Layer](intent://local/task/note-def456)
+```
+
+---
+
+## What Agents Sometimes Write Instead (Incorrect)
+
+### Problem: Empty Tasks Section
+
+```markdown
+## Tasks
+
+## Design Reference
+```
+
+**Issue**: The agent wrote a `## Tasks` header but left it empty, with no `@@@task` blocks.
+
+### Problem: Plain Markdown Lists
+
+```markdown
+## Tasks
+
+- Authentication System
+- Database Layer
+- API Endpoints
+```
+
+**Issue**: Plain bullet lists are not recognized as task proposals. They're just text.
+
+### Problem: Regular Checkboxes
+
+```markdown
+## Tasks
+
+- [ ] Authentication System
+- [ ] Database Layer
+```
+
+**Issue**: Regular checkboxes are not automatically converted to Task Notes. Use `@@@task` blocks instead.
+
+### Problem: Using `tasks` (plural) instead of `task` (singular)
+
+````markdown
+@@@tasks
+# Task One
+...
+# Task Two
+...
+@@@
+````
+
+**Issue**: The old `@@@tasks` (plural) syntax is deprecated. Use individual `@@@task` blocks instead.
+
+---
+
+## Comparison Table
+
+| Syntax | Creates Task Notes? | Supports Rich Content? |
+|--------|---------------------|------------------------|
+| `@@@task` block (one per task) | ✅ Yes | ✅ Yes (body below title) |
+| `- [ ] Task Name` (no marker) | ❌ No | N/A |
+| Plain bullet list | ❌ No | N/A |
+| Empty section | ❌ No | N/A |
+| `@@@tasks` (plural, deprecated) | ❌ No | N/A |
+
+---
+
+## Debugging
+
+### Check if content has task blocks
+
+```typescript
+import { hasTaskBlocks } from '../features/notes/utils/task-block-parser';
+
+const content = note.content;
+console.log('Has task blocks:', hasTaskBlocks(content));
+```
+
+### Extract tasks from blocks
+
+```typescript
+import { extractTasksBlocks } from '../features/notes/utils/task-block-parser';
+
+const result = extractTasksBlocks(content);
+console.log('Block count:', result.blockCount);
+console.log('Valid tasks:', result.validTaskCount);
+console.log('Invalid blocks:', result.invalidBlockCount);
+console.log('Tasks found:', result.tasks);
+// Each task has: { title: string, content: string }
+```
+
+---
+
+## Robustness
+
+The parser handles these edge cases for `@@@task` syntax:
+
+- **Trailing whitespace**: `@@@task   ` (with spaces/tabs after `task`) is accepted
+- **Windows line endings**: Both `\n` and `\r\n` are supported
+- **Empty titles**: `#    ` (whitespace-only title) is rejected as invalid
+- **Content before title**: Any text before the first `# Title` is ignored
+- **Multiple `#` headings**: Only the first `# Title` is the task title; subsequent ones are part of the body
+- **`##` and `###`**: These are NOT treated as titles (only single `#` works)
+
+Invalid blocks are replaced with `<!-- invalid-task-block-removed -->` comment.
+
+---
+
+## Agent Instructions Reference
+
+The agent instructions should specify:
+
+> Use `@@@task` blocks to propose tasks with rich context:
+> - Write **one task per block**
+> - Use the first `# Title` heading for the task title
+> - Add detailed context, requirements, and acceptance criteria in the body
+> - When saved, each block is automatically converted to a linked Task Note

--- a/docs/fe/workspaces-link-handler.md
+++ b/docs/fe/workspaces-link-handler.md
@@ -1,0 +1,214 @@
+# Intent Link Handler
+
+## Overview
+
+The intent link handler enables internal navigation using `intent://` protocol links. This allows agents and users to create clickable links to notes that work in both chat messages and note editors.
+
+## URL Format
+
+```
+intent://local/note/{note-id}
+intent://local/task/{note-id}
+intent://local/workspace/{workspace-id}
+intent://local/{workspace-id}/note/{note-id}
+intent://local/{workspace-id}/task/{note-id}
+```
+
+### Components
+
+- **Protocol**: `intent://`
+- **Org ID**: `local` (placeholder for future organization support)
+- **Workspace Segment**: Optional. When present (and the second segment is `note` or `task`), the link targets a specific workspace
+- **Resource Type**: `note`, `task`, or `workspace`
+- **Resource ID**: The backing note ID for `note`/`task` links (e.g., `spec`, task UUIDs, other note IDs), or the workspace ID for `workspace` links
+
+### Examples
+
+```markdown
+[Spec Note](intent://local/note/spec)
+[Task Note](intent://local/task/550e8400-e29b-41d4-a716-446655440000)
+[Meeting Notes](intent://local/note/meeting-2024-01-15)
+[UUID Note](intent://local/note/550e8400-e29b-41d4-a716-446655440000)
+[Workspace](intent://local/workspace/my-workspace-id)
+[Cross-Workspace Note](intent://local/workspace-123/note/spec)
+[Cross-Workspace Task](intent://local/workspace-123/task/550e8400-e29b-41d4-a716-446655440000)
+```
+
+## Implementation
+
+### Core Module
+
+**File**: `src/lib/utils/workspaces-link-handler.ts`
+
+**Exports**:
+
+- `parseIntentLink(url: string)` - Parse an intent:// URL
+- `generateNoteLink(noteId: string, workspaceId?: string)` - Deprecated compatibility wrapper around `noteUrl()`
+- `handleIntentLink(url: string)` - Navigate to an intent:// URL
+- `createIntentLinkClickHandler()` - Create a Tiptap click handler
+
+**Preferred helpers**:
+
+- `noteUrl(noteId, workspaceId?)` from `$shared/constants/intent-links`
+- `taskNoteUrl(noteId)` from `$shared/constants/intent-links` for current-workspace task links
+- `workspaceUrl(workspaceId)` / `workspaceLink(text, workspaceId)` from `$shared/constants/intent-links` for workspace links
+
+### Integration Points
+
+Link clicks are now centralized in the unified link handler (`src/features/navigation/link-handler.ts`), which handles intent:// links alongside other URL types.
+
+1. **MarkdownViewer.svelte** (Chat)
+   - Intercepts clicks on intent:// links in chat messages
+   - Uses `createIntentLinkClickHandler()` in `editorProps.handleClick`
+
+2. **editor-config.ts** (Notes Editor, `src/lib/utils/editor-config.ts`)
+   - Intercepts clicks on intent:// links in note editor
+   - Checks for intent:// links before other click handlers
+
+## Behavior
+
+### Successful Navigation
+
+When a valid intent:// link is clicked:
+
+1. URL is parsed to extract org-id, optional workspace-id, resource type, and resource ID
+2. `note` and `task` links both resolve to note records (task notes are regular notes with task metadata)
+3. The system checks whether the target note exists in the current or specified workspace
+4. If needed, the app navigates to the target workspace first and opens the note there
+5. If the note doesn't exist, the user sees an error toast
+
+### Error Handling
+
+- **Invalid URL format**: Shows toast with error message
+- **Note not found**: Shows "Note not found in current workspace" toast
+- **Cross-workspace note not found**: Shows which workspace ID was checked
+- **Workspace not found**: Shows "Workspace {id} not found" toast
+- **No workspace open for short-form links**: Shows "No space is currently open" toast
+- **Unknown resource type**: Shows "Cannot handle {type} links yet" toast
+
+### Implemented navigation modes
+
+- Current-workspace notes: `intent://local/note/{note-id}`
+- Current-workspace task notes: `intent://local/task/{note-id}`
+- Workspace links: `intent://local/workspace/{workspace-id}`
+- Cross-workspace notes: `intent://local/{workspace-id}/note/{note-id}`
+- Cross-workspace task notes: `intent://local/{workspace-id}/task/{note-id}`
+
+## Testing
+
+### Test Files
+
+- `src/lib/utils/workspaces-link-handler.test.ts` - Unit tests (15 tests)
+- `src/lib/utils/workspaces-link-handler.integration.test.ts` - Integration tests (9 tests)
+
+### Running Tests
+
+```bash
+# Run all workspaces link handler tests
+pnpm test src/lib/utils/workspaces-link-handler --run
+
+# Run with verbose output
+pnpm test src/lib/utils/workspaces-link-handler --run --reporter=verbose
+```
+
+### Test Coverage
+
+- ✅ URL parsing (valid and invalid formats)
+- ✅ Link generation
+- ✅ Task link parsing
+- ✅ Cross-workspace note/task parsing
+- ✅ Round-trip parsing/generation
+- ✅ Tiptap click handler integration
+- ✅ Error handling
+- ✅ Edge cases (empty IDs, unknown types, etc.)
+
+## Usage
+
+### For Agents
+
+Agents should generate note links with `noteUrl()` and treat `generateNoteLink()` as a deprecated compatibility wrapper:
+
+```typescript
+import { noteUrl, taskNoteUrl, workspaceUrl, workspaceLink } from '$shared/constants/intent-links';
+
+const noteLink = noteUrl('spec');
+// Returns: "intent://local/note/spec"
+
+const taskLink = taskNoteUrl('550e8400-e29b-41d4-a716-446655440000');
+// Returns: "intent://local/task/550e8400-e29b-41d4-a716-446655440000"
+
+const wsLink = workspaceUrl('my-workspace-id');
+// Returns: "intent://local/workspace/my-workspace-id"
+
+// Use in markdown
+const markdown = `See the [spec note](${noteLink}) or [task](${taskLink}).`;
+const wsMarkdown = workspaceLink('My Workspace', 'my-workspace-id');
+// Returns: "[My Workspace](intent://local/workspace/my-workspace-id)"
+```
+
+For chat-side rendering, prefer the fenced ` ```workspace ` block (handled by `ChatWorkspaceCard`) so the user sees a live, clickable workspace card with title, repo, branch, and status. Use the workspace markdown link only when you must reference a workspace inline in a sentence.
+
+### For Users
+
+Users can manually create links in markdown:
+
+```markdown
+Check out the [spec](intent://local/note/spec) for requirements.
+```
+
+## Future Enhancements
+
+### Planned
+
+1. **Organization Support**: Replace `local` placeholder with actual org-id
+2. **Additional Resource Types**: Support for files, agents, etc.
+3. **Deep Linking**: Link to specific sections within notes
+
+### URL Format Evolution
+
+Future URL formats might look like:
+
+```
+intent://example-org/note/spec
+intent://example-org/file/src/main.ts
+intent://example-org/agent/session-123
+intent://example-org/note/spec#section-2
+```
+
+## Design Decisions
+
+### Why `local` as Placeholder?
+
+The `local` placeholder reserves the org-id slot in the URL structure without requiring organization infrastructure today. This makes the URLs forward-compatible.
+
+### Why Not OS-Level Protocol Handling?
+
+We chose to handle links at the application level (Tiptap click handlers) rather than OS-level protocol registration because:
+
+- Faster to implement
+- No platform-specific code needed
+- Works immediately without OS configuration
+- Can be upgraded to OS-level later if needed
+
+### Why Fire-and-Forget for Async Handlers?
+
+Tiptap's `handleClick` doesn't support async functions. We call the async handler without awaiting to avoid blocking the UI thread. This is acceptable because:
+
+- Navigation happens quickly
+- Errors are shown via toast notifications
+- User gets immediate feedback
+
+## Troubleshooting
+
+### Links Not Working
+
+1. Check that the note exists in the current workspace
+2. Verify the URL format is correct
+3. Check browser console for errors
+4. Ensure a workspace is currently open
+
+### Tests Failing
+
+1. Run `pnpm test src/lib/utils/workspaces-link-handler --run`
+2. Check for import errors or missing dependencies
+3. Verify workspace store is properly mocked in tests


### PR DESCRIPTION
## Summary

Migrates the 23 "kept" docs from `packages/cloudlands-fe/docs/` into a new `docs/fe/` directory in the monorepo, per the docs audit disposition. The `real/` and `proposals/` subfolders are flattened into `docs/fe/`.

## What's included

- **23 docs copied** to `docs/fe/` (flattened: `real/DEPLOYING.md` → `DEPLOYING.md`, `proposals/PANEL_TAB_UX_SPEC.md` → `PANEL_TAB_UX_SPEC.md`).
- **Per-doc accuracy fixes** from the audit findings applied to the KEEP-WITH-EDITS set (no rewrites beyond the audit items):
  - `DEPLOYING.md` / `RELEASING.md` — current runners (`macos-15-xlarge`, `gh-windows-16x`, self-hosted Linux x64/arm64), 4-platform builds and feed files, upload globs.
  - `PANEL_TAB_UX_SPEC.md` — leader key corrected from `Cmd+K` to `Cmd+;`; implementation checklist refreshed.
  - `EVENT_SYSTEM.md` — removed DomainEvents layer, neutralized `mainDispatch`, daemon-owned change detection, removed dead `activity-log:*` channels.
  - `STATE_MANAGEMENT.md` — main-process store removal reflected in "Local rules"; companion-doc link repointed.
  - `agent-message-dedup-and-stream-sagas.md` — stream lifecycle paths updated to `daemon-events-bridge.client.ts`; deleted test references removed.
  - `MODULE_BOUNDARY_GUIDE.md` — shims-removed status; remaining-work table corrected.
  - `DEVELOPER_GUIDE.md` — version 2.22.0; panel-layout Redux slice; background-agent executor/settings slices.
  - `TROUBLESHOOTING_GUIDE.md` — removed nonexistent `consolidatedBackend` APIs, scripts, and error-code table.
  - `IPC_DEBUG_GUIDE.md` — generated preload allowlist (`generate:ipc-channels`) instead of hand-editing.
  - `ERROR_HANDLING_SYSTEM.md` — Error Console removal; correct `src/lib/utils/` paths.
  - `KEYBINDINGS.md` — `Mod+Shift+N` reserved for New Window; wishlist sections marked as proposals.
  - `BROWSER_PANEL_SPEC.md` — browser state moved to Redux `browser` slice.
  - `MULTI_BACKEND_CONNECT.md` — connections IPC bridge is now `connections-saga.ts`.
  - `panel-system-refactoring.md` — one-off changelog sections marked historical; panel-layout slice references.
  - `code-review-ui.md` — Phase 1/2 checklists marked implemented.
  - `workspaces-link-handler.md` — unified link handler noted; `editor-config.ts` location fixed.
- **Intra-doc links fixed** for the new location (`./real/` and `./proposals/` prefixes dropped; `../CHANGELOG.md` and companion-doc links repointed to `../../packages/cloudlands-fe/...`).
- **`docs/README.md`** — new "Frontend — `fe/`" section indexing all 23 docs by category.

## Not included (by design)

- No changes under `packages/` — the deletion of `packages/cloudlands-fe/docs/` and reference updates (AGENTS.md routing table, README, eslint messages) happen in the cloudlands-fe repo PR.

Part of the cloudlands-fe docs audit/migration effort.
