### PR TITLE
docs: document hourly alpha builds and shipped-work tracking

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,14 +109,16 @@ rolling bump PR may cover both submodule refs); do not file a manual bump PR.
 
 ## Release Process
 
-Releases are per-component and channel-based: merging a release PR publishes to **beta**;
-**stable** is a promotion of an existing release (no new build), triggered by a manual
-workflow dispatch.
+Releases are per-component and channel-based: merging a release PR publishes to the
+rolling **alpha** channel (several workflows are historically named "beta" but publish
+to alpha); **stable** is a promotion of an existing release (no new build), triggered
+by a manual workflow dispatch.
 
 ### intentd
 
 - release-plz maintains a release PR on `main`. Merging it cuts the `vX.Y.Z` tag,
-  cargo-dist builds the artifacts, and the beta manifest publishes automatically.
+  cargo-dist builds the artifacts, and the alpha channel manifest (`alpha.json` on the
+  `channel-alpha` release) publishes automatically.
 - Stable is promotion-only: dispatch `promote-stable.yml` with the `version` input, then
   verify `stable.json` on the `channel-stable` release.
 - Daemon archives and channel manifests are **mirrored** to the public
@@ -164,6 +166,22 @@ workflow dispatch.
 intentd release → promote intentd stable → cloudlands-fe pin-bump PR → cloudlands-fe
 release → promote cloudlands-fe stable → monorepo pins advance automatically via the
 auto-bump workflow (no manual bump PR).
+
+### Tracking shipped work (hourly alpha builds)
+
+Alpha builds happen automatically: releases are cut every hour, so merged work ships
+in a cloudlands-fe alpha shortly after landing. When the work changed intentd and/or
+cloudlands-fe, the workspace is NOT done once the PRs are merged: wait on / monitor
+the release PR(s) until the work ships in a cloudlands-fe alpha, then update the
+final workspace status message with the version that carries the feat/fix (e.g.
+"Shipped in cloudlands-fe vX.Y.Z (alpha)."). This applies to intentd-only changes
+too: an intentd change first ships in an intentd release, is then pinned into
+cloudlands-fe automatically, and finally rides the next cloudlands-fe alpha (roughly
+an hour later) — the version to report is still the cloudlands-fe alpha (verify
+inclusion via `intentdVersion` in the published release's `release-manifest.json`).
+Use background monitoring (`ws.pr.monitor` / `ws.hook.*`) — never block a turn
+polling. Monorepo-only work (docs, Makefile, CI, scripts) ships nothing to the alpha
+channel, so it needs no release monitoring or shipped-version status message.
 
 ### Gotchas
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,8 +111,10 @@ rolling bump PR may cover both submodule refs); do not file a manual bump PR.
 
 Releases are per-component and channel-based: merging a release PR publishes to the
 rolling **alpha** channel (several workflows are historically named "beta" but publish
-to alpha); **stable** is a promotion of an existing release (no new build), triggered
-by a manual workflow dispatch.
+to alpha); **beta** and **stable** are promotions of existing releases (no new build),
+each triggered by a manual workflow dispatch (`promote-beta.yml` /
+`promote-stable.yml` on intentd, `promote-beta.yml` / `release-stable.yml` on
+cloudlands-fe).
 
 ### intentd
 
@@ -140,8 +142,10 @@ by a manual workflow dispatch.
 ### cloudlands-fe
 
 - The intentd sidecar version is pinned in `intentd.version` at the cloudlands-fe repo
-  root (`packages/cloudlands-fe/` in this monorepo). Bump it via PR and verify by running
-  `node scripts/fetch-sidecar.cjs` from that directory.
+  root (`packages/cloudlands-fe/` in this monorepo). The pin advances automatically:
+  `auto-pin-intentd.yml` follows the intentd alpha channel and lands the bump via a
+  rolling PR — a manual pin-bump PR is only for overrides (verify with
+  `node scripts/fetch-sidecar.cjs` from that directory).
 - release-please maintains a release PR. Merging it cuts the tag and `release-beta.yml`
   publishes to `intent-hq/cloudlands-releases`.
 - Stable: dispatch `release-stable.yml` with the `version` input.
