### PR TITLE
docs: describe completeness-gated, channel-free release notifier

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ monorepo pin advance (Phase 2) then happens automatically.
 When the change fixes a monorepo issue, reference it with the full cross-repo form —
 `Fixes intent-hq/monorepo#N` — in the squash-commit message or PR body. GitHub
 auto-closes the issue on merge, and the release notifier (see Release Process) comments
-on it when the fix ships in a release.
+on it once a release actually contains the complete fix.
 
 ### Phase 2 — Monorepo pin advance (automated)
 
@@ -179,19 +179,31 @@ cloudlands-fe).
 
 ### Release notifier
 
-- Both component repos run `scripts/notify-fixed-issues.sh` from their release workflows.
-  On alpha publish it scans the released tag range (commit messages plus squash-merged PR
-  bodies, resolved via the `(#N)` subject suffix) for `intent-hq/monorepo#N` / full issue
-  URL references and posts "Fixed in <component> vX.Y.Z (alpha)" on each referenced issue;
-  beta comments come from the manual `promote-beta.yml` promotion, and on stable promotion
-  it posts a "promoted to stable" comment covering the range since the
-  previous stable. cloudlands-fe comments also name the bundled intentd version.
-- Comments embed a hidden per-component/version/channel marker, so tag rebuilds and
-  workflow re-runs never double-post. `--dry-run` prints intended comments without
-  posting.
-- Posting uses the `MONOREPO_ISSUES_TOKEN` secret (issues:write on `intent-hq/monorepo`)
-  in both component repos. Notifier steps are fail-soft (`continue-on-error`; skipped
-  with a warning when the secret is absent) — they never block a release or promotion.
+- Both component repos run `scripts/notify-fixed-issues.sh` from their release (tag
+  build) workflows only — promotion workflows post nothing. Each release scans for
+  `intent-hq/monorepo#N` / full issue URL references (commit messages plus
+  squash-merged PR bodies, resolved via the `(#N)` subject suffix): intentd scans its
+  released tag range; cloudlands-fe scans its own range plus the bundled intentd
+  delta `v{prev pin}..v{new pin}`, so an fe release that merely bumps the sidecar
+  still comments on intentd-fixed issues.
+- Comments never name a channel and there are no beta/stable promotion comments.
+  intentd posts "This fix is included in intentd vX.Y.Z."; cloudlands-fe posts
+  "This fix is included in cloudlands-fe vX.Y.Z (bundles intentd vA.B.C)."
+- Completeness gate ("stay silent until complete"): a comment is posted only when
+  every fix PR linked to the issue across both component repos is merged and
+  contained — intentd PRs in the released / bundled intentd tag, fe PRs in the fe
+  tag. Any open or not-yet-contained linked fix PR → skip; a later release whose
+  scan re-references the issue picks it up. When completeness cannot be determined
+  (API error, token cannot see a repo), the notifier skips with a warning rather
+  than post a possibly-false claim. Issues with no linked fix PRs at all fall back
+  to the range-scan evidence (best effort).
+- Comments embed a hidden per-component/version marker, so tag rebuilds and workflow
+  re-runs never double-post. `--dry-run` prints intended comments without posting.
+- Posting uses the `MONOREPO_ISSUES_TOKEN` secret (issues:write on
+  `intent-hq/monorepo` plus pull-requests:read on `intent-hq/intentd` and
+  `intent-hq/cloudlands-fe` — the PR reads power the completeness gate) in both
+  component repos. Notifier steps are fail-soft (`continue-on-error`; skipped with a
+  warning when the secret is absent) — they never block a release.
 
 ### Coordinated Release Ordering
 
@@ -256,7 +268,8 @@ for all components.
 - **Cross-reference**: reference the issue number in related commits/PRs (e.g.
   `fix: correct panel focus (#123)`). In submodule PRs, use the full cross-repo form
   `Fixes intent-hq/monorepo#N` so the issue auto-closes on merge and the release
-  notifier comments on it when the fix ships (see Release Process).
+  notifier comments on it once a release contains the complete fix (see Release
+  Process).
 
 ## Terminology
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -190,13 +190,17 @@ cloudlands-fe).
   intentd posts "This fix is included in intentd vX.Y.Z."; cloudlands-fe posts
   "This fix is included in cloudlands-fe vX.Y.Z (bundles intentd vA.B.C)."
 - Completeness gate ("stay silent until complete"): a comment is posted only when
-  every fix PR linked to the issue across both component repos is merged and
-  contained — intentd PRs in the released / bundled intentd tag, fe PRs in the fe
-  tag. Any open or not-yet-contained linked fix PR → skip; a later release whose
-  scan re-references the issue picks it up. When completeness cannot be determined
-  (API error, token cannot see a repo), the notifier skips with a warning rather
-  than post a possibly-false claim. Issues with no linked fix PRs at all fall back
-  to the range-scan evidence (best effort).
+  every linked fix PR the gate considers is merged and contained. The gates differ
+  in scope: intentd's gate is component-scoped — it checks only intentd-linked fix
+  PRs against the released intentd tag (an intentd release still comments while an
+  fe-side fix PR is open); cloudlands-fe's gate is cross-repo — fe PRs must be
+  contained in the fe tag AND intentd PRs in the bundled intentd tag, making the fe
+  comment the user-facing availability signal. Any in-scope open or
+  not-yet-contained linked fix PR → skip; a later release whose scan re-references
+  the issue picks it up. When completeness cannot be determined (API error, token
+  cannot see a repo), the notifier skips with a warning rather than post a
+  possibly-false claim. Issues with no linked fix PRs at all fall back to the
+  range-scan evidence (best effort).
 - Comments embed a hidden per-component/version marker, so tag rebuilds and workflow
   re-runs never double-post. `--dry-run` prints intended comments without posting.
 - Posting uses the `MONOREPO_ISSUES_TOKEN` secret (issues:write on


### PR DESCRIPTION
Brings the monorepo docs in line with the reworked release notifier (intent-hq/intentd#1232, intent-hq/cloudlands-fe#1245).

## Changes (AGENTS.md only)

- **Release notifier section** rewritten to the new model:
  - Comments only on release (tag build) workflows — promotion workflows post nothing; no channel wording, no beta/stable promotion comments.
  - New wording: "This fix is included in intentd vX.Y.Z." / "This fix is included in cloudlands-fe vX.Y.Z (bundles intentd vA.B.C)."
  - cloudlands-fe scans the bundled intentd delta `v{prev pin}..v{new pin}` in addition to its own range.
  - Completeness gate documented: silent until every linked fix PR across both component repos is merged and contained; indeterminate completeness skips with a warning; no-linked-PR issues fall back to range-scan evidence.
  - Idempotency marker described as per-component/version (channel-free).
- **`MONOREPO_ISSUES_TOKEN`** description updated to the extended PAT: issues:write on `intent-hq/monorepo` plus pull-requests:read on `intent-hq/intentd` and `intent-hq/cloudlands-fe` (the PR reads power the completeness gate).
- The two fix-reference mentions (Phase 1 and Filing Issues) now say the notifier comments once a release actually contains the complete fix.

The cloudlands-fe AGENTS.md notifier mention lives in the fe repo and was handled in the fe PR; no submodule changes here.

## Verification

- `grep -rn "notify-fixed-issues\|Fixed in\|promoted to" docs/ AGENTS.md` shows only accurate text (remaining `docs/PROTOCOL.md` matches are unrelated "promoted to the queue head" wording).
