### PR TITLE
docs: clarify PR merge instructions in AGENTS.md (no merge queue)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,12 +67,15 @@ submodule refs).
 - **Conventional commits** are required. PR titles are validated by CI
   (`amannn/action-semantic-pull-request`) against: `feat`, `fix`, `chore`, `docs`,
   `refactor`, `test`, `ci`, `perf`.
-- **Merging**: The repository allows squash and rebase merges. When squash-merging, the
-  commit title defaults to the commit message (or PR title as fallback), and the commit
-  message includes all commit messages from the PR. On single-commit PRs, ensure the branch
-  commit message is itself a valid conventional commit (amend auto-commits like
-  "Coordinator" before pushing) to prevent non-conventional commits from landing on main
-  (e.g., PR #102 incident).
+- **Merging**: The repository allows squash and rebase merges; no merge queue is enabled.
+  Merge with `gh pr merge --squash` (optionally `--auto` to merge once checks pass). The
+  GraphQL `enqueuePullRequest` mutation fails with "Merge queues are not enabled" — it is
+  only relevant if a merge queue is re-enabled later. When squash-merging, the commit
+  title defaults to the commit message (or PR title as fallback), and the commit message
+  includes all commit messages from the PR. On single-commit PRs, ensure the branch commit
+  message is itself a valid conventional commit (amend auto-commits like "Coordinator"
+  before pushing) to prevent non-conventional commits from landing on main (e.g., PR #102
+  incident).
 - **Changelogs** are generated with `git-cliff` (see `cliff.toml`).
 - **Rust**: keep `cargo fmt --check`, `cargo clippy -- -D warnings`, and `cargo build`
   green in `packages/intentd` before opening a PR. The **monorepo-root** `Makefile` exposes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,7 +70,7 @@ submodule refs).
 - **Merging**: The repository allows squash and rebase merges; no merge queue is enabled.
   Merge with `gh pr merge --squash` (optionally `--auto` to merge once checks pass). The
   GraphQL `enqueuePullRequest` mutation fails with "Merge queues are not enabled" — it is
-  only relevant if a merge queue is re-enabled later. When squash-merging, the commit
+  only relevant if a merge queue is enabled later. When squash-merging, the commit
   title defaults to the commit message (or PR title as fallback), and the commit message
   includes all commit messages from the PR. On single-commit PRs, ensure the branch commit
   message is itself a valid conventional commit (amend auto-commits like "Coordinator"


### PR DESCRIPTION
Updates the "Merging" bullet under Conventions in AGENTS.md to give explicit merge instructions matching the repo's actual settings:

- Merge PRs with `gh pr merge --squash` (optionally `--auto` to merge once checks pass) — no merge queue is enabled on this repository.
- Notes that the GraphQL `enqueuePullRequest` mutation fails with "Merge queues are not enabled" and is only relevant if a merge queue is re-enabled later (kept as a reference).
- Keeps the existing warning that on single-commit PRs the squash commit message defaults to the sole commit's message, so every branch commit must itself be a valid conventional commit.

Context: during the recent submodule-bump effort (#1956, #1957, #1958, #1961), agents confirmed the merge queue is disabled and all merges went through `gh pr merge --squash`.
