### PR TITLE
ci: trigger submodule auto-bump via repository_dispatch from submodule repos

### DIFF
--- a/.github/workflows/auto-bump-submodules.yml
+++ b/.github/workflows/auto-bump-submodules.yml
@@ -4,6 +4,8 @@ on:
   schedule:
     - cron: "*/30 * * * *"
   workflow_dispatch:
+  repository_dispatch:
+    types: [submodule-update]
 
 permissions:
   contents: read

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,10 +42,17 @@ on it when the fix ships in a release.
 ### Phase 2 — Monorepo pin advance (automated)
 
 Submodule pins are advanced automatically by the `auto-bump-submodules` workflow
-(`.github/workflows/auto-bump-submodules.yml`): a cron run every 30 minutes (plus
-manual dispatch) detects submodule tips ahead of the recorded pins and lands the bump
-via a single rolling PR on the `auto/submodule-bump` branch with auto-merge armed;
-repeat runs update that PR instead of opening new ones.
+(`.github/workflows/auto-bump-submodules.yml`): it detects submodule tips ahead of the
+recorded pins and lands the bump via a single rolling PR on the `auto/submodule-bump`
+branch with auto-merge armed; repeat runs update that PR instead of opening new ones.
+The workflow is triggered three ways: each submodule repo notifies the monorepo on push
+to `main` via a `repository_dispatch` event (`submodule-update` type), so bumps normally
+land within about a minute of a submodule merge; a cron run every 30 minutes acts as a
+backstop; and manual `workflow_dispatch` is available for urgent bumps. The
+`repository_dispatch` notifications are sent by the submodule repos using the
+`MONOREPO_DISPATCH_TOKEN` secret (stored in each submodule repo; a fine-grained PAT with
+contents:write on `intent-hq/monorepo`), and are fail-soft: when the secret is absent
+the notify step logs a warning and skips, and the cron backstop still advances the pins.
 
 **Agents (and humans) must NOT file manual submodule bump PRs on the monorepo.** The
 workflow owns pin advancement. If an urgent bump is needed, dispatch the workflow

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,10 +51,12 @@ Changes that touch a submodule land in two phases:
    branch in the submodule repo (e.g. `intent-hq/intentd`), open a PR there, and
    merge it (squash merge preferred).
 2. **Phase 2 — automated monorepo pin advance.** The `auto-bump-submodules`
-   workflow (cron every 30 minutes, plus manual dispatch) advances the monorepo's
-   submodule pins to the merged tips via a single rolling auto-merged PR on the
-   `auto/submodule-bump` branch. **Do not file manual submodule bump PRs** — if an
-   urgent bump is needed, dispatch the workflow manually
+   workflow (triggered by `repository_dispatch` from submodule merges for
+   ~1-minute latency, with a 30-minute cron backstop, plus manual dispatch)
+   advances the monorepo's submodule pins to the merged tips via a single
+   rolling auto-merged PR on the `auto/submodule-bump` branch. **Do not file
+   manual submodule bump PRs** — if an urgent bump is needed, dispatch the
+   workflow manually
    (`gh workflow run auto-bump-submodules.yml`) instead of opening a PR.
 
 Monorepo-only changes (docs, Makefile, CI, scripts, templates) are unaffected by


### PR DESCRIPTION
Make the monorepo auto-bump workflow respond to `repository_dispatch` events sent by submodule repos, so pin bumps land within ~a minute of a submodule merge instead of waiting for the 30-minute cron (which remains as a backstop).

## Changes

- `.github/workflows/auto-bump-submodules.yml`: add `repository_dispatch` with `types: [submodule-update]` alongside the existing `schedule` + `workflow_dispatch` triggers. No script changes — drift detection in `scripts/auto-bump-submodules.sh` is trigger-agnostic.
- `AGENTS.md`: document the new immediacy path in the Phase 2 auto-bump section — submodule repos notify the monorepo on push to `main` via `repository_dispatch` (`submodule-update` event) using the `MONOREPO_DISPATCH_TOKEN` secret (stored in each submodule repo; fine-grained PAT with contents:write on `intent-hq/monorepo`; fail-soft when absent, with the cron backstop still advancing pins).

## Verification

- `actionlint .github/workflows/auto-bump-submodules.yml` — clean (actionlint 1.7.12).
- Grepped `AGENTS.md` for `MONOREPO_DISPATCH_TOKEN` / `repository_dispatch` / `submodule-update` consistency with the workflow trigger.

The companion notify workflows in the submodule repos (senders of the dispatch event) are being added separately.
