### PR TITLE
fix: probe cargo subcommands instead of command -v in Makefile guards

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -233,7 +233,7 @@ test: test-intentd ## Run the Rust test suite (cargo nextest; needs cargo-nextes
 # retries, slow-timeout). nextest does not run doctests; the workspace has
 # none, so nothing is lost.
 test-intentd: ensure-intentd-submodule
-	@command -v cargo-nextest >/dev/null 2>&1 || { \
+	@cargo nextest --version >/dev/null 2>&1 || { \
 		echo "[test-intentd] ERROR: cargo-nextest is not installed — run 'cargo install cargo-nextest --locked'"; \
 		exit 1; \
 	}
@@ -249,7 +249,7 @@ clean-dev: ## Wipe the dev-seat state dir (.dev/)
 # initializing the submodule just to sweep a target/ dir that cannot exist yet
 # would be overkill, so it short-circuits with a friendly no-op instead.
 sweep: ## Prune intentd build artifacts older than $(SWEEP_DAYS) days (needs cargo-sweep)
-	@command -v cargo-sweep >/dev/null 2>&1 || { \
+	@cargo sweep --version >/dev/null 2>&1 || { \
 		echo "[sweep] ERROR: cargo-sweep is not installed — run 'cargo install cargo-sweep'"; \
 		exit 1; \
 	}
@@ -260,7 +260,7 @@ sweep: ## Prune intentd build artifacts older than $(SWEEP_DAYS) days (needs car
 	fi
 
 sweep-all: ## Sweep intentd build artifacts in every worktree under $(WORKSPACES_DIR)
-	@command -v cargo-sweep >/dev/null 2>&1 || { \
+	@cargo sweep --version >/dev/null 2>&1 || { \
 		echo "[sweep-all] ERROR: cargo-sweep is not installed — run 'cargo install cargo-sweep'"; \
 		exit 1; \
 	}


### PR DESCRIPTION
The three tool guards in the root Makefile (`test-intentd`, `sweep`, `sweep-all`) probed the binary name with `command -v cargo-nextest` / `command -v cargo-sweep`, which false-negatives on working setups: cargo resolves external subcommands from `$CARGO_HOME/bin` regardless of `PATH`, so the guard could block a run that would have succeeded.

This changes the guards to probe the capability instead:

- `test-intentd`: `command -v cargo-nextest` → `cargo nextest --version >/dev/null 2>&1`
- `sweep`: `command -v cargo-sweep` → `cargo sweep --version >/dev/null 2>&1`
- `sweep-all`: same as `sweep`

Error messages and `exit 1` semantics are unchanged. No `PATH` mutation in recipes.

## Verification

- `cargo sweep --version` confirmed supported (cargo-sweep 0.8.0 prints `cargo-sweep-sweep 0.8.0`, exit 0).
- Positive, PATH-stripped (`PATH="/usr/bin:/bin:/tmp/cargo-only"` where `/tmp/cargo-only` holds only a `cargo` symlink, so neither `cargo-nextest` nor `cargo-sweep` is on `PATH`):
  - `command -v cargo-nextest` / `command -v cargo-sweep` exit 127 (old guards would have tripped);
  - `cargo nextest --version` / `cargo sweep --version` exit 0 (new probes pass);
  - `make sweep` passes the guard (no-ops: no `target/` dir);
  - `make test-intentd` passes the guard and reaches `cargo nextest run --workspace`.
- Negative: `cargo definitely-not-a-subcommand --version` exits 101 (non-zero), so the guard still trips when the tool is absent.
- Full `make test` green: 6266 tests run, 6266 passed, 1 skipped.

Fixes intent-hq/monorepo#2066
