### PR TITLE
ci: auto-advance submodule pins via auto-bump workflow

### DIFF
--- a/.github/workflows/auto-bump-submodules.yml
+++ b/.github/workflows/auto-bump-submodules.yml
@@ -1,0 +1,46 @@
+name: Auto-bump submodules
+
+on:
+  schedule:
+    - cron: "*/30 * * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: auto-bump-submodules
+  cancel-in-progress: false
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      # Fail-soft: without the token, warn and end the run successfully
+      # (mirrors INTENTD_RELEASES_TOKEN / MONOREPO_ISSUES_TOKEN handling).
+      - name: Check for SUBMODULE_BUMP_TOKEN
+        id: token
+        env:
+          SUBMODULE_BUMP_TOKEN: ${{ secrets.SUBMODULE_BUMP_TOKEN }}
+        run: |
+          if [ -n "$SUBMODULE_BUMP_TOKEN" ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::SUBMODULE_BUMP_TOKEN is not set; skipping submodule auto-bump."
+            echo "present=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # The PAT is persisted as the credential for github.com, so both the
+      # ls-remote reads of the submodule repos and the branch push use it.
+      - name: Checkout
+        if: steps.token.outputs.present == 'true'
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.SUBMODULE_BUMP_TOKEN }}
+          submodules: false
+
+      - name: Bump submodule pins
+        if: steps.token.outputs.present == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.SUBMODULE_BUMP_TOKEN }}
+        run: bash scripts/auto-bump-submodules.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,8 @@ The durable engineering docs live in `docs/ARCHITECTURE.md` (backend architectur
 
 ## Commit & PR Workflow
 
-When changes span a submodule and the monorepo, follow this sequence: Phase 1 → Phase 2.
+When changes span a submodule and the monorepo, land the submodule PR (Phase 1); the
+monorepo pin advance (Phase 2) then happens automatically.
 
 ### Phase 1 — Submodule PRs
 
@@ -38,15 +39,32 @@ When the change fixes a monorepo issue, reference it with the full cross-repo fo
 auto-closes the issue on merge, and the release notifier (see Release Process) comments
 on it when the fix ships in a release.
 
-### Phase 2 — Monorepo Update
+### Phase 2 — Monorepo pin advance (automated)
 
-1. Pull latest `main` in the updated submodule so it points to the newly merged commit.
-2. **Stage the submodule ref change** in the monorepo (`git add packages/<name>`).
-3. **Commit** with a message like `chore: update <name> submodule to latest main`.
-4. **Push** the monorepo branch.
-5. **File a PR** on the monorepo repo (`intent-hq/monorepo`). Reference the submodule PR
-   in the body.
-6. **Merge the monorepo PR**.
+Submodule pins are advanced automatically by the `auto-bump-submodules` workflow
+(`.github/workflows/auto-bump-submodules.yml`): a cron run every 30 minutes (plus
+manual dispatch) detects submodule tips ahead of the recorded pins and lands the bump
+via a single rolling PR on the `auto/submodule-bump` branch with auto-merge armed;
+repeat runs update that PR instead of opening new ones.
+
+**Agents (and humans) must NOT file manual submodule bump PRs on the monorepo.** The
+workflow owns pin advancement. If an urgent bump is needed, dispatch the workflow
+manually instead of filing a PR:
+
+```bash
+gh workflow run auto-bump-submodules.yml
+```
+
+Regular monorepo PRs for actual content changes (docs, Makefile, CI, scripts) are
+unaffected and still follow the normal PR flow.
+
+The workflow authenticates with the `SUBMODULE_BUMP_TOKEN` secret — a fine-grained PAT
+with contents:read on `intent-hq/intentd`, `intent-hq/cloudlands-fe`, and
+`intent-hq/ios`, plus contents:write and pull-requests:write on `intent-hq/monorepo`.
+Like `INTENTD_RELEASES_TOKEN` / `MONOREPO_ISSUES_TOKEN`, it is fail-soft: when the
+secret is absent the workflow logs a warning and exits successfully. The private
+`packages/ios` submodule is best-effort — if its tip cannot be read, it is skipped
+with a warning and never fails the run.
 
 ### Cross-component features (intentd + cloudlands-fe)
 
@@ -58,9 +76,10 @@ is not enough. This intentd-first rule applies specifically to protocol changes 
 daemon↔fe wire contract, `docs/PROTOCOL.md`): whenever a feature touches the protocol,
 the daemon side must land first. Rationale: cloudlands-fe may depend on daemon
 behavior/protocol that only exists once the intentd change has landed, so an fe-first
