### PR TITLE
feat: add UDS-to-WS bridge dev tool (make uds-to-unauthed-wss-bridge)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,3 +49,17 @@ jobs:
             test
             ci
             perf
+
+  # The UDS→WS bridge shim (scripts/uds-ws-bridge.mjs) is zero-dependency
+  # Node, so its node:test suite is also seconds-long and runs directly on a
+  # GitHub-hosted runner — no tinybox routing, no submodules needed.
+  bridge-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - run: node --test scripts/uds-ws-bridge.test.mjs

--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,9 @@ export DEV_PORT
 # (held by the daemon's authed WSS for iOS). Overridable, e.g.
 # `make uds-to-unauthed-wss-bridge BRIDGE_PORT=5182`.
 BRIDGE_PORT ?= 51337
+# Injectable platform seam for the bridge's installed-daemon socket default.
+# An explicit INTENTD_SOCKET always takes precedence.
+BRIDGE_PLATFORM ?= $(shell uname -s)
 
 # Build-artifact GC (cargo-sweep). Rust target/ dirs grow without bound as
 # deps and toolchains churn; `sweep` prunes artifacts older than SWEEP_DAYS
@@ -412,33 +415,28 @@ uds-to-unauthed-wss-bridge: ## Expose the installed intentd's UDS as an UNAUTHEN
 	# connection to the installed daemon, with 1:1 JSON-RPC frame translation
 	# (docs/PROTOCOL.md). The daemon's own auth posture — authed WSS on 5181
 	# for iOS — is untouched; despite the target name, the endpoint is plain
-	# ws:// (no TLS). Socket resolution mirrors run-fe-local: an INTENTD_SOCKET
-	# already set in the caller's environment wins over the platform default,
-	# and on non-Windows the target errors if the socket does not exist.
+	# ws:// (no TLS). Socket resolution: an explicit INTENTD_SOCKET always
+	# takes precedence over the platform default (BRIDGE_PLATFORM is the
+	# injectable `uname -s` seam), and the target errors if the resolved
+	# socket does not exist.
 	# Long-running; does not exit until you stop it (Ctrl-C).
-	@sock="$$INTENTD_SOCKET"; \
-	is_windows=0; \
-	case "$$(uname -s)" in \
-		MINGW*|MSYS*|CYGWIN*) is_windows=1 ;; \
-	esac; \
-	if [ -n "$$sock" ]; then \
-		echo "[uds-to-unauthed-wss-bridge] using caller-provided INTENTD_SOCKET"; \
-	else \
-		case "$$(uname -s)" in \
-			Darwin) sock="$$HOME/Library/Application Support/intentd/intentd.sock" ;; \
-			Linux) sock="$${XDG_DATA_HOME:-$$HOME/.local/share}/intentd/intentd.sock" ;; \
-			MINGW*|MSYS*|CYGWIN*) sock="$$APPDATA/intentd/data/intentd.sock" ;; \
-			*) echo "[uds-to-unauthed-wss-bridge] ERROR: unsupported platform $$(uname -s) — no known installed-daemon socket path."; \
-			   exit 1 ;; \
-		esac; \
-	fi; \
-	if [ "$$is_windows" -eq 0 ] && [ ! -S "$$sock" ]; then \
-		echo "[uds-to-unauthed-wss-bridge] ERROR: no UDS socket at '$$sock' — is the installed Intent daemon running?"; \
-		exit 1; \
-	fi; \
-	echo "[uds-to-unauthed-wss-bridge] INTENTD_SOCKET=$$sock"; \
-	echo "[uds-to-unauthed-wss-bridge] WARNING: this exposes the FULL UNAUTHENTICATED daemon API as plain ws:// on 127.0.0.1:$(BRIDGE_PORT) — no TLS, no auth. Loopback-only by design; any process on this machine can drive the daemon while the bridge runs."; \
-	INTENTD_SOCKET="$$sock" BRIDGE_PORT=$(BRIDGE_PORT) node scripts/uds-ws-bridge.mjs
+	@socket="$$INTENTD_SOCKET"; \
+		if [ -z "$$socket" ]; then \
+			case "$(BRIDGE_PLATFORM)" in \
+				Darwin) socket="$$HOME/Library/Application Support/intentd/intentd.sock" ;; \
+				Linux) socket="$${XDG_DATA_HOME:-$$HOME/.local/share}/intentd/intentd.sock" ;; \
+				*) echo "[uds-to-unauthed-wss-bridge] ERROR: unsupported platform '$(BRIDGE_PLATFORM)'; set INTENTD_SOCKET explicitly."; \
+				   exit 1 ;; \
+			esac; \
+		fi; \
+		if [ ! -S "$$socket" ]; then \
+			echo "[uds-to-unauthed-wss-bridge] ERROR: daemon socket not found at $$socket"; \
+			echo "[uds-to-unauthed-wss-bridge] Start the installed Intent daemon first, or set INTENTD_SOCKET to its socket path."; \
+			exit 1; \
+		fi; \
+		echo "[uds-to-unauthed-wss-bridge] Bridging installed daemon socket: $$socket"; \
+		echo "[uds-to-unauthed-wss-bridge] WARNING: this exposes the FULL UNAUTHENTICATED daemon API as plain ws:// on 127.0.0.1:$(BRIDGE_PORT) — no TLS, no auth. Loopback-only by design; any process on this machine can drive the daemon while the bridge runs."; \
+		INTENTD_SOCKET="$$socket" BRIDGE_PORT=$(BRIDGE_PORT) node scripts/uds-ws-bridge.mjs
 
 build-sidecar: ensure-intentd-submodule ensure-fe-submodule ## Build intentd release + stage the sidecar binary for FE packaging
 	# Builds the intentd release binary (may take several minutes on first build) and

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,13 @@ DEV_PORT ?= 5190
 # actually sees the default/override in the child environment.
 export DEV_PORT
 
+# BRIDGE_PORT is the loopback port for `make uds-to-unauthed-wss-bridge` — the
+# source-only dev shim that exposes the installed daemon's UDS socket as an
+# UNAUTHENTICATED plain ws:// endpoint on 127.0.0.1. 51337 stays clear of 5181
+# (held by the daemon's authed WSS for iOS). Overridable, e.g.
+# `make uds-to-unauthed-wss-bridge BRIDGE_PORT=5182`.
+BRIDGE_PORT ?= 51337
+
 # Build-artifact GC (cargo-sweep). Rust target/ dirs grow without bound as
 # deps and toolchains churn; `sweep` prunes artifacts older than SWEEP_DAYS
 # days in this worktree's intentd, and `sweep-all` does the same across every
