### PR TITLE
docs: state that fe release assets live only on the cloudlands-releases mirror

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,8 +132,11 @@ guardrails) lives in [docs/RELEASING.md](./docs/RELEASING.md). The agent-facing 
   "Shipped in cloudlands-fe vX.Y.Z (alpha)."). This applies to intentd-only changes
   too: they ride the chained cloudlands-fe alpha, and the version to report is the
   cloudlands-fe alpha — verify inclusion via `intentdVersion` in the published
-  release's `release-manifest.json`. Use background monitoring (`ws.pr.monitor` /
-  `ws.hook.*`) — never block a turn polling.
+  release's `release-manifest.json` on the
+  [intent-hq/cloudlands-releases](https://github.com/intent-hq/cloudlands-releases)
+  mirror (same tag; cloudlands-fe source-repo releases carry no assets). Use
+  background monitoring (`ws.pr.monitor` / `ws.hook.*`) — never block a turn
+  polling.
 - Monorepo-only work (docs, Makefile, CI, scripts) ships nothing to the alpha channel,
   so it needs no release monitoring or shipped-version status message.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,9 +134,9 @@ guardrails) lives in [docs/RELEASING.md](./docs/RELEASING.md). The agent-facing 
   cloudlands-fe alpha — verify inclusion via `intentdVersion` in the published
   release's `release-manifest.json` on the
   [intent-hq/cloudlands-releases](https://github.com/intent-hq/cloudlands-releases)
-  mirror (same tag; cloudlands-fe source-repo releases carry no assets). Use
-  background monitoring (`ws.pr.monitor` / `ws.hook.*`) — never block a turn
-  polling.
+  distribution repo (same tag; cloudlands-fe source-repo releases carry no
+  assets). Use background monitoring (`ws.pr.monitor` / `ws.hook.*`) — never
+  block a turn polling.
 - Monorepo-only work (docs, Makefile, CI, scripts) ships nothing to the alpha channel,
   so it needs no release monitoring or shipped-version status message.
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -60,7 +60,14 @@ cloudlands-fe).
   PR (verify with `node scripts/fetch-sidecar.cjs` from that directory) and cuts the
   cloudlands-fe release.
 - release-please maintains a release PR. Merging it cuts the tag and `release-beta.yml`
-  publishes to `intent-hq/cloudlands-releases`.
+  publishes to `intent-hq/cloudlands-releases`. All release assets — installers,
+  update feeds, and `release-manifest.json` — live **only** on the
+  [intent-hq/cloudlands-releases](https://github.com/intent-hq/cloudlands-releases)
+  mirror (same `vX.Y.Z` tag); the release on the `cloudlands-fe` source repo carries
+  the changelog but **no assets**. Anything polling for release assets (e.g. checking
+  `intentdVersion` in `release-manifest.json`) must query the mirror, not the source
+  repo. (intentd differs: its manifests are dual-published, so its source-repo
+  releases do carry assets — see the intentd section above.)
 - The Release PR merge is automated by `auto-cut-beta.yml`, which is event-chained
   with an hourly cron backstop: the pin-bump squash merge (a push to `main` touching
   `intentd.version`, made with `RELEASE_PAT` so it triggers workflows) chains straight
@@ -128,6 +135,8 @@ the crons (:15 pin bump, :30 cut) keep everything working at cron cadence.
   sections are hidden), so a sidecar pin bump never appears in the release PR
   diff/changelog. The tag is cut on the merge commit whose tree contains the pin; the
   authoritative check is `intentdVersion` in the published release's
-  `release-manifest.json`.
+  `release-manifest.json` on the
+  [intent-hq/cloudlands-releases](https://github.com/intent-hq/cloudlands-releases)
+  mirror (same tag) — cloudlands-fe source-repo releases carry no assets.
 - Commits merged after the release PR was cut ride the next release PR (e.g. intentd#517
   landed via follow-up release PR intentd#520).

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -63,11 +63,12 @@ cloudlands-fe).
   publishes to `intent-hq/cloudlands-releases`. All release assets — installers,
   update feeds, and `release-manifest.json` — live **only** on the
   [intent-hq/cloudlands-releases](https://github.com/intent-hq/cloudlands-releases)
-  mirror (same `vX.Y.Z` tag); the release on the `cloudlands-fe` source repo carries
-  the changelog but **no assets**. Anything polling for release assets (e.g. checking
-  `intentdVersion` in `release-manifest.json`) must query the mirror, not the source
-  repo. (intentd differs: its manifests are dual-published, so its source-repo
-  releases do carry assets — see the intentd section above.)
+  distribution repo (same `vX.Y.Z` tag); the release on the `cloudlands-fe` source
+  repo carries the changelog but **no assets**. Anything polling for release assets
+  (e.g. checking `intentdVersion` in `release-manifest.json`) must query the
+  distribution repo, not the source repo. (intentd differs: cargo-dist publishes
+  daemon archives to the source repo's releases, and its channel manifests are
+  dual-published — see the intentd section above.)
 - The Release PR merge is automated by `auto-cut-beta.yml`, which is event-chained
   with an hourly cron backstop: the pin-bump squash merge (a push to `main` touching
   `intentd.version`, made with `RELEASE_PAT` so it triggers workflows) chains straight
@@ -137,6 +138,6 @@ the crons (:15 pin bump, :30 cut) keep everything working at cron cadence.
   authoritative check is `intentdVersion` in the published release's
   `release-manifest.json` on the
   [intent-hq/cloudlands-releases](https://github.com/intent-hq/cloudlands-releases)
-  mirror (same tag) — cloudlands-fe source-repo releases carry no assets.
+  distribution repo (same tag) — cloudlands-fe source-repo releases carry no assets.
 - Commits merged after the release PR was cut ride the next release PR (e.g. intentd#517
   landed via follow-up release PR intentd#520).


### PR DESCRIPTION
Fixes intent-hq/monorepo#2564

## Problem

`docs/RELEASING.md` and `AGENTS.md` point shipped-work verification at `intentdVersion` in "the published release's `release-manifest.json`" without saying where that release lives. In practice `intent-hq/cloudlands-fe` releases carry **no assets** — the manifest and all artifacts are published only on the `intent-hq/cloudlands-releases` mirror (same tag). An agent following the docs verbatim polls the source repo and never finds the manifest (observed while tracking intentd v0.7.2 → cloudlands-fe v2.51.0: `repos/intent-hq/cloudlands-fe/releases/tags/v2.51.0` has `assets: []`; the mirror's `v2.51.0` release has the manifest with `intentdVersion: 0.7.2`).

## Changes (docs-only)

- **docs/RELEASING.md → cloudlands-fe**: state that all fe release assets — installers, update feeds, `release-manifest.json` — live only on the cloudlands-releases mirror (same tag); the source-repo release carries the changelog but no assets. Notes the intentd contrast (dual-published manifests, source-repo releases do carry assets).
- **docs/RELEASING.md → Gotchas**: the authoritative `intentdVersion` check now names the mirror explicitly.
- **AGENTS.md → Release Process**: the shipped-work tracking rule now says to verify on the cloudlands-releases mirror.

No workflow behavior changes.
