### PR TITLE
docs: fix turn-correlation bullet to reflect queueInfo.batchId stamp

### DIFF
--- a/docs/protocol/methods/agents.md
+++ b/docs/protocol/methods/agents.md
@@ -515,8 +515,9 @@ question-hold derivation, and queue persistence/rehydration are all untouched by
   `turnId`, and ALL flushed rows persist — and their `agent:message` echoes are stamped —
   under that same combined `turnId` (not each entry's own), so all N echoes correlate with
   the single `agent:queue:processing` / `agent:stream:*` lifecycle. The queue entries
-  themselves keep their own `turnId`s (entry ids / `messageMetadata` / `queueInfo` are
-  untouched). The merged turn options carry attachments and prepend payloads from all entries
+  themselves keep their own `turnId`s and ids; the only metadata mutation beyond the
+  single-drain annotations is the shared `queueInfo.batchId` grouping stamp on every entry
+  of the batch. The merged turn options carry attachments and prepend payloads from all entries
   in message order, the head entry's `queuedAt` / `interruptPriority` / `messageMetadata`,
   and a user origin when ANY flushed entry is user-origin (a user message is being
   delivered); the turn-begin report clear is suppressed only when EVERY entry is a #576


### PR DESCRIPTION
Follow-up to #2943, addressing the verifier finding in https://github.com/intent-hq/monorepo/pull/2943#issuecomment-5352499189 (filed as a new PR because #2943 was already merged and its branch deleted).

The "Turn correlation (monorepo#1022)" bullet in the "Queued-message flush" section still claimed the queue entries' `messageMetadata` / `queueInfo` are untouched by a batch flush, contradicting the `queueInfo.batchId` grouping stamp documented two bullets earlier (and the updated Rust doc comment on `prepare_flush_turn` from intent-hq/intentd#1335).

## Changes

`docs/protocol/methods/agents.md`, "Turn correlation" bullet: reworded the parenthetical to "keep their own `turnId`s and ids; the only metadata mutation beyond the single-drain annotations is the shared `queueInfo.batchId` grouping stamp on every entry of the batch."

Docs-only; no code.