@@ -76,7 +83,7 @@ FE_BUILD_HEAP_MB ?= 16384
 	update \
 	build build-intentd build-sidecar test test-intentd fmt clippy check clean clean-dev \
 	sweep sweep-all seed-dev-providers seed-dev-workspaces dev-daemon release-daemon \
-	run-intentd run-fe run-fe-local dev ios-open ios-info dist-mac
+	run-intentd run-fe run-fe-local uds-to-unauthed-wss-bridge dev ios-open ios-info dist-mac
 
 all: build
 
@@ -398,6 +405,40 @@ run-fe-local: ensure-fe-submodule ## Run the FE against the locally INSTALLED in
 	fi; \
 	echo "[run-fe-local] INTENTD_SOCKET=$$sock"; \
 	cd $(FE_DIR) && INTENTD_SOCKET="$$sock" pnpm run dev
+
+uds-to-unauthed-wss-bridge: ## Expose the installed intentd's UDS as an UNAUTHENTICATED plain ws:// endpoint on 127.0.0.1:$(BRIDGE_PORT)
+	# Runs scripts/uds-ws-bridge.mjs (zero-dependency, Node >= 20): each WS
+	# client on ws://127.0.0.1:$(BRIDGE_PORT)/ws gets its own dedicated UDS
+	# connection to the installed daemon, with 1:1 JSON-RPC frame translation
+	# (docs/PROTOCOL.md). The daemon's own auth posture — authed WSS on 5181
+	# for iOS — is untouched; despite the target name, the endpoint is plain
+	# ws:// (no TLS). Socket resolution mirrors run-fe-local: an INTENTD_SOCKET
+	# already set in the caller's environment wins over the platform default,
+	# and on non-Windows the target errors if the socket does not exist.
+	# Long-running; does not exit until you stop it (Ctrl-C).
+	@sock="$$INTENTD_SOCKET"; \
+	is_windows=0; \
+	case "$$(uname -s)" in \
+		MINGW*|MSYS*|CYGWIN*) is_windows=1 ;; \
+	esac; \
+	if [ -n "$$sock" ]; then \
+		echo "[uds-to-unauthed-wss-bridge] using caller-provided INTENTD_SOCKET"; \
+	else \
+		case "$$(uname -s)" in \
+			Darwin) sock="$$HOME/Library/Application Support/intentd/intentd.sock" ;; \
+			Linux) sock="$${XDG_DATA_HOME:-$$HOME/.local/share}/intentd/intentd.sock" ;; \
+			MINGW*|MSYS*|CYGWIN*) sock="$$APPDATA/intentd/data/intentd.sock" ;; \
+			*) echo "[uds-to-unauthed-wss-bridge] ERROR: unsupported platform $$(uname -s) — no known installed-daemon socket path."; \
+			   exit 1 ;; \
+		esac; \
+	fi; \
+	if [ "$$is_windows" -eq 0 ] && [ ! -S "$$sock" ]; then \
+		echo "[uds-to-unauthed-wss-bridge] ERROR: no UDS socket at '$$sock' — is the installed Intent daemon running?"; \
+		exit 1; \
+	fi; \
+	echo "[uds-to-unauthed-wss-bridge] INTENTD_SOCKET=$$sock"; \
+	echo "[uds-to-unauthed-wss-bridge] WARNING: this exposes the FULL UNAUTHENTICATED daemon API as plain ws:// on 127.0.0.1:$(BRIDGE_PORT) — no TLS, no auth. Loopback-only by design; any process on this machine can drive the daemon while the bridge runs."; \
+	INTENTD_SOCKET="$$sock" BRIDGE_PORT=$(BRIDGE_PORT) node scripts/uds-ws-bridge.mjs
 
 build-sidecar: ensure-intentd-submodule ensure-fe-submodule ## Build intentd release + stage the sidecar binary for FE packaging
 	# Builds the intentd release binary (may take several minutes on first build) and

--- a/Makefile
+++ b/Makefile
@@ -415,12 +415,16 @@ uds-to-unauthed-wss-bridge: ## Expose the installed intentd's UDS as an UNAUTHEN
 	# connection to the installed daemon, with 1:1 JSON-RPC frame translation
 	# (docs/PROTOCOL.md). The daemon's own auth posture — authed WSS on 5181
 	# for iOS — is untouched; despite the target name, the endpoint is plain
-	# ws:// (no TLS). Socket resolution: an explicit INTENTD_SOCKET always
-	# takes precedence over the platform default (BRIDGE_PLATFORM is the
-	# injectable `uname -s` seam), and the target errors if the resolved
-	# socket does not exist.
+	# ws:// (no TLS). Socket resolution matches the script's own
+	# defaultSocketPath(): an explicit INTENTD_SOCKET always takes precedence,
+	# then an INTENTD_DATA_DIR-derived path ($$INTENTD_DATA_DIR/intentd.sock),
+	# then the platform default (BRIDGE_PLATFORM is the injectable `uname -s`
+	# seam). The target errors if the resolved socket does not exist.
 	# Long-running; does not exit until you stop it (Ctrl-C).
 	@socket="$$INTENTD_SOCKET"; \
+		if [ -z "$$socket" ] && [ -n "$$INTENTD_DATA_DIR" ]; then \
+			socket="$$INTENTD_DATA_DIR/intentd.sock"; \
+		fi; \
 		if [ -z "$$socket" ]; then \
 			case "$(BRIDGE_PLATFORM)" in \
 				Darwin) socket="$$HOME/Library/Application Support/intentd/intentd.sock" ;; \