@@ -149,10 +153,11 @@ by a manual workflow dispatch.
 ### Release notifier
 
 - Both component repos run `scripts/notify-fixed-issues.sh` from their release workflows.
-  On beta publish it scans the released tag range (commit messages plus squash-merged PR
+  On alpha publish it scans the released tag range (commit messages plus squash-merged PR
   bodies, resolved via the `(#N)` subject suffix) for `intent-hq/monorepo#N` / full issue
-  URL references and posts "Fixed in <component> vX.Y.Z (beta)" on each referenced issue;
-  on stable promotion it posts a "promoted to stable" comment covering the range since the
+  URL references and posts "Fixed in <component> vX.Y.Z (alpha)" on each referenced issue;
+  beta comments come from the manual `promote-beta.yml` promotion, and on stable promotion
+  it posts a "promoted to stable" comment covering the range since the
   previous stable. cloudlands-fe comments also name the bundled intentd version.
 - Comments embed a hidden per-component/version/channel marker, so tag rebuilds and
   workflow re-runs never double-post. `--dry-run` prints intended comments without
@@ -163,9 +168,9 @@ by a manual workflow dispatch.
 
 ### Coordinated Release Ordering
 
-intentd release → promote intentd stable → cloudlands-fe pin-bump PR → cloudlands-fe
-release → promote cloudlands-fe stable → monorepo pins advance automatically via the
-auto-bump workflow (no manual bump PR).
+intentd release → cloudlands-fe pin bump (automatic via `auto-pin-intentd.yml`) →
+cloudlands-fe release → promote each component's stable → monorepo pins advance
+automatically via the auto-bump workflow (no manual bump PR).
 
 ### Tracking shipped work (hourly alpha builds)
 

--- a/docs/fe/DEPLOYING.md
+++ b/docs/fe/DEPLOYING.md
@@ -35,8 +35,10 @@ version number by hand.
 1. On every push to `main`, release-please opens (or updates) a **Release PR**
    that bumps `package.json` and regenerates `CHANGELOG.md` from the
    conventional commits since the last `v*` tag.
-2. A human merges the Release PR when it's time to ship — that is the release
-   timing gate.
+2. The Release PR is auto-merged hourly by `auto-cut-beta.yml` (cron at :30)
+   when it is green — that is the release timing gate. The `hold-release`
+   label on the Release PR pauses the auto-cut; a human can still merge
+   early.
 3. On the merge, release-please creates the `v{version}` tag and a GitHub
    Release on `cloudlands-fe`. The workflow authenticates with `RELEASE_PAT`
    (not the default `GITHUB_TOKEN`) so the pushed tag triggers downstream


### PR DESCRIPTION
Documents the hourly alpha build cadence and the workspace obligation to track work until it ships.

## New subsection — `### Tracking shipped work (hourly alpha builds)`

Added under Release Process (after "Coordinated Release Ordering", before "Gotchas"):

- Alpha builds happen automatically: releases are cut every hour, so merged work ships in a cloudlands-fe alpha shortly after landing.
- When the work changed intentd and/or cloudlands-fe, the workspace is not done once the PRs are merged: wait on / monitor the release PR(s) until the work ships in a cloudlands-fe alpha, then update the final workspace status message with the version that carries the feat/fix (e.g. "Shipped in cloudlands-fe vX.Y.Z (alpha).").
- Applies to intentd-only changes too: an intentd change ships in an intentd release, is pinned into cloudlands-fe automatically, and rides the next cloudlands-fe alpha (~an hour later) — the reported version is still the cloudlands-fe alpha, verified via `intentdVersion` in the published release's `release-manifest.json`.
- Use background monitoring (`ws.pr.monitor` / `ws.hook.*`) — never block a turn polling.
- Monorepo-only work (docs, Makefile, CI, scripts) ships nothing to the alpha channel, so it needs no release monitoring or shipped-version status message.

## Consistency touch-ups (beta → alpha)

- Release Process intro: merging a release PR publishes to the rolling **alpha** channel (several workflows are historically named "beta" but publish to alpha); stable promotion unchanged.
- intentd bullet: "the beta manifest publishes automatically" → "the alpha channel manifest (`alpha.json` on the `channel-alpha` release) publishes automatically", matching `publish-channel-manifest.yml`.
