### PR TITLE
ci: retry PR title validation once to absorb transient TLS failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,31 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
+      # Intermittent TLS failures reaching api.github.com can kill this action
+      # sub-second, before it validates anything — a spurious red that reads
+      # like a bad title (intent-hq/monorepo#2098). Tolerate a first-attempt
+      # failure and retry once; the retry is authoritative, so a genuinely
+      # bad title still fails the job.
       - uses: amannn/action-semantic-pull-request@v6
+        id: title_check
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            chore
+            docs
+            refactor
+            test
+            ci
+            perf
+      - name: Wait before retrying title validation
+        if: steps.title_check.outcome == 'failure'
+        run: sleep 15
+      - uses: amannn/action-semantic-pull-request@v6
+        if: steps.title_check.outcome == 'failure'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
## Why

Intermittent TLS verification failures reaching api.github.com kill the `Validate PR Title` check sub-second, before the action validates anything — a spurious red that reads like a malformed title (intent-hq/monorepo#2098).

Investigation established that the failed job (cloudlands-fe [run 31573747608 attempt 1](https://github.com/intent-hq/cloudlands-fe/actions/runs/31573747608), job `Validate PR Title`) ran on a **GitHub-hosted** runner (`runner_group_name: "GitHub Actions"`, labels `ubuntu-latest`) — not tinybox. So this is not the local network or an intercepting proxy on self-hosted infra; it is a transient failure inside GitHub-hosted infrastructure, and nothing repo-side can prevent the first attempt from failing. What repo config *can* do is absorb it.

## What

Retry the `amannn/action-semantic-pull-request` step once:

- attempt 1 carries `continue-on-error: true`;
- on failure, wait 15 s and run the action again — the retry is authoritative.

A genuinely malformed title fails both attempts and still fails the job. A transient network failure on the first attempt no longer produces a spurious red. The same change lands in intent-hq/intentd, intent-hq/cloudlands-fe, and intent-hq/monorepo, which define the identical `pr-title` job.

Refs intent-hq/monorepo#2098
