### PR TITLE
docs(protocol): agent-scoped browser tab ownership contract (§5.9)

### DIFF
--- a/docs/protocol/methods/execution-locus.md
+++ b/docs/protocol/methods/execution-locus.md
@@ -62,6 +62,13 @@ in the bullet under this table).
   result. The daemon forwards the `browser.exec` envelope verbatim — the wire shape is
   unchanged; rewritten action results carry the additive `requestedUrl` / `finalUrl` /
   `rewritten` / `reason` echo fields. Full contract in §5.9.
+- **`browser.exec` agent-scoped tab ownership — FE-enforced (monorepo#2857).** Embedded
+  browser tabs carry a nullable `ownerAgentId`; agents may only manipulate tabs they
+  own, may claim unowned tabs (`claimTab`, atomic first-claim-wins), and agent-owned
+  tabs render under CDP viewport emulation. Enforcement lives entirely on the frontend
+  that serves the reverse RPC — the daemon forwards the `browser.exec` envelope
+  verbatim (agent-initiated calls always carry `agentId`; callers without `agentId`
+  are the user, unrestricted) and the wire shape is unchanged. Full contract in §5.9.
 - `host.exec` is a **daemon-owned one-shot exec** so the FE never spawns workspace-adjacent
   commands itself. It uses `argv` only — **no shell interpolation** — and spawns with the child
   in its own process group and `kill_on_drop` (so `timeoutMs` reaps the whole tree). The

--- a/docs/protocol/methods/files-terminal-browser.md
+++ b/docs/protocol/methods/files-terminal-browser.md
@@ -4,7 +4,7 @@
 
 | Method | Params | Result |
 | --- | --- | --- |
-| browser.exec | actions (req, non-empty array), tabId?, agentId?, workspaceId? | single action → the action's `{ action, success, result?, error? }` envelope; multi-action → `{ results: [...] }` — **client-callable trigger** whose real work is served by the connected FE via a reverse RPC (`browser.exec`, `id: "rev-<n>"`), see below |
+| browser.exec | actions (req, non-empty array), tabId?, agentId?, workspaceId? | single action → the action's `{ action, success, result?, error? }` envelope; multi-action → `{ results: [...] }` — **client-callable trigger** whose real work is served by the connected FE via a reverse RPC (`browser.exec`, `id: "rev-<n>"`), see below. Tabs are **agent-scoped**: `claimTab` / `listTabs` scoping / `resizeTab` and the structured ownership errors are FE-enforced — see the tab-ownership block below (monorepo#2857) |
 | browser.docs | topic (req) | docs string — **not exposed**: no router arm; see the `browser.docs — not exposed` block below |
 | terminal.list | workspaceId (req) | `{ terminals: [{ id, name, cwd, isExecutingCommand }], daemonBootId }` (v4.0 envelope — the pre-4.0 bare terminals array is retired; monorepo#1334). `daemonBootId` is the daemon's per-boot identifier (UUID v4, minted once per daemon process; never persisted): stable within one daemon lifetime and fresh after a restart, so equal values across responses prove the same daemon lifetime and an **empty `terminals` list is authoritative** for that lifetime (not a restarted daemon that lost its PTYs). `name` is **always present** on each entry: the PTY's daemon-tracked display name when one was assigned at spawn (e.g. **"Setup Script"** for the workspace setup terminal, §5.1/§5.25), else the constant `"Terminal"`. The underlying PTY display name is optional spawn metadata (§5.13); the `name` field is not (clients may still fall back to `"Terminal"` defensively). The agent-facing MCP `ws.terminal.list` binding unwraps the envelope internally — agents still see the bare terminals array (§6.8) |
 | terminal.readOutput | workspaceId (req), terminalId (req), maxLines? | output buffer text |
@@ -217,6 +217,52 @@
 > hostname is rewritten (scheme, port, path, query, and hash are preserved), and only
 > top-level `navigate` / `openTab` URLs are interpreted — never URLs inside pages
 > (redirects, fetches, links).
+>
+> **Agent-scoped tab ownership — FE-enforced (monorepo#2857).** Every embedded browser
+> tab carries a **nullable `ownerAgentId`**. User-opened tabs start **unowned**
+> (`ownerAgentId: null`); agent-opened tabs are owned by the opening agent from
+> creation. Agents may only manipulate (navigate / close / evaluate / screenshot / …)
+> tabs they own — other agents' tabs are visible in `listTabs` but not manipulable.
+> Caller attribution rides the existing envelope: agent-initiated `browser.exec` (the
+> MCP `ws.browser.exec` binding, §6.8) **always carries `agentId`**; a call without
+> `agentId` is the **user**, who is unrestricted (no ownership checks apply). Ownership
+> is enforced **entirely on the frontend** that serves the reverse RPC: the action
+> vocabulary is FE-served, the daemon remains a thin proxy, and the `browser.exec`
+> request / reverse-RPC **wire shape is unchanged** — no daemon change is involved.
+>
+> - **`claimTab { tabId, width, height? }`** — claims an **unowned** tab for the calling
+>   agent. `width` is **required** (a claim without `width` is a validation error);
+>   `height` is optional. Claims are **atomic, first-claim-wins**: a successful claim
+>   transfers ownership *and* enables viewport emulation at the given size in one step.
+>   There is **no stealing** — a claim on an already-owned tab fails with the structured
+>   `already-claimed` error naming the owning agent. Unowned tabs can only originate
+>   from users.
+> - **`listTabs { scope? }`** — `scope: 'mine' | 'unclaimed' | 'all'` (default `all`).
+>   Every returned tab carries `ownerAgentId` (`null` when unowned) plus owner display
+>   info, and **sizing info**: `mode: 'native' | 'emulated'` and, when emulated, the
+>   current `width` / `height` — so an agent can see a tab's current size before
+>   deciding to claim or resize.
+> - **Structured ownership errors** — `not-owner` (an op on a tab owned by another
+>   agent) and `already-claimed` (a claim lost to an earlier claim) surface as
+>   **action-result errors** — inside the per-action `{ action, success: false, error }`
+>   envelope, never as JSON-RPC-level errors — and each names the owning agent.
+>
+> **Viewport sizing invariant.** Unowned (user) tabs are **always native**; agent-owned
+> tabs are **always emulated** — the FE applies the size as CDP device-metrics viewport
+> emulation, so owned tabs render deterministically offscreen without disturbing the
+> user's panel layout. There is no opt-in and no clear/reset op. Agent-issued `openTab`
+> accepts optional `width` / `height` and the tab is emulated from creation; omitted
+> `width` defaults to a standard desktop viewport of **1280×800**.
+> **`resizeTab { tabId, width, height? }`** changes an owned tab's emulated size —
+> owner-only (on a non-owned tab it returns the structured `not-owner` error); there is
+> no size op for unowned (user) tabs and no reset-to-native form.
+>
+> **Ownership lifecycle.** Ownership persists when the owning agent completes. Agent
+> **deletion destroys all** the agent's tabs — self-opened and claimed alike (there is
+> no release-to-unowned path, so no tab ever transitions emulated→native); workspace
+> archive/delete discards all tabs. A user "close" of an agent-owned tab is a UI-level
+> **hide**, not a destroy: the tab stays alive and continues to appear in `listTabs`
+> for its owner. Unowned tabs close/destroy normally.
 >
 > **`browser.docs` — not exposed.** The `browser_docs` MCP tool that
 > served static reference docs on-demand has no consumer in the daemon surface (skills-style

--- a/docs/protocol/methods/files-terminal-browser.md
+++ b/docs/protocol/methods/files-terminal-browser.md
@@ -237,32 +237,52 @@
 >   There is **no stealing** — a claim on an already-owned tab fails with the structured
 >   `already-claimed` error naming the owning agent. Unowned tabs can only originate
 >   from users.
+> - **`openTab` dedupe is per-agent** — an agent re-opening the same `requestedUrl`
+>   reuses its own existing tab; tabs owned by other agents (or unowned tabs) are
+>   never reused, so two agents opening the same URL get two tabs.
 > - **`listTabs { scope? }`** — `scope: 'mine' | 'unclaimed' | 'all'` (default `all`).
 >   Every returned tab carries `ownerAgentId` (`null` when unowned) plus owner display
 >   info, and **sizing info**: `mode: 'native' | 'emulated'` and, when emulated, the
 >   current `width` / `height` — so an agent can see a tab's current size before
 >   deciding to claim or resize.
-> - **Structured ownership errors** — `not-owner` (an op on a tab owned by another
->   agent) and `already-claimed` (a claim lost to an earlier claim) surface as
->   **action-result errors** — inside the per-action `{ action, success: false, error }`
->   envelope, never as JSON-RPC-level errors — and each names the owning agent.
+> - **Structured ownership errors** — `not-owner` (an op on a tab the caller does not
+>   own — another agent's tab, or an unowned tab the caller has not claimed) and
+>   `already-claimed` (a claim lost to an earlier claim) surface as **action-result
+>   errors**: inside the per-action `{ action, success: false, error }` envelope, never
+>   as JSON-RPC-level errors. Each names the owning agent when the tab has one; a
+>   `not-owner` on an **unowned** tab carries no owner info (there is no agent to
+>   name — the remedy is `claimTab`). Ownership failures are **never** reported as the
+>   FE's top-level failure envelope (`success: false` + top-level `error`, which the
+>   daemon maps to `-32603`, see above): the FE reports the batch as executed with the
+>   failing action's envelope in `results`, so the error reaches the caller through
+>   the normal single-/multi-action reshape.
 >
 > **Viewport sizing invariant.** Unowned (user) tabs are **always native**; agent-owned
 > tabs are **always emulated** — the FE applies the size as CDP device-metrics viewport
 > emulation, so owned tabs render deterministically offscreen without disturbing the
-> user's panel layout. There is no opt-in and no clear/reset op. Agent-issued `openTab`
-> accepts optional `width` / `height` and the tab is emulated from creation; omitted
-> `width` defaults to a standard desktop viewport of **1280×800**.
-> **`resizeTab { tabId, width, height? }`** changes an owned tab's emulated size —
-> owner-only (on a non-owned tab it returns the structured `not-owner` error); there is
-> no size op for unowned (user) tabs and no reset-to-native form.
+> user's panel layout. There is no opt-in and no clear/reset op. Everywhere they appear
+> (`claimTab` / `openTab` / `resizeTab`), `width` and `height` are **positive
+> integers** (CSS px): zero, negative, fractional, or non-finite values are validation
+> errors — an emulated tab can never carry a disabling zero size. Agent-issued
+> `openTab` accepts optional `width` / `height` and the tab is emulated from creation;
+> omitted `width` defaults to **1280** and omitted `height` to **800** (the standard
+> desktop viewport 1280×800 when both are omitted), and `claimTab` with omitted
+> `height` likewise defaults to **800**.
+> **`resizeTab { tabId, width, height? }`** changes an owned tab's emulated size
+> (omitted `height` keeps the tab's current emulated height) — owner-only (on a tab
+> the caller does not own it returns the structured `not-owner` error); there is no
+> size op for unowned (user) tabs and no reset-to-native form.
 >
-> **Ownership lifecycle.** Ownership persists when the owning agent completes. Agent
-> **deletion destroys all** the agent's tabs — self-opened and claimed alike (there is
-> no release-to-unowned path, so no tab ever transitions emulated→native); workspace
-> archive/delete discards all tabs. A user "close" of an agent-owned tab is a UI-level
-> **hide**, not a destroy: the tab stays alive and continues to appear in `listTabs`
-> for its owner. Unowned tabs close/destroy normally.
+> **Ownership lifecycle.** Ownership is **FE-persisted** alongside the tab and survives
+> app restarts — an owned tab never silently reverts to unowned on relaunch. Ownership
+> persists when the owning agent completes. Agent **deletion destroys all** the agent's
+> tabs — self-opened and claimed alike (there is no release-to-unowned path, so no tab
+> ever transitions emulated→native); destruction happens when the deletion **commits**:
+> an `agent.delete` still inside its `undoDelayMs` grace window (§5.5) leaves the tabs
+> untouched, and `agent.cancelDelete` restores the agent with its tabs intact.
+> Workspace archive/delete discards all tabs. A user "close" of an agent-owned tab is a
+> UI-level **hide**, not a destroy: the tab stays alive and continues to appear in
+> `listTabs` for its owner. Unowned tabs close/destroy normally.
 >
 > **`browser.docs` — not exposed.** The `browser_docs` MCP tool that
 > served static reference docs on-demand has no consumer in the daemon surface (skills-style


### PR DESCRIPTION
Updates the canonical wire contract for agent-scoped browser tab ownership (design: intent-hq/monorepo#2857). Docs-only — no code; the daemon stays a thin proxy and the `browser.exec` request / reverse-RPC wire shape is unchanged (`BrowserExecArgs` already carries `agentId`).

## §5.9 `browser.exec` — new tab-ownership block

- **Ownership model**: every tab carries a nullable `ownerAgentId`; user-opened tabs start unowned, agent-opened tabs are owned from creation. Agents may only manipulate tabs they own. Agent-initiated `browser.exec` always carries `agentId`; callers without `agentId` are the user (unrestricted). Enforcement is entirely FE-side (action vocabulary is FE-served).
- **`claimTab { tabId, width, height? }`**: atomic, first-claim-wins, no stealing; `width` required (validation error without it) — a claim transfers ownership and enables viewport emulation at that size in one step.
- **`listTabs { scope? }`**: `scope: 'mine' | 'unclaimed' | 'all'` (default `all`); every returned tab carries `ownerAgentId` + owner display info, plus sizing info (`mode: 'native' | 'emulated'` and, when emulated, `width`/`height`).
- **Structured ownership errors**: `not-owner` and `already-claimed` surface as action-result errors (per-action `{ action, success: false, error }` envelope, never JSON-RPC-level), each naming the owning agent.
- **Viewport sizing invariant**: unowned tabs always native; agent-owned tabs always emulated (CDP device-metrics viewport emulation — deterministic offscreen, does not disturb user panel layout). No opt-in, no reset. Agent `openTab` takes optional `width`/`height`; omitted `width` defaults to 1280×800. `resizeTab { tabId, width, height? }` is owner-only.
- **Lifecycle**: ownership persists through agent completion; agent deletion destroys all the agent's tabs (self-opened and claimed alike — no release-to-unowned path, so no emulated→native transition); workspace archive/delete discards all tabs; a user "close" of an agent-owned tab is a UI-level hide, not a destroy.

## §5.14 execution-locus.md

Short cross-reference bullet next to the existing FE-served loopback-hostname convention, pointing at the full §5.9 contract.

Refs intent-hq/monorepo#2857 (design issue stays open until the FE implementation lands).
