### PR TITLE
docs: document the fe auto-cut BE-dependency freshness guardrail

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -85,6 +85,20 @@ cloudlands-fe).
   age bound stops a failed intentd build from deferring fe cuts forever, and the
   check fails open on any lookup error (missing `INTENTD_READ_PAT`, unreachable
   manifest, unreadable tags) so an unreadable intentd never blocks fe releases.
+  BE-dependency freshness guardrail (intent-hq/monorepo#2985): the intentd-first
+  rule orders merges, not releases, so an fe commit can merge after its intentd
+  counterpart and still ship in an alpha whose pinned sidecar predates that BE
+  work. Before merging, the cut resolves the pin from `intentd.version` on fe
+  main and compares `v<pin>...main` on `intent-hq/intentd`: when intentd main has
+  no commits after the pinned tag (the expected common case, one cheap API
+  comparison) the cut proceeds unrestricted; when intentd main is ahead and the
+  cut would ship fe commits merged after that tag was cut, it defers — those
+  commits may depend on intentd work in no published sidecar, and the next
+  intentd alpha's pin-bump push chains into a cut that re-evaluates (push runs
+  with polling budget left retry in-run). Automation commits (the sidecar
+  pin-bump itself, `chore(release):` merges) are exempt from the freshness test,
+  and the check fails open on any lookup error (missing `INTENTD_READ_PAT`,
+  unreadable pin/tags/comparison) — same convention as the in-flight guardrail.
 - Stable: dispatch `release-stable.yml` with the `version` input.
 
 ## Release notifier


### PR DESCRIPTION
Documents the BE-dependency freshness guardrail added to cloudlands-fe's `auto-cut-beta.yml` in [intent-hq/cloudlands-fe#1511](https://github.com/intent-hq/cloudlands-fe/pull/1511) (for #2985 — the fe PR carries the `Fixes`; this is docs-only).

Adds a paragraph to the cloudlands-fe section of `docs/RELEASING.md` next to the existing in-flight guardrail, covering:

- why the guard exists (the intentd-first rule orders merges, not releases)
- the relaxation rule (intentd main not ahead of the pinned tag → cut unrestricted; expected common case, one cheap API comparison)
- the defer rule (intentd main ahead + fe commits merged after the pinned tag was cut)
- automation-commit exemptions (sidecar pin-bump, `chore(release):` merges)
- fail-open semantics on every lookup error, matching the in-flight guardrail convention