--- a/scripts/uds-ws-bridge.mjs
+++ b/scripts/uds-ws-bridge.mjs
@@ -1,0 +1,345 @@
+#!/usr/bin/env node
+// uds-ws-bridge: expose a running intentd's UDS JSON-RPC socket as an
+// UNAUTHENTICATED plain ws:// endpoint on loopback (dev tool, source-only).
+//
+// - RFC 6455 WebSocket server built on node:http + node:crypto (zero npm deps).
+// - One dedicated UDS connection per WebSocket client (1:1).
+// - Translation: one complete WS text message <-> one newline-terminated
+//   JSON-RPC line on the UDS socket. Binary frames are ignored.
+//
+// Config (env or flags): BRIDGE_PORT/--port (default 51337),
+// BRIDGE_HOST/--host (default 127.0.0.1), INTENTD_SOCKET/--socket
+// (default: platform intentd data dir, honoring INTENTD_DATA_DIR).
+//
+// See intent-hq/monorepo#2526.
+
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import http from 'node:http';
+import net from 'node:net';
+import os from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+import { pathToFileURL } from 'node:url';
+
+// Matches the daemon's per-message transport limit.
+export const MAX_MESSAGE_BYTES = 40 * 1024 * 1024;
+
+const WS_GUID = '258EAFA5-E914-47DA-95CA-C5AB0DC85B11';
+const NL = Buffer.from('\n');
+
+const OP_CONT = 0x0;
+const OP_TEXT = 0x1;
+const OP_BINARY = 0x2;
+const OP_CLOSE = 0x8;
+const OP_PING = 0x9;
+const OP_PONG = 0xa;
+
+export function defaultSocketPath(env = process.env, platform = process.platform) {
+  if (env.INTENTD_SOCKET) return env.INTENTD_SOCKET;
+  let dataDir;
+  if (env.INTENTD_DATA_DIR) {
+    dataDir = env.INTENTD_DATA_DIR;
+  } else if (platform === 'darwin') {
+    dataDir = path.join(os.homedir(), 'Library', 'Application Support', 'intentd');
+  } else {
+    dataDir = path.join(env.XDG_DATA_HOME || path.join(os.homedir(), '.local', 'share'), 'intentd');
+  }
+  return path.join(dataDir, 'intentd.sock');
+}
+
+export function computeAccept(key) {
+  return crypto.createHash('sha1').update(key + WS_GUID).digest('base64');
+}
+
+export function encodeFrame(opcode, payload, fin = true) {
+  const len = payload.length;
+  let header;
+  if (len < 126) {
+    header = Buffer.from([(fin ? 0x80 : 0) | opcode, len]);
+  } else if (len < 65536) {
+    header = Buffer.alloc(4);
+    header[0] = (fin ? 0x80 : 0) | opcode;
+    header[1] = 126;
+    header.writeUInt16BE(len, 2);
+  } else {
+    header = Buffer.alloc(10);
+    header[0] = (fin ? 0x80 : 0) | opcode;
+    header[1] = 127;
+    header.writeBigUInt64BE(BigInt(len), 2);
+  }
+  return Buffer.concat([header, payload]);
+}
+
+function closePayload(code, reason = '') {
+  const reasonBuf = Buffer.from(reason, 'utf8').subarray(0, 123);
+  const buf = Buffer.alloc(2 + reasonBuf.length);
+  buf.writeUInt16BE(code, 0);
+  reasonBuf.copy(buf, 2);
+  return buf;
+}
+
+function handleConnection(socket, head, socketPath) {
+  let wsBuf = Buffer.alloc(0);
+  let udsBuf = Buffer.alloc(0);
+  let fragments = null; // { opcode, chunks, size } while reassembling
+  let closeSent = false;
+  let closed = false;
+
+  const uds = net.connect(socketPath);
+
+  const sendFrame = (opcode, payload, fin = true) => {
+    if (!socket.destroyed && socket.writable) socket.write(encodeFrame(opcode, payload, fin));
+  };
+
+  const shutdown = (code, reason) => {
+    if (closed) return;
+    closed = true;
+    if (!closeSent) {
+      closeSent = true;
+      sendFrame(OP_CLOSE, closePayload(code, reason));
+    }
+    socket.end();
+    uds.destroy();
+    // Hard-close if the peer never completes the closing handshake.
+    setTimeout(() => socket.destroy(), 1000).unref();
+  };
+
+  uds.on('error', (err) => shutdown(1011, `intentd UDS error: ${err.code || err.message}`));
+  uds.on('close', () => shutdown(1000, 'intentd UDS connection closed'));
+  uds.on('data', (chunk) => {
+    udsBuf = udsBuf.length ? Buffer.concat([udsBuf, chunk]) : chunk;
+    let nl;
+    while ((nl = udsBuf.indexOf(0x0a)) !== -1) {
+      const line = udsBuf.subarray(0, nl);
+      udsBuf = udsBuf.subarray(nl + 1);
+      if (line.length > MAX_MESSAGE_BYTES) {
+        shutdown(1009, 'message from daemon exceeds 40 MiB cap');
+        return;
+      }
+      sendFrame(OP_TEXT, line);
+    }
+    if (udsBuf.length > MAX_MESSAGE_BYTES) shutdown(1009, 'message from daemon exceeds 40 MiB cap');
+  });
+
+  const deliver = (payload) => {
+    if (!uds.destroyed) uds.write(Buffer.concat([payload, NL]));
+  };
+
+  const handleFrame = (fin, opcode, payload) => {
+    switch (opcode) {
+      case OP_PING:
+        sendFrame(OP_PONG, payload);
+        return;
+      case OP_PONG:
+        return;
+      case OP_CLOSE:
+        if (!closeSent) {
+          closeSent = true;
+          sendFrame(OP_CLOSE, payload.subarray(0, 2));
+        }
+        closed = true;
+        socket.end();
+        uds.destroy();
+        return;
+      case OP_TEXT:
+      case OP_BINARY:
+        if (fin) {
+          if (opcode === OP_TEXT) deliver(payload);
+          return;
+        }
+        fragments = { opcode, chunks: [payload], size: payload.length };
+        return;
+      case OP_CONT: {
+        if (!fragments) return; // stray continuation — ignore
+        fragments.chunks.push(payload);
+        fragments.size += payload.length;
+        if (fin) {
+          const { opcode: op, chunks } = fragments;
+          fragments = null;
+          if (op === OP_TEXT) deliver(Buffer.concat(chunks));
+        }
+        return;
+      }
+      default:
+        return; // unknown opcode — ignore
+    }
+  };
+
+  const onData = (chunk) => {
+    wsBuf = wsBuf.length ? Buffer.concat([wsBuf, chunk]) : chunk;
+    while (!closed) {
+      if (wsBuf.length < 2) break;
+      const fin = (wsBuf[0] & 0x80) !== 0;
+      const opcode = wsBuf[0] & 0x0f;
+      const masked = (wsBuf[1] & 0x80) !== 0;
+      let len = wsBuf[1] & 0x7f;
+      let off = 2;
+      if (len === 126) {
+        if (wsBuf.length < 4) break;
+        len = wsBuf.readUInt16BE(2);
+        off = 4;
+      } else if (len === 127) {
+        if (wsBuf.length < 10) break;
+        const big = wsBuf.readBigUInt64BE(2);
+        if (big > BigInt(MAX_MESSAGE_BYTES)) {
+          shutdown(1009, 'message exceeds 40 MiB cap');
+          return;
+        }
+        len = Number(big);
+        off = 10;
+      }
+      if (opcode === OP_TEXT || opcode === OP_BINARY || opcode === OP_CONT) {
+        const assembled = fragments ? fragments.size : 0;
+        if (len > MAX_MESSAGE_BYTES || assembled + len > MAX_MESSAGE_BYTES) {
+          shutdown(1009, 'message exceeds 40 MiB cap');
+          return;
+        }
+      }
+      const maskLen = masked ? 4 : 0;
+      if (wsBuf.length < off + maskLen + len) break;
+      let payload = wsBuf.subarray(off + maskLen, off + maskLen + len);
+      if (masked) {
+        const mask = wsBuf.subarray(off, off + 4);
+        payload = Buffer.from(payload);
+        for (let i = 0; i < payload.length; i++) payload[i] ^= mask[i & 3];
+      }
+      wsBuf = wsBuf.subarray(off + maskLen + len);
+      handleFrame(fin, opcode, payload);
+    }
+  };
+
+  socket.on('data', onData);
+  socket.on('error', () => {
+    closed = true;
+    uds.destroy();
+    socket.destroy();
+  });
+  // HTTP-server upgrade sockets allow half-open: a client FIN emits 'end'
+  // without 'close', so tear down both sides explicitly.
+  socket.on('end', () => {
+    closed = true;
+    uds.destroy();
+    socket.destroy();
+  });
+  socket.on('close', () => {
+    closed = true;
+    uds.destroy();
+  });
+  if (head && head.length) onData(head);
+}
+
+export function createBridge({ socketPath, host = '127.0.0.1', port = 51337 } = {}) {
+  const sockets = new Set();
+  const server = http.createServer((req, res) => {
+    res.writeHead(400, { 'content-type': 'text/plain' });
+    res.end('This is a WebSocket endpoint; connect with a WebSocket client.\n');
+  });
+  server.on('upgrade', (req, socket, head) => {
+    const key = req.headers['sec-websocket-key'];
+    const upgrade = (req.headers.upgrade || '').toLowerCase();
+    if (req.method !== 'GET' || upgrade !== 'websocket' || !key) {
+      socket.write('HTTP/1.1 400 Bad Request\r\nConnection: close\r\n\r\n');
+      socket.destroy();
+      return;
+    }
+    socket.write(
+      'HTTP/1.1 101 Switching Protocols\r\n' +
+        'Upgrade: websocket\r\n' +
+        'Connection: Upgrade\r\n' +
+        `Sec-WebSocket-Accept: ${computeAccept(key)}\r\n\r\n`,
+    );
+    sockets.add(socket);
+    socket.on('close', () => sockets.delete(socket));
+    handleConnection(socket, head, socketPath);
+  });
+  return {
+    server,
+    listen: (cb) => server.listen(port, host, cb),
+    close: () => {
+      for (const s of sockets) s.destroy();
+      return new Promise((resolve) => server.close(resolve));
+    },
+  };
+}
+
+const USAGE = `usage: node scripts/uds-ws-bridge.mjs [--port N] [--host H] [--socket PATH]
+
+env: BRIDGE_PORT (default 51337), BRIDGE_HOST (default 127.0.0.1),
+     INTENTD_SOCKET (default: platform intentd data dir, honors INTENTD_DATA_DIR)`;
+
+function parseArgs(argv) {
+  const out = {};
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    const eat = (name) => {
+      if (arg === `--${name}`) return argv[++i];
+      if (arg.startsWith(`--${name}=`)) return arg.slice(name.length + 3);
+      return undefined;
+    };
+    const port = eat('port');
+    if (port !== undefined) {
+      out.port = Number(port);
+      continue;
+    }
+    const host = eat('host');
+    if (host !== undefined) {
+      out.host = host;
+      continue;
+    }
+    const sock = eat('socket');
+    if (sock !== undefined) {
+      out.socketPath = sock;
+      continue;
+    }
+    if (arg === '--help' || arg === '-h') {
+      out.help = true;
+      continue;
+    }
+    console.error(`unknown argument: ${arg}\n${USAGE}`);
+    process.exit(2);
+  }
+  return out;
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    console.log(USAGE);
+    return;
+  }
+  const port = args.port ?? Number(process.env.BRIDGE_PORT || 51337);
+  const host = args.host ?? process.env.BRIDGE_HOST ?? '127.0.0.1';
+  const socketPath = args.socketPath ?? defaultSocketPath();
+  if (!Number.isInteger(port) || port < 0 || port > 65535) {
+    console.error(`[uds-ws-bridge] error: invalid port ${port}`);
+    process.exit(2);
+  }
+  if (!fs.existsSync(socketPath)) {
+    console.error(`[uds-ws-bridge] error: intentd UDS socket not found at ${socketPath}`);
+    console.error('[uds-ws-bridge] is intentd running? Override with INTENTD_SOCKET or --socket.');
+    process.exit(1);
+  }
+  const bridge = createBridge({ socketPath, host, port });
+  bridge.listen(() => {
+    const addr = bridge.server.address();
+    console.log(`[uds-ws-bridge] listening on ws://${addr.address}:${addr.port}/ws`);
+    console.log(`[uds-ws-bridge] proxying to UDS socket ${socketPath} (one UDS connection per WS client)`);
+    console.warn('[uds-ws-bridge] *****************************************************************');
+    console.warn('[uds-ws-bridge] * WARNING: this endpoint exposes the FULL intentd daemon API   *');
+    console.warn('[uds-ws-bridge] * with NO AUTHENTICATION. Anything that can reach this port    *');
+    console.warn('[uds-ws-bridge] * fully controls the daemon. Loopback-only; dev use only.      *');
+    console.warn('[uds-ws-bridge] *****************************************************************');
+    if (host !== '127.0.0.1' && host !== 'localhost' && host !== '::1') {
+      console.warn(`[uds-ws-bridge] * DANGER: bound to non-loopback host ${host} — do NOT do this.`);
+    }
+  });
+  const stop = (sig) => {
+    console.log(`[uds-ws-bridge] ${sig} received, shutting down`);
+    bridge.close().then(() => process.exit(0));
+  };
+  process.on('SIGINT', () => stop('SIGINT'));
+  process.on('SIGTERM', () => stop('SIGTERM'));
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) main();