-merge can break main or ship against a contract that doesn't exist yet. After both are
-merged, the normal Phase 2 submodule bump applies (a single monorepo PR may bump both
-submodule refs).
+merge can break main or ship against a contract that doesn't exist yet. This rule is
+about submodule PR merges, not monorepo bumps — after both are merged, the
+auto-bump-submodules workflow advances both monorepo pins automatically (a single
+rolling bump PR may cover both submodule refs); do not file a manual bump PR.
 
 ## Conventions
 
@@ -136,7 +155,8 @@ workflow dispatch.
 ### Coordinated Release Ordering
 
 intentd release → promote intentd stable → cloudlands-fe pin-bump PR → cloudlands-fe
-release → promote cloudlands-fe stable → monorepo submodule bump PR.
+release → promote cloudlands-fe stable → monorepo pins advance automatically via the
+auto-bump workflow (no manual bump PR).
 
 ### Gotchas
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,12 +50,15 @@ Changes that touch a submodule land in two phases:
 1. **Phase 1 — submodule PR.** Make scoped, conventional commits on a feature
    branch in the submodule repo (e.g. `intent-hq/intentd`), open a PR there, and
    merge it (squash merge preferred).
-2. **Phase 2 — monorepo gitlink bump.** Point the submodule at the newly merged
-   commit, commit the pointer change in the monorepo (e.g.
-   `chore: update intentd submodule to latest main`), and open a monorepo PR that
-   references the submodule PR.
+2. **Phase 2 — automated monorepo pin advance.** The `auto-bump-submodules`
+   workflow (cron every 30 minutes, plus manual dispatch) advances the monorepo's
+   submodule pins to the merged tips via a single rolling auto-merged PR on the
+   `auto/submodule-bump` branch. **Do not file manual submodule bump PRs** — if an
+   urgent bump is needed, dispatch the workflow manually
+   (`gh workflow run auto-bump-submodules.yml`) instead of opening a PR.
 
-Monorepo-only changes (docs, CI, templates) need only a single monorepo PR.
+Monorepo-only changes (docs, Makefile, CI, scripts, templates) are unaffected by
+the automation and need only a single normal monorepo PR.
 
 ## Conventional commits
 

