### PR TITLE
docs: idleReapMinutes now defaults to 10, and memoryBudgetMb bounds to real RAM

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -674,17 +674,20 @@ reached by an agent doing exactly what agents are for — three concurrent test
 runs projects to ~29 GB (3 × the measured 9.6 GB, not itself a capture), an
 ordinary coordinator fan-out.
 
-**The tree is retained, not leaked.** At the shipped `agents.idleReapMinutes
-= 30`, every agent touched inside the window stays resident (monorepo#2109,
-measured on real `claude-code` chains, 10 agents driven to idle then left
-alone):
+**The tree is retained, not leaked.** Every agent touched inside the
+`agents.idleReapMinutes` window stays resident (monorepo#2109, measured on
+real `claude-code` chains, 10 agents driven to idle then left alone):
 
 | `idleReapMinutes` | After idle | Result |
 | --- | --- | --- |
-| **30 (shipped default)** | 10 minutes | **40 procs / 5.85 GB, flat — zero processes exited** |
+| **30 (default until monorepo#2109)** | 10 minutes | **40 procs / 5.85 GB, flat — zero processes exited** |
 | 2 | 122 s after last turn | **0 procs / 0 GB — drained completely** |
 
-The reaper works; it simply is not asked to run for half an hour. An agent
+The reaper works; it was simply not asked to run for half an hour. That
+measurement is what moved the shipped default to **10 minutes**: the same tree
+begins draining once the window passes rather than holding 5.85 GB for a
+further 20 minutes, and the 30-minute row above now describes the old default
+rather than the shipped one. An agent
 becomes a candidate at the TTL and is picked up by the next sweep (interval
 `ttl/4` clamped to `[30s, 300s]`, `reap_timings` in the `intentd` binary
 crate), so **selection** is bounded by TTL + one sweep — but release is not
@@ -704,8 +707,8 @@ self-described at the point of use in `DEFAULT_CONFIG_TEMPLATE`,
 
 | Knob | Default | Bounds |
 | --- | --- | --- |
-| `idleReapMinutes` | `30` | How long an idle agent subtree is retained. **The lever for a memory-constrained seat.** |
-| `memoryBudgetMb` | `0` (off) | Aggregate RSS of the whole child tree, as a soft admission gate on new spawns. |
+| `idleReapMinutes` | `10` | How long an idle agent subtree is retained (`0` disables reaping). **The lever for a memory-constrained seat.** |
+| `memoryBudgetMb` | `0` (off) | Aggregate RSS of the whole child tree, as a soft admission gate on new spawns. Catalog max is the machine's own physical RAM. |
 | `maxConcurrentAdapters` | `6` (on) | Concurrently live ephemeral adapter chains (quick actions, model probes). |
 | `maxConcurrent` | `0` (auto from RAM) | Agent **slots**. Not a memory bound — see the 22× range above. |
 
@@ -729,6 +732,11 @@ self-described at the point of use in `DEFAULT_CONFIG_TEMPLATE`,
   re-checked and can carry the tree past the budget by itself, and the gate's
   only lever against that is refusing later spawns and evicting idle trees.
   Admission only — nothing running is ever killed, and all turns complete.
+  The settings catalog advertises the bound as `min 0` / `max` = detected
+  physical RAM in MB (a static 1,024,000 MB where detection is unavailable —
+  Linux/macOS only), so a client renders a slider over the range the setting
+  can meaningfully take; the `config.toml` parse bound stays at the static
+  figure so a config file written on one seat still parses on another.
 - **`maxConcurrentAdapters` closes the quick-action burst path**
   (monorepo#2062). One-shot completions and model probes never enter
   `ProcessRegistry`, so they consume no `maxConcurrent` slot and do not appear
@@ -759,14 +767,21 @@ one** — the inverted conclusion. Steady state is accurate (a running soak read
 5.85 GB by both methods); the field aliases only on transients, which is
 precisely the case it was introduced for.
 
-**Defaults deliberately stay as they are** (decision recorded on
-monorepo#2109). Reaping earlier costs every user a warm process on next use,
-and the measured accumulation is a function of how many agents a seat touches
-— which differs enormously between a single-agent user and a coordinator
-fanning out a dozen. A default that suits one badly hurts the other, and both
-bounds already exist for anyone who needs them. A seat hitting the
-accumulation path should reach for `idleReapMinutes` first, then
-`memoryBudgetMb`.
+**`idleReapMinutes` now defaults to 10, not 30** (monorepo#2109, reversing the
+earlier decision on that issue to leave defaults alone). The reasoning that
+originally argued for holding still is unchanged and is what keeps the new
+default off the floor: reaping earlier costs every user a warm process on next
+use, and the measured accumulation is a function of how many agents a seat
+touches — which differs enormously between a single-agent user and a
+coordinator fanning out a dozen. What changed is the read on where the
+midpoint sits. 30 minutes is long enough that the two cases converge in the
+worst direction — the coordinator holds every subtree it touched all session
+(the 5.85 GB flat row above), and the single-agent user gains a warm process
+they were unlikely to return to that late anyway. 10 minutes keeps the warm
+path for the case that actually re-enters an agent while bounding what a
+fan-out retains, and `0` still disables reaping entirely for anyone who wants
+the old unbounded behaviour. A seat still hitting the accumulation path should
+reach for `idleReapMinutes` first, then `memoryBudgetMb`.
 
 ## Read-path performance principles
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -683,6 +683,13 @@ real `claude-code` chains, 10 agents driven to idle then left alone):
 | **30 (default until monorepo#2109)** | 10 minutes | **40 procs / 5.85 GB, flat — zero processes exited** |
 | 2 | 122 s after last turn | **0 procs / 0 GB — drained completely** |
 
+Retention claims in this section describe the **idle-reap sweep** with
+`memoryBudgetMb` off, which is the shipped default. A non-zero budget adds a
+second, independent eviction path: `ProcessRegistry::evict_idle` takes no TTL
+and drops the LRU idle subtree to admit a spawn, so with a budget set an idle
+tree can go before its TTL and none of the retention figures below are
+guaranteed floors.
+
 The reaper works; it was simply not asked to run for half an hour. That
 measurement is what moved the shipped default to **10 minutes**: the same tree
 begins draining once the window passes rather than holding 5.85 GB for a
@@ -708,9 +715,10 @@ a large idle set drains over a tail rather than all at once. Only processes
 idle past the TTL are candidates, and the sweep skips any agent the manager
 reports busy when it checks (`AgentManager::reap_idle_older_than`'s
 eligibility predicate).
-Consequence for sizing: a seat that touches 20 agents within the window holds
-all 20 subtrees at once even if only one is active — projecting to ~12 GB at
-the measured ~0.6 GB idle median, more if any of them ran a test suite.
+Consequence for sizing: with the budget off, a seat that touches 20 agents
+within the window holds all 20 subtrees at once even if only one is active —
+projecting to ~12 GB at the measured ~0.6 GB idle median, more if any of them
+ran a test suite.
 
 **The knobs**, all under the `[agents]` table in `config.toml` (each is
 self-described at the point of use in `DEFAULT_CONFIG_TEMPLATE`,
@@ -788,16 +796,17 @@ precisely the case it was introduced for.
 **`idleReapMinutes` now defaults to 10, not 30** — on new installs; see the
 upgrade note above for why an existing seat is unaffected (monorepo#2109,
 reversing the earlier decision on that issue to leave defaults alone). The
-reasoning that
-originally argued for holding still is unchanged and is what keeps the new
-default off the floor: reaping earlier costs every user a warm process on next
+reasoning that originally argued for holding still is unchanged and is what
+keeps the new default off the floor: reaping earlier costs every user a warm
+process on next
 use, and the measured accumulation is a function of how many agents a seat
 touches — which differs enormously between a single-agent user and a
 coordinator fanning out a dozen. What changed is the read on where the
 midpoint sits. 30 minutes is long enough that the two cases converge in the
-worst direction — the coordinator holds every subtree it touched anywhere in
-that half-hour window, re-extending it on each fan-out (the 5.85 GB flat row
-above measured 10 minutes of that, not a whole session), while the single-agent
+worst direction — with the budget off, the coordinator holds every subtree it
+touched anywhere in that half-hour window, re-extending it on each fan-out (the
+5.85 GB flat row above measured 10 minutes of that, not a whole session), while
+the single-agent
 user gains a warm process they were unlikely to return to that late anyway. 10
 minutes keeps the warm path for the case that actually re-enters an agent while
 bounding what a fan-out retains, and `0` still turns the sweep off entirely for

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -719,7 +719,7 @@ self-described at the point of use in `DEFAULT_CONFIG_TEMPLATE`,
 | Knob | Default | Bounds |
 | --- | --- | --- |
 | `idleReapMinutes` | `10` (new installs; an existing `config.toml` keeps its own value — see above) | How long an idle agent subtree is retained (`0` disables reaping). **The lever for a memory-constrained seat.** |
-| `memoryBudgetMb` | `0` (off) | Aggregate RSS of the whole child tree, as a soft admission gate on new spawns. Catalog max is the machine's own physical RAM. |
+| `memoryBudgetMb` | `0` (off) | Aggregate RSS of the whole child tree, as a soft admission gate on new spawns. Catalog max is the machine's own physical RAM, capped at 1,024,000 MB. |
 | `maxConcurrentAdapters` | `6` (on) | Concurrently live ephemeral adapter chains (quick actions, model probes). |
 | `maxConcurrent` | `0` (auto from RAM) | Agent **slots**. Not a memory bound — see the 22× range above. |
 
@@ -744,10 +744,17 @@ self-described at the point of use in `DEFAULT_CONFIG_TEMPLATE`,
   only lever against that is refusing later spawns and evicting idle trees.
   Admission only — nothing running is ever killed, and all turns complete.
   The settings catalog advertises the bound as `min 0` / `max` = detected
-  physical RAM in MB (a static 1,024,000 MB where detection is unavailable —
-  Linux/macOS only), so a client renders a slider over the range the setting
-  can meaningfully take; the `config.toml` parse bound stays at the static
-  figure so a config file written on one seat still parses on another.
+  physical RAM in MB, **capped at 1,024,000 MB** — which is also the value used
+  where detection is unavailable (it is Linux/macOS only) and the static bound
+  `config.toml` parsing enforces. So a client renders a slider over the range
+  the setting can meaningfully take, and on a seat with more than ~1 TB of RAM
+  the cap binds instead of the RAM figure. The cap is not cosmetic: the
+  catalog bound must never exceed the parse bound, or `settings.update` would
+  accept a value that the same schema then rejects on the way to disk. The
+  parse bound itself stays static and machine-independent, so a `config.toml`
+  written on one seat still parses on another — meaning the divergence runs
+  one way only, and a config carrying a budget above *this* machine's RAM
+  still loads and is reported with a `value` above the advertised `max`.
 - **`maxConcurrentAdapters` closes the quick-action burst path**
   (monorepo#2062). One-shot completions and model probes never enter
   `ProcessRegistry`, so they consume no `maxConcurrent` slot and do not appear

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -697,13 +697,16 @@ further 20 minutes, and the 30-minute row above now describes the old default
 rather than the shipped one.
 
 > **On upgrade, an existing seat keeps the value its `config.toml` already
-> carries.** The 10-minute default applies to **new installs**: the config
-> template is written only when the file is absent, and every install created
-> before this change has an explicit `idleReapMinutes = 30` in it, which wins
-> over the shipped default. The practical consequence is the one that matters
-> here — **a seat accumulating memory today will not change behaviour when it
-> upgrades.** Check the file and set the value explicitly if you want the
-> shorter window.
+> carries — permanently.** The 10-minute default applies to **new installs**:
+> the config template is written only when the file is absent, and every
+> install created before this change has an explicit `idleReapMinutes = 30` in
+> it, which wins over the shipped default. There is **no migration** — that 30
+> stays until someone edits the file, by decision (monorepo#2109): a boot
+> rewrite cannot tell a deliberate 30 from one the old template baked in, and
+> silently overriding the former was judged worse than leaving the latter.
+>
+> So if your seat is accumulating memory right now, **upgrading will not change
+> that — open `config.toml` and set `idleReapMinutes` yourself.**
 
 An agent
 becomes a candidate at the TTL and is picked up by the next sweep (interval

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -687,7 +687,18 @@ The reaper works; it was simply not asked to run for half an hour. That
 measurement is what moved the shipped default to **10 minutes**: the same tree
 begins draining once the window passes rather than holding 5.85 GB for a
 further 20 minutes, and the 30-minute row above now describes the old default
-rather than the shipped one. An agent
+rather than the shipped one.
+
+> **On upgrade, an existing seat keeps the value its `config.toml` already
+> carries.** The 10-minute default applies to **new installs**: the config
+> template is written only when the file is absent, and every install created
+> before this change has an explicit `idleReapMinutes = 30` in it, which wins
+> over the shipped default. The practical consequence is the one that matters
+> here — **a seat accumulating memory today will not change behaviour when it
+> upgrades.** Check the file and set the value explicitly if you want the
+> shorter window.
+
+An agent
 becomes a candidate at the TTL and is picked up by the next sweep (interval
 `ttl/4` clamped to `[30s, 300s]`, `reap_timings` in the `intentd` binary
 crate), so **selection** is bounded by TTL + one sweep — but release is not
@@ -707,7 +718,7 @@ self-described at the point of use in `DEFAULT_CONFIG_TEMPLATE`,
 
 | Knob | Default | Bounds |
 | --- | --- | --- |
-| `idleReapMinutes` | `10` | How long an idle agent subtree is retained (`0` disables reaping). **The lever for a memory-constrained seat.** |
+| `idleReapMinutes` | `10` (new installs; an existing `config.toml` keeps its own value — see above) | How long an idle agent subtree is retained (`0` disables reaping). **The lever for a memory-constrained seat.** |
 | `memoryBudgetMb` | `0` (off) | Aggregate RSS of the whole child tree, as a soft admission gate on new spawns. Catalog max is the machine's own physical RAM. |
 | `maxConcurrentAdapters` | `6` (on) | Concurrently live ephemeral adapter chains (quick actions, model probes). |
 | `maxConcurrent` | `0` (auto from RAM) | Agent **slots**. Not a memory bound — see the 22× range above. |
@@ -767,8 +778,10 @@ one** — the inverted conclusion. Steady state is accurate (a running soak read
 5.85 GB by both methods); the field aliases only on transients, which is
 precisely the case it was introduced for.
 
-**`idleReapMinutes` now defaults to 10, not 30** (monorepo#2109, reversing the
-earlier decision on that issue to leave defaults alone). The reasoning that
+**`idleReapMinutes` now defaults to 10, not 30** — on new installs; see the
+upgrade note above for why an existing seat is unaffected (monorepo#2109,
+reversing the earlier decision on that issue to leave defaults alone). The
+reasoning that
 originally argued for holding still is unchanged and is what keeps the new
 default off the floor: reaping earlier costs every user a warm process on next
 use, and the measured accumulation is a function of how many agents a seat

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -718,7 +718,7 @@ self-described at the point of use in `DEFAULT_CONFIG_TEMPLATE`,
 
 | Knob | Default | Bounds |
 | --- | --- | --- |
-| `idleReapMinutes` | `10` (new installs; an existing `config.toml` keeps its own value — see above) | How long an idle agent subtree is retained (`0` disables reaping). **The lever for a memory-constrained seat.** |
+| `idleReapMinutes` | `10` (new installs; an existing `config.toml` keeps its own value — see above) | How long an idle agent subtree is retained (`0` disables the idle-reap **sweep** — it does not guarantee idle trees survive, since a non-zero `memoryBudgetMb` can still evict them at admission). **The lever for a memory-constrained seat.** |
 | `memoryBudgetMb` | `0` (off) | Aggregate RSS of the whole child tree, as a soft admission gate on new spawns. Catalog max is the machine's own physical RAM, capped at 1,024,000 MB. |
 | `maxConcurrentAdapters` | `6` (on) | Concurrently live ephemeral adapter chains (quick actions, model probes). |
 | `maxConcurrent` | `0` (auto from RAM) | Agent **slots**. Not a memory bound — see the 22× range above. |
@@ -795,13 +795,16 @@ use, and the measured accumulation is a function of how many agents a seat
 touches — which differs enormously between a single-agent user and a
 coordinator fanning out a dozen. What changed is the read on where the
 midpoint sits. 30 minutes is long enough that the two cases converge in the
-worst direction — the coordinator holds every subtree it touched all session
-(the 5.85 GB flat row above), and the single-agent user gains a warm process
-they were unlikely to return to that late anyway. 10 minutes keeps the warm
-path for the case that actually re-enters an agent while bounding what a
-fan-out retains, and `0` still disables reaping entirely for anyone who wants
-the old unbounded behaviour. A seat still hitting the accumulation path should
-reach for `idleReapMinutes` first, then `memoryBudgetMb`.
+worst direction — the coordinator holds every subtree it touched anywhere in
+that half-hour window, re-extending it on each fan-out (the 5.85 GB flat row
+above measured 10 minutes of that, not a whole session), while the single-agent
+user gains a warm process they were unlikely to return to that late anyway. 10
+minutes keeps the warm path for the case that actually re-enters an agent while
+bounding what a fan-out retains, and `0` still turns the sweep off entirely for
+anyone who wants the old behaviour — with the caveat above that `0` stops the
+sweep, not every path that can reclaim an idle tree. A seat still hitting the
+accumulation path should reach for `idleReapMinutes` first, then
+`memoryBudgetMb`.
 
 ## Read-path performance principles
 


### PR DESCRIPTION
Companion to **intent-hq/intentd#1166**, which lowers the shipped
`agents.idleReapMinutes` default from 30 to 10 and makes the
`agents.memoryBudgetMb` catalog max the detected physical RAM.

The "Agent process-tree memory" section (added by #2114) documents the old
defaults *and the reasoning for keeping them*, so three claims in it become
false the moment the daemon PR lands:

1. **The measurement table** labelled the 40 procs / 5.85 GB flat capture as
   "30 (shipped default)". The capture is real and stays — it is re-labelled as
   the default *until* #2109, since it is now the evidence **for** the change
   rather than a description of shipped behaviour.
2. **The knobs table** advertised `idleReapMinutes` = `30`.
3. **The closing paragraph** recorded the decision on #2109 that defaults would
   deliberately not change. That is the one that mattered most: left alone, the
   doc would assert a decision the code had already reversed.

The original reasoning is kept rather than deleted, because it is still what
keeps the new default off the floor — it is now stated as the argument for 10
over 2, not for 30 over anything. What changed is the read on where the midpoint
sits: 30 minutes is long enough that the coordinator and single-agent cases
converge in the worst direction, while 10 preserves the warm-process path for
agents a seat actually re-enters. `0` still disables reaping entirely.

Also notes the new `memoryBudgetMb` catalog bound (max = detected physical RAM,
static 1,024,000 MB fallback where detection is unavailable) and that the
`config.toml` parse bound deliberately stays static so config files stay
portable between machines.

No `PROTOCOL.md` change: `min`/`max` are already §5.12 `SettingDefinition`
fields, so the dynamic bound needs no new wire field and no version bump.

Refs #2109, #2114