### PR TITLE
docs: execute-only workspace.create setupScript semantics (PROTOCOL §5.1) + submodule bumps

### DIFF
--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -786,16 +786,21 @@ workspace visibility. The seed captures an initial `v1` version snapshot and pub
 idempotency scope (§6.5) between `workspace:created` and initial-agent orchestration —
 a replayed create returns the stored result and does not re-seed.
 
-**Setup script persistence and execution (`workspace.create`).** When an explicit
-`setupScript` parameter is supplied, the daemon writes it into
-`<worktree-root>/.intent/config.json` (best-effort, warn on failure) after worktree
-provisioning, using merge semantics — unrelated keys (e.g., `setupScript`, `scripts`) are preserved;
-writes are no-op when the existing value is identical. The `.intent/config.json` file
-becomes the sole source of truth for the setup script; the workspace DB `setup_script`
-field is retired from all write paths (kept for wire compat and legacy read-only
-fallback only). After the config write, if an effective setup script exists (non-empty,
-resolved via worktree-first `.intent/config.json` read with legacy DB fallback), the
-daemon executes it non-blocking (fire-and-forget spawn) in the worktree directory via
+**Setup script execution (`workspace.create`).** The `setupScript` parameter is
+**execute-only**: when supplied, the daemon executes the script as provided for that
+creation (taking precedence over the committed repo config) but **never persists** it —
+nothing is written to `<worktree-root>/.intent/config.json`, and the create path
+performs no workspace DB `setup_script` write (the field is retired from all write
+paths, kept for wire compat and legacy read-only fallback only). The worktree
+`.intent/config.json` remains the sole persisted source of truth, mutated only by the
+explicit write paths `workspace.saveSetupScript` (§5.25) and `repoConfig.save` (§5.33).
+When the parameter is omitted, the effective script resolves via the unchanged
+worktree-first `.intent/config.json` read with legacy DB fallback. FE contract:
+cloudlands-fe always sends the script shown in the create form, except when it is the
+unedited repo-config script (so the committed config stays authoritative); the
+"last used for this repo" default is kept client-side. If an effective setup script
+exists (non-empty), the daemon executes it non-blocking (fire-and-forget spawn) after
+worktree provisioning in the worktree directory via
 `/bin/sh` (POSIX; on Windows, via a discovered Git-for-Windows `sh.exe` running the same
 POSIX wrapper, falling back to a `cmd.exe` `.cmd` wrapper that receives the script path
 through the `INTENT_SETUP_SCRIPT` env var) with env vars `MAIN_CHECKOUT` (repository root path), `WORKTREE_PATH`
@@ -3761,7 +3766,8 @@ read-only fallback only). `detectProjectType` inspects manifest files to classif
 `generateSetupScript` is the **AI-assisted** generator. Every method requires `workspaceId`.
 
 **Setup script execution:** When a workspace is created (`workspace.create`) and an effective
-setup script exists (non-empty, resolved from worktree `.intent/config.json` or legacy DB
+setup script exists (non-empty, resolved from an explicit `setupScript` param — execute-only,
+never persisted, §5.1 — else from worktree `.intent/config.json` or legacy DB
 fallback), the daemon executes it non-blocking (fire-and-forget spawn) after worktree
 provisioning in the worktree directory via `/bin/sh` (POSIX; on Windows, via a discovered
 Git-for-Windows `sh.exe` running the same POSIX wrapper, falling back to a `cmd.exe` `.cmd`

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -788,7 +788,8 @@ a replayed create returns the stored result and does not re-seed.
 
 **Setup script execution (`workspace.create`).** The `setupScript` parameter is
 **execute-only**: when supplied, the daemon executes the script as provided for that
-creation (taking precedence over the committed repo config) but **never persists** it —
+creation (taking precedence over the committed repo config; an empty supplied script is
+treated as omitted) but **never persists** it —
 nothing is written to `<worktree-root>/.intent/config.json`, and the create path
 performs no workspace DB `setup_script` write (the field is retired from all write
 paths, kept for wire compat and legacy read-only fallback only). The worktree


### PR DESCRIPTION
## Summary

Phase-2 monorepo follow-up for the execute-only setup-script feature (references intent-hq/monorepo#1870, already auto-closed by the component PRs):

- **docs/PROTOCOL.md §5.1** — rewrites the `workspace.create` setup-script paragraph from *persist-and-execute* to **execute-only** semantics: an explicit `setupScript` param executes as provided (taking precedence over the committed repo config) but is never written to `.intent/config.json` nor the workspace DB; the omitted-param worktree-first committed-config read is unchanged. Also notes the FE contract (form script always sent except the unedited repo-config script; last-used default kept client-side) and aligns the §5.25 execution paragraph's resolution wording. `workspace.saveSetupScript` (§5.25) and `repoConfig.save` (§5.33) remain the only persistence paths — their wording is untouched.
- **Submodule bumps** — `packages/cloudlands-fe` → `72e2bfaf` (latest main, includes [intent-hq/cloudlands-fe#994](https://github.com/intent-hq/cloudlands-fe/pull/994)). `packages/intentd` already points at `d7d76d29` on main (includes [intent-hq/intentd#1066](https://github.com/intent-hq/intentd/pull/1066)); no further ref change needed after rebase.

## Component PRs

- Daemon: [intent-hq/intentd#1066](https://github.com/intent-hq/intentd/pull/1066) (merged first, squash `0730405e`)
- FE: [intent-hq/cloudlands-fe#994](https://github.com/intent-hq/cloudlands-fe/pull/994) (merged second, squash `72e2bfaf`)

## Verification

- `make check` — fmt, clippy `-D warnings`, build: all green
- `make test` — 5899 passed, 1 skipped
- `rg -n "setupScript" docs/PROTOCOL.md` swept for stale create-path-write mentions