--- a/scripts/auto-bump-submodules.sh
+++ b/scripts/auto-bump-submodules.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# Detect submodule tip drift and land pin bumps via an auto-merged PR.
+#
+# For each submodule in .gitmodules, the gitlink recorded in monorepo HEAD is
+# compared against the remote branch tip (git ls-remote; submodules are never
+# cloned). If any pin differs, the remote tip wins (pins track main): the
+# auto/submodule-bump branch is force-updated with the new gitlink(s), pushed,
+# and a PR is created or updated with auto-merge (squash) enabled.
+#
+# packages/ios is best-effort: if its remote tip cannot be read (private repo,
+# no token access), it is skipped with a warning and never fails the run.
+#
+# Usage: auto-bump-submodules.sh [--dry-run]
+#   --dry-run  Report which pins are behind; never writes, pushes, or
+#              touches PRs. Requires only ambient git auth (no gh).
+set -euo pipefail
+
+BRANCH="auto/submodule-bump"
+DRY_RUN=0
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=1 ;;
+    *) echo "error: unknown argument: $arg" >&2; exit 2 ;;
+  esac
+done
+
+if [ ! -f .gitmodules ]; then
+  echo "error: .gitmodules not found; run from the monorepo root" >&2
+  exit 1
+fi
+
+warn() { echo "warning: $*" >&2; }
+
+# Collect drifted submodules (parallel arrays).
+paths=()
+names=()
+olds=()
+news=()
+repos=()
+while read -r key path; do
+  name=${key#submodule.}
+  name=${name%.path}
+  url=$(git config -f .gitmodules --get "submodule.$name.url")
+  branch=$(git config -f .gitmodules --get "submodule.$name.branch" || true)
+  branch=${branch:-main}
+
+  if ! old=$(git rev-parse --verify --quiet "HEAD:$path"); then
+    warn "$path: no gitlink recorded in HEAD; skipping"
+    continue
+  fi
+
+  if ! tip_line=$(git ls-remote "$url" "refs/heads/$branch") || [ -z "$tip_line" ]; then
+    if [ "$path" = "packages/ios" ]; then
+      warn "$path: cannot read remote tip (no token access?); skipping"
+      continue
+    fi
+    echo "error: $path: git ls-remote $url refs/heads/$branch failed" >&2
+    exit 1
+  fi
+  new=${tip_line%%[[:space:]]*}
+
+  if [ "$old" = "$new" ]; then
+    echo "$path: up to date at ${old:0:7}"
+    continue
+  fi
+
+  repo=${url#https://github.com/}
+  repo=${repo%.git}
+  echo "$path: behind (${old:0:7} -> ${new:0:7})"
+  paths+=("$path")
+  names+=("${path##*/}")
+  olds+=("$old")
+  news+=("$new")
+  repos+=("$repo")
+done < <(git config -f .gitmodules --get-regexp '^submodule\..*\.path$')
+
+if [ ${#paths[@]} -eq 0 ]; then
+  echo "All submodule pins match their remote tips; nothing to do."
+  exit 0
+fi
+
+if [ "$DRY_RUN" = 1 ]; then
+  echo "dry-run: would bump ${#paths[@]} submodule pin(s) via branch $BRANCH"
+  exit 0
+fi
+
+# "intentd" / "intentd and cloudlands-fe" / "intentd, cloudlands-fe and ios"
+join_names() {
+  local n=${#names[@]} out i
+  out=${names[0]}
+  for ((i = 1; i < n - 1; i++)); do out+=", ${names[i]}"; done
+  if [ "$n" -gt 1 ]; then out+=" and ${names[n - 1]}"; fi
+  printf '%s' "$out"
+}
+
+plural=submodule
+if [ ${#names[@]} -gt 1 ]; then plural=submodules; fi
+title="chore: update $(join_names) $plural to latest main"
+
+commit_body=""
+for i in "${!paths[@]}"; do
+  commit_body+="${paths[i]}: ${olds[i]:0:7} -> ${news[i]:0:7}"$'\n'
+done
+
+export GIT_AUTHOR_NAME=${GIT_AUTHOR_NAME:-github-actions[bot]}
+export GIT_AUTHOR_EMAIL=${GIT_AUTHOR_EMAIL:-41898282+github-actions[bot]@users.noreply.github.com}
+export GIT_COMMITTER_NAME=${GIT_COMMITTER_NAME:-$GIT_AUTHOR_NAME}
+export GIT_COMMITTER_EMAIL=${GIT_COMMITTER_EMAIL:-$GIT_AUTHOR_EMAIL}
+
+tmp_index=$(mktemp)
+pr_body_file=$(mktemp)
+trap 'rm -f "$tmp_index" "$pr_body_file"' EXIT
+
+# Build the bumped tree in a temporary index; the worktree is never touched.
+head=$(git rev-parse HEAD)
+GIT_INDEX_FILE=$tmp_index git read-tree "$head"
+for i in "${!paths[@]}"; do
+  GIT_INDEX_FILE=$tmp_index git update-index --cacheinfo "160000,${news[i]},${paths[i]}"
+done
+tree=$(GIT_INDEX_FILE=$tmp_index git write-tree)
+
+# Skip the push when the remote branch already carries this exact tree, so
+# repeated runs don't churn the PR (and its CI) with identical commits.
+push_needed=1
+if git fetch --quiet origin "refs/heads/$BRANCH" 2>/dev/null; then
+  if [ "$(git rev-parse --verify --quiet 'FETCH_HEAD^{tree}' || true)" = "$tree" ]; then
+    push_needed=0
+    echo "Branch $BRANCH already has the desired pins; skipping push."
+  fi
+fi
+if [ "$push_needed" = 1 ]; then
+  commit=$(git commit-tree "$tree" -p "$head" -m "$title" -m "$commit_body")
+  git push --force origin "$commit:refs/heads/$BRANCH"
+  echo "Pushed $commit to $BRANCH."
+fi
+
+{
+  echo "Automated submodule pin bump: pins track each submodule's \`main\` branch tip."
+  echo
+  echo "| Submodule | Old | New | Compare |"
+  echo "|---|---|---|---|"
+  for i in "${!paths[@]}"; do
+    compare="https://github.com/${repos[i]}/compare/${olds[i]}...${news[i]}"
+    echo "| ${paths[i]} | ${olds[i]:0:7} | ${news[i]:0:7} | [${olds[i]:0:7}...${news[i]:0:7}]($compare) |"
+  done
+} > "$pr_body_file"
+
+pr=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number // empty')
+if [ -n "$pr" ]; then
+  gh pr edit "$pr" --title "$title" --body-file "$pr_body_file"
+  echo "Updated existing PR #$pr."
+else
+  gh pr create --head "$BRANCH" --title "$title" --body-file "$pr_body_file"
+  pr=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number // empty')
+  echo "Created PR #$pr."
+fi
+
+if ! gh pr merge "$pr" --auto --squash; then
+  warn "could not enable auto-merge on PR #$pr; leaving it open"
+fi


### PR DESCRIPTION
Adds an auto-bump-submodules workflow (30-min cron + manual dispatch) that detects submodule tip drift via git ls-remote and lands pin bumps through a single rolling auto-merged PR on the auto/submodule-bump branch. Fail-soft when the SUBMODULE_BUMP_TOKEN secret is absent; packages/ios is best-effort (warn + skip). AGENTS.md and CONTRIBUTING.md updated: agents must NOT file manual submodule bump PRs — urgent bumps go through manual workflow dispatch. Normal monorepo PRs (docs/Makefile/CI/scripts) are unaffected.