--- a/scripts/uds-ws-bridge.mjs
+++ b/scripts/uds-ws-bridge.mjs
@@ -11,6 +11,10 @@
 // BRIDGE_HOST/--host (default 127.0.0.1), INTENTD_SOCKET/--socket
 // (default: platform intentd data dir, honoring INTENTD_DATA_DIR).
 //
+// Loopback-only is non-negotiable: non-loopback hosts are refused at startup
+// unless --unsafe-allow-non-loopback / BRIDGE_UNSAFE_NON_LOOPBACK=1 is passed,
+// and browser upgrades with a non-loopback Origin are rejected with 403.
+//
 // See intent-hq/monorepo#2526.
 
 import crypto from 'node:crypto';
@@ -50,6 +54,23 @@ export function defaultSocketPath(env = process.env, platform = process.platform
 
 export function computeAccept(key) {
   return crypto.createHash('sha1').update(key + WS_GUID).digest('base64');
+}
+
+export function isLoopbackHost(host) {
+  const h = String(host).replace(/^\[|\]$/g, '').toLowerCase();
+  return h === 'localhost' || h === '::1' || /^127(\.\d{1,3}){3}$/.test(h);
+}
+
+// Browser pages are not stopped by loopback binding (they run on this
+// machine), so upgrades carrying a non-loopback Origin are rejected;
+// non-browser clients send no Origin header and are unaffected.
+export function isAllowedOrigin(origin) {
+  if (origin === undefined) return true;
+  try {
+    return isLoopbackHost(new URL(origin).hostname);
+  } catch {
+    return false;
+  }
 }
 
 export function encodeFrame(opcode, payload, fin = true) {
@@ -239,8 +260,11 @@ export function createBridge({ socketPath, host = '127.0.0.1', port = 51337 } = 
     const key = req.headers['sec-websocket-key'];
     const upgrade = (req.headers.upgrade || '').toLowerCase();
     if (req.method !== 'GET' || upgrade !== 'websocket' || !key) {
-      socket.write('HTTP/1.1 400 Bad Request\r\nConnection: close\r\n\r\n');
-      socket.destroy();
+      socket.end('HTTP/1.1 400 Bad Request\r\nConnection: close\r\n\r\n');
+      return;
+    }
+    if (!isAllowedOrigin(req.headers.origin)) {
+      socket.end('HTTP/1.1 403 Forbidden\r\nConnection: close\r\n\r\n');
       return;
     }
     socket.write(
@@ -263,10 +287,11 @@ export function createBridge({ socketPath, host = '127.0.0.1', port = 51337 } = 
   };
 }
 
-const USAGE = `usage: node scripts/uds-ws-bridge.mjs [--port N] [--host H] [--socket PATH]
+const USAGE = `usage: node scripts/uds-ws-bridge.mjs [--port N] [--host H] [--socket PATH] [--unsafe-allow-non-loopback]
 
 env: BRIDGE_PORT (default 51337), BRIDGE_HOST (default 127.0.0.1),
-     INTENTD_SOCKET (default: platform intentd data dir, honors INTENTD_DATA_DIR)`;
+     INTENTD_SOCKET (default: platform intentd data dir, honors INTENTD_DATA_DIR),
+     BRIDGE_UNSAFE_NON_LOOPBACK=1 (dangerous: allow a non-loopback host)`;
 
 function parseArgs(argv) {
   const out = {};
@@ -292,6 +317,10 @@ function parseArgs(argv) {
       out.socketPath = sock;
       continue;
     }
+    if (arg === '--unsafe-allow-non-loopback') {
+      out.unsafeAllowNonLoopback = true;
+      continue;
+    }
     if (arg === '--help' || arg === '-h') {
       out.help = true;
       continue;
@@ -315,6 +344,14 @@ function main() {
     console.error(`[uds-ws-bridge] error: invalid port ${port}`);
     process.exit(2);
   }
+  const allowNonLoopback =
+    args.unsafeAllowNonLoopback || process.env.BRIDGE_UNSAFE_NON_LOOPBACK === '1';
+  if (!isLoopbackHost(host) && !allowNonLoopback) {
+    console.error(`[uds-ws-bridge] error: refusing to bind non-loopback host ${host}`);
+    console.error('[uds-ws-bridge] this endpoint is the FULL UNAUTHENTICATED daemon API; loopback-only is non-negotiable.');
+    console.error('[uds-ws-bridge] if you really must, pass --unsafe-allow-non-loopback or BRIDGE_UNSAFE_NON_LOOPBACK=1.');
+    process.exit(2);
+  }
   if (!fs.existsSync(socketPath)) {
     console.error(`[uds-ws-bridge] error: intentd UDS socket not found at ${socketPath}`);
     console.error('[uds-ws-bridge] is intentd running? Override with INTENTD_SOCKET or --socket.');
@@ -330,8 +367,12 @@ function main() {
     console.warn('[uds-ws-bridge] * with NO AUTHENTICATION. Anything that can reach this port    *');
     console.warn('[uds-ws-bridge] * fully controls the daemon. Loopback-only; dev use only.      *');
     console.warn('[uds-ws-bridge] *****************************************************************');
-    if (host !== '127.0.0.1' && host !== 'localhost' && host !== '::1') {
-      console.warn(`[uds-ws-bridge] * DANGER: bound to non-loopback host ${host} — do NOT do this.`);
+    if (!isLoopbackHost(host)) {
+      console.warn('[uds-ws-bridge] !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!');
+      console.warn(`[uds-ws-bridge] !!! DANGER: --unsafe-allow-non-loopback bound ${host} — the`);
+      console.warn('[uds-ws-bridge] !!! FULL UNAUTHENTICATED daemon API is reachable from the');
+      console.warn('[uds-ws-bridge] !!! network. Anyone who can reach this port owns the daemon.');
+      console.warn('[uds-ws-bridge] !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!');
     }
   });
   const stop = (sig) => {

--- a/scripts/uds-ws-bridge.test.mjs
+++ b/scripts/uds-ws-bridge.test.mjs
@@ -2,6 +2,7 @@
 // Run: node --test scripts/uds-ws-bridge.test.mjs
 
 import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
 import crypto from 'node:crypto';
 import { once } from 'node:events';
 import http from 'node:http';
@@ -9,8 +10,11 @@ import net from 'node:net';
 import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
+import { fileURLToPath } from 'node:url';
 
 import { createBridge, MAX_MESSAGE_BYTES } from './uds-ws-bridge.mjs';
+
+const BRIDGE_PATH = fileURLToPath(new URL('./uds-ws-bridge.mjs', import.meta.url));
 
 const WS_GUID = '258EAFA5-E914-47DA-95CA-C5AB0DC85B11';
 
@@ -83,7 +87,7 @@ class FrameReader {
   }
 }
 
-async function wsConnect(port, urlPath = '/ws') {
+async function wsConnect(port, urlPath = '/ws', extraHeaders = '') {
   const key = crypto.randomBytes(16).toString('base64');
   const sock = net.connect(port, '127.0.0.1');
   await once(sock, 'connect');
@@ -93,7 +97,9 @@ async function wsConnect(port, urlPath = '/ws') {
       'Upgrade: websocket\r\n' +
       'Connection: Upgrade\r\n' +
       `Sec-WebSocket-Key: ${key}\r\n` +
-      'Sec-WebSocket-Version: 13\r\n\r\n',
+      'Sec-WebSocket-Version: 13\r\n' +
+      extraHeaders +
+      '\r\n',
   );
   let head = Buffer.alloc(0);
   while (head.indexOf('\r\n\r\n') === -1) {
@@ -274,6 +280,61 @@ test('binary frames are ignored', async (t) => {
   assert.equal(frame.payload.toString(), 'after-binary');
   assert.equal(received.toString(), 'after-binary\n');
   sock.destroy();
+});
+
+test('client-initiated Close is echoed with the same code, then the socket closes', async (t) => {
+  let resolveConn;
+  const gotConn = new Promise((resolve) => (resolveConn = resolve));
+  const { port } = await setup(t, (c) => resolveConn(c));
+  const { sock, reader } = await wsConnect(port);
+  const conn = await gotConn;
+  const connClosed = once(conn, 'close');
+  const sockClosed = once(sock, 'close');
+  const payload = Buffer.concat([Buffer.from([0x03, 0xe8]), Buffer.from('done')]); // 1000 + reason
+  sock.write(clientFrame(0x8, payload));
+  const frame = await reader.next();
+  assert.equal(frame.opcode, 0x8);
+  assert.equal(frame.payload.readUInt16BE(0), 1000);
+  await sockClosed;
+  await connClosed;
+});
+
+test('over-cap line from the UDS side closes the WS client with 1009', async (t) => {
+  const { port } = await setup(t, (c) => {
+    c.write(Buffer.alloc(MAX_MESSAGE_BYTES + 1, 0x61));
+  });
+  const { sock, reader } = await wsConnect(port);
+  const frame = await reader.next();
+  assert.equal(frame.opcode, 0x8);
+  assert.equal(frame.payload.readUInt16BE(0), 1009);
+  await once(sock, 'close');
+});
+
+test('upgrade with a non-loopback Origin is rejected with 403', async (t) => {
+  const { port } = await setup(t);
+  const { sock, headerText } = await wsConnect(port, '/ws', 'Origin: https://evil.example\r\n');
+  assert.match(headerText, /^HTTP\/1\.1 403 /);
+  sock.destroy();
+});
+
+test('upgrade with a loopback Origin is accepted and round-trips', async (t) => {
+  const { port } = await setup(t);
+  const { sock, reader, headerText } = await wsConnect(port, '/ws', 'Origin: http://localhost:5173\r\n');
+  assert.match(headerText, /^HTTP\/1\.1 101 /);
+  sock.write(clientFrame(0x1, '{"id":1}'));
+  const frame = await reader.next();
+  assert.equal(frame.payload.toString(), '{"id":1}');
+  sock.destroy();
+});
+
+test('non-loopback host is refused at startup without the unsafe opt-out', async () => {
+  const child = spawn(process.execPath, [BRIDGE_PATH, '--host', '0.0.0.0', '--socket', '/nonexistent.sock']);
+  let stderr = '';
+  child.stderr.on('data', (d) => (stderr += d));
+  const [code] = await once(child, 'exit');
+  assert.equal(code, 2);
+  assert.match(stderr, /refusing to bind non-loopback host 0\.0\.0\.0/);
+  assert.match(stderr, /--unsafe-allow-non-loopback/);
 });
 
 test('UDS connect failure closes the WS client with a clear reason', async (t) => {

--- a/scripts/uds-ws-bridge.test.mjs
+++ b/scripts/uds-ws-bridge.test.mjs
@@ -1,0 +1,290 @@
+// Tests for scripts/uds-ws-bridge.mjs — node:test only, no live daemon.
+// Run: node --test scripts/uds-ws-bridge.test.mjs
+
+import assert from 'node:assert/strict';
+import crypto from 'node:crypto';
+import { once } from 'node:events';
+import http from 'node:http';
+import net from 'node:net';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import { createBridge, MAX_MESSAGE_BYTES } from './uds-ws-bridge.mjs';
+
+const WS_GUID = '258EAFA5-E914-47DA-95CA-C5AB0DC85B11';
+
+// Independent client-side frame codec (deliberately not reusing the bridge's
+// encoder, so encode/decode bugs cannot cancel out).
+function clientFrame(opcode, payload, fin = true) {
+  const data = Buffer.from(payload);
+  const mask = crypto.randomBytes(4);
+  const masked = Buffer.from(data);
+  for (let i = 0; i < masked.length; i++) masked[i] ^= mask[i & 3];
+  let header;
+  const len = data.length;
+  if (len < 126) {
+    header = Buffer.from([(fin ? 0x80 : 0) | opcode, 0x80 | len]);
+  } else if (len < 65536) {
+    header = Buffer.alloc(4);
+    header[0] = (fin ? 0x80 : 0) | opcode;
+    header[1] = 0x80 | 126;
+    header.writeUInt16BE(len, 2);
+  } else {
+    header = Buffer.alloc(10);
+    header[0] = (fin ? 0x80 : 0) | opcode;
+    header[1] = 0x80 | 127;
+    header.writeBigUInt64BE(BigInt(len), 2);
+  }
+  return Buffer.concat([header, mask, masked]);
+}
+
+function parseServerFrame(buf) {
+  if (buf.length < 2) return null;
+  const fin = (buf[0] & 0x80) !== 0;
+  const opcode = buf[0] & 0x0f;
+  assert.equal(buf[1] & 0x80, 0, 'server frames must be unmasked');
+  let len = buf[1] & 0x7f;
+  let off = 2;
+  if (len === 126) {
+    if (buf.length < 4) return null;
+    len = buf.readUInt16BE(2);
+    off = 4;
+  } else if (len === 127) {
+    if (buf.length < 10) return null;
+    len = Number(buf.readBigUInt64BE(2));
+    off = 10;
+  }
+  if (buf.length < off + len) return null;
+  return { fin, opcode, payload: buf.subarray(off, off + len), total: off + len };
+}
+
+class FrameReader {
+  constructor() {
+    this.buf = Buffer.alloc(0);
+    this.frames = [];
+    this.waiters = [];
+  }
+
+  feed(chunk) {
+    this.buf = this.buf.length ? Buffer.concat([this.buf, chunk]) : chunk;
+    let frame;
+    while ((frame = parseServerFrame(this.buf)) !== null) {
+      this.buf = this.buf.subarray(frame.total);
+      const waiter = this.waiters.shift();
+      if (waiter) waiter(frame);
+      else this.frames.push(frame);
+    }
+  }
+
+  next() {
+    if (this.frames.length) return Promise.resolve(this.frames.shift());
+    return new Promise((resolve) => this.waiters.push(resolve));
+  }
+}
+
+async function wsConnect(port, urlPath = '/ws') {
+  const key = crypto.randomBytes(16).toString('base64');
+  const sock = net.connect(port, '127.0.0.1');
+  await once(sock, 'connect');
+  sock.write(
+    `GET ${urlPath} HTTP/1.1\r\n` +
+      `Host: 127.0.0.1:${port}\r\n` +
+      'Upgrade: websocket\r\n' +
+      'Connection: Upgrade\r\n' +
+      `Sec-WebSocket-Key: ${key}\r\n` +
+      'Sec-WebSocket-Version: 13\r\n\r\n',
+  );
+  let head = Buffer.alloc(0);
+  while (head.indexOf('\r\n\r\n') === -1) {
+    const [chunk] = await once(sock, 'data');
+    head = Buffer.concat([head, chunk]);
+  }
+  const idx = head.indexOf('\r\n\r\n');
+  const headerText = head.subarray(0, idx).toString();
+  const reader = new FrameReader();
+  const rest = head.subarray(idx + 4);
+  sock.on('data', (chunk) => reader.feed(chunk));
+  if (rest.length) reader.feed(rest);
+  return { sock, key, headerText, reader };
+}
+
+function tmpSockPath() {
+  return path.join(os.tmpdir(), `udsws-${crypto.randomBytes(6).toString('hex')}.sock`);
+}
+
+async function startUds(onConnection) {
+  const socketPath = tmpSockPath();
+  const conns = new Set();
+  const server = net.createServer((c) => {
+    conns.add(c);
+    c.on('close', () => conns.delete(c));
+    c.on('error', () => {});
+    onConnection(c);
+  });
+  await new Promise((resolve) => server.listen(socketPath, resolve));
+  return {
+    socketPath,
+    conns,
+    close: () => {
+      for (const c of conns) c.destroy();
+      return new Promise((resolve) => server.close(resolve));
+    },
+  };
+}
+
+async function setup(t, onConnection = (c) => c.pipe(c)) {
+  const uds = await startUds(onConnection);
+  const bridge = createBridge({ socketPath: uds.socketPath, host: '127.0.0.1', port: 0 });
+  await new Promise((resolve) => bridge.listen(resolve));
+  t.after(async () => {
+    await bridge.close();
+    await uds.close();
+  });
+  return { uds, port: bridge.server.address().port };
+}
+
+test('handshake returns the correct Sec-WebSocket-Accept', async (t) => {
+  const { port } = await setup(t);
+  const { sock, key, headerText } = await wsConnect(port);
+  assert.match(headerText, /^HTTP\/1\.1 101 /);
+  const expected = crypto.createHash('sha1').update(key + WS_GUID).digest('base64');
+  assert.ok(headerText.includes(`Sec-WebSocket-Accept: ${expected}`));
+  sock.destroy();
+});
+
+test('non-upgrade HTTP request is rejected with 400', async (t) => {
+  const { port } = await setup(t);
+  const res = await new Promise((resolve, reject) => {
+    http.get({ host: '127.0.0.1', port, path: '/ws', agent: false }, resolve).on('error', reject);
+  });
+  assert.equal(res.statusCode, 400);
+  res.resume();
+  await once(res, 'end');
+});
+
+test('WS text message round-trips through the UDS as one NDJSON line', async (t) => {
+  let received = Buffer.alloc(0);
+  const { port } = await setup(t, (c) => {
+    c.on('data', (d) => {
+      received = Buffer.concat([received, d]);
+      c.write(d);
+    });
+  });
+  const { sock, reader } = await wsConnect(port);
+  const msg = JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'workspace.list' });
+  sock.write(clientFrame(0x1, msg));
+  const frame = await reader.next();
+  assert.equal(frame.opcode, 0x1);
+  assert.equal(frame.payload.toString(), msg);
+  assert.equal(received.toString(), msg + '\n');
+  sock.destroy();
+});
+
+test('fragmented client message is reassembled into one line', async (t) => {
+  let received = Buffer.alloc(0);
+  const { port } = await setup(t, (c) => {
+    c.on('data', (d) => {
+      received = Buffer.concat([received, d]);
+      c.write(d);
+    });
+  });
+  const { sock, reader } = await wsConnect(port);
+  sock.write(clientFrame(0x1, '{"a"', false));
+  sock.write(clientFrame(0x0, ':"b', false));
+  sock.write(clientFrame(0x0, 'c"}', true));
+  const frame = await reader.next();
+  assert.equal(frame.opcode, 0x1);
+  assert.equal(frame.payload.toString(), '{"a":"bc"}');
+  assert.equal(received.toString(), '{"a":"bc"}\n');
+  sock.destroy();
+});
+
+test('multi-MB message survives both directions', async (t) => {
+  const { port } = await setup(t);
+  const { sock, reader } = await wsConnect(port);
+  const big = 'x'.repeat(3 * 1024 * 1024);
+  sock.write(clientFrame(0x1, big));
+  const frame = await reader.next();
+  assert.equal(frame.opcode, 0x1);
+  assert.equal(frame.payload.length, big.length);
+  assert.equal(frame.payload.toString(), big);
+  sock.destroy();
+});
+
+test('over-cap message closes the connection with 1009', async (t) => {
+  const { port } = await setup(t);
+  const { sock, reader } = await wsConnect(port);
+  const header = Buffer.alloc(10);
+  header[0] = 0x81; // FIN + text
+  header[1] = 0x80 | 127; // masked + 64-bit length
+  header.writeBigUInt64BE(BigInt(MAX_MESSAGE_BYTES + 1), 2);
+  sock.write(header);
+  const frame = await reader.next();
+  assert.equal(frame.opcode, 0x8);
+  assert.equal(frame.payload.readUInt16BE(0), 1009);
+  await once(sock, 'close');
+});
+
+test('UDS-side disconnect closes the WS client', async (t) => {
+  let resolveConn;
+  const gotConn = new Promise((resolve) => (resolveConn = resolve));
+  const { port } = await setup(t, (c) => resolveConn(c));
+  const { sock, reader } = await wsConnect(port);
+  const conn = await gotConn;
+  conn.destroy();
+  const frame = await reader.next();
+  assert.equal(frame.opcode, 0x8);
+  await once(sock, 'close');
+});
+
+test('WS-side disconnect closes the UDS connection', async (t) => {
+  let resolveConn;
+  const gotConn = new Promise((resolve) => (resolveConn = resolve));
+  const { port } = await setup(t, (c) => resolveConn(c));
+  const { sock } = await wsConnect(port);
+  const conn = await gotConn;
+  sock.destroy();
+  await once(conn, 'close');
+});
+
+test('ping is answered with a pong carrying the same payload', async (t) => {
+  const { port } = await setup(t);
+  const { sock, reader } = await wsConnect(port);
+  sock.write(clientFrame(0x9, 'ping-payload'));
+  const frame = await reader.next();
+  assert.equal(frame.opcode, 0xa);
+  assert.equal(frame.payload.toString(), 'ping-payload');
+  sock.destroy();
+});
+
+test('binary frames are ignored', async (t) => {
+  let received = Buffer.alloc(0);
+  const { port } = await setup(t, (c) => {
+    c.on('data', (d) => {
+      received = Buffer.concat([received, d]);
+      c.write(d);
+    });
+  });
+  const { sock, reader } = await wsConnect(port);
+  sock.write(clientFrame(0x2, Buffer.from([1, 2, 3])));
+  sock.write(clientFrame(0x1, 'after-binary'));
+  const frame = await reader.next();
+  assert.equal(frame.opcode, 0x1);
+  assert.equal(frame.payload.toString(), 'after-binary');
+  assert.equal(received.toString(), 'after-binary\n');
+  sock.destroy();
+});
+
+test('UDS connect failure closes the WS client with a clear reason', async (t) => {
+  const bridge = createBridge({ socketPath: tmpSockPath(), host: '127.0.0.1', port: 0 });
+  await new Promise((resolve) => bridge.listen(resolve));
+  t.after(() => bridge.close());
+  const { sock, reader } = await wsConnect(bridge.server.address().port);
+  sock.write(clientFrame(0x1, '{"jsonrpc":"2.0","id":1,"method":"workspace.list"}'));
+  const frame = await reader.next();
+  assert.equal(frame.opcode, 0x8);
+  assert.equal(frame.payload.readUInt16BE(0), 1011);
+  assert.match(frame.payload.subarray(2).toString(), /intentd UDS error/);
+  await once(sock, 'close');
+});


### PR DESCRIPTION
Part of intent-hq/monorepo#2526 (docs PR on cloudlands-fe and live E2E validation follow; do not auto-close).

## Summary

Source-checkout-only dev tool that exposes a running intentd's UDS socket as an **unauthenticated plain `ws://` endpoint on loopback**, so WS-only clients (the `dev:web` renderer, plain WS clients, agents) can drive the full daemon API against a production daemon without touching its auth posture (authed WSS on 5181 for iOS keeps working).

- `scripts/uds-ws-bridge.mjs` — zero-dependency Node shim (built-in `http`/`crypto`/`net` only; no package.json added). RFC 6455 server on `ws://127.0.0.1:51337` (BRIDGE_PORT/BRIDGE_HOST/INTENTD_SOCKET overridable), one dedicated UDS connection per WS client, 1:1 framing translation (WS text frame ↔ NDJSON line), 40 MiB cap both directions, ping/pong, fragmentation, clean lifecycle teardown, loud unauthed-endpoint startup warning, fail-fast when the socket is missing.
- `scripts/uds-ws-bridge.test.mjs` — `node:test` suite (11 tests, no npm install): handshake, round-trip via fake UDS echo server, fragmentation, large/over-cap messages, disconnect propagation both ways, ping/pong, binary-frame ignore, connect-failure close reason.
- `Makefile` — documented `uds-to-unauthed-wss-bridge` target; socket resolution mirrors the `dev-prod` pattern from #2157 (explicit `INTENTD_SOCKET` wins → platform default → existence check with clear error) so the two can unify into a shared helper later.
- `.github/workflows/ci.yml` — `bridge-test` job running `node --test scripts/uds-ws-bridge.test.mjs`.

Note: #2157 (`make dev-prod`) touches the same Makefile posture-comment/.PHONY area — whichever lands second rebases; contents are complementary (dev-prod = Electron FE on UDS; this = WS access).

## Verification

- `node --test scripts/uds-ws-bridge.test.mjs` — 11/11 pass on system Node.
- `make help` lists the target; missing-socket error path and port override exercised.
- Live end-to-end validation against the running production daemon (bridge → `pnpm dev:web` → embedded tab via `browser.exec` → screenshot) is a dedicated follow-up task; evidence will be posted on #2526.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author