### PR TITLE
docs(protocol): state §5.9 viewport sizing bounds 320–3840 px

### DIFF
--- a/docs/protocol/methods/files-terminal-browser.md
+++ b/docs/protocol/methods/files-terminal-browser.md
@@ -262,10 +262,13 @@
 > emulation, so owned tabs render deterministically offscreen without disturbing the
 > user's panel layout. There is no opt-in and no clear/reset op. Everywhere they appear
 > (`claimTab` / `openTab` / `resizeTab`), `width` and `height` are **integers within
-> 320–3840** (CSS px, inclusive): fractional, non-finite, or out-of-range values
-> (below 320 — which covers zero and negatives — or above 3840) are validation
-> errors, reported inside the per-action `{ action, success: false, error }` result
-> envelope — an emulated tab can never carry a disabling zero size. Agent-issued
+> 320–3840** (CSS px, inclusive), enforced up-front by action-sequence schema
+> validation: fractional, non-finite, or out-of-range values (below 320 — which
+> covers zero and negatives — or above 3840) reject the **whole batch before any
+> action executes**, surfacing through the FE top-level failure envelope
+> (`success: false` + top-level `error`, `Invalid action sequence: …`) that the
+> daemon maps to `-32603` (see above) — an emulated tab can never carry a
+> disabling zero size. Agent-issued
 > `openTab` accepts optional `width` / `height` and the tab is emulated from creation;
 > omitted `width` defaults to **1280** and omitted `height` to **800** (the standard
 > desktop viewport 1280×800 when both are omitted), and `claimTab` with omitted

--- a/docs/protocol/methods/files-terminal-browser.md
+++ b/docs/protocol/methods/files-terminal-browser.md
@@ -261,9 +261,11 @@
 > tabs are **always emulated** — the FE applies the size as CDP device-metrics viewport
 > emulation, so owned tabs render deterministically offscreen without disturbing the
 > user's panel layout. There is no opt-in and no clear/reset op. Everywhere they appear
-> (`claimTab` / `openTab` / `resizeTab`), `width` and `height` are **positive
-> integers** (CSS px): zero, negative, fractional, or non-finite values are validation
-> errors — an emulated tab can never carry a disabling zero size. Agent-issued
+> (`claimTab` / `openTab` / `resizeTab`), `width` and `height` are **integers within
+> 320–3840** (CSS px, inclusive): fractional, non-finite, or out-of-range values
+> (below 320 — which covers zero and negatives — or above 3840) are validation
+> errors, reported inside the per-action `{ action, success: false, error }` result
+> envelope — an emulated tab can never carry a disabling zero size. Agent-issued
 > `openTab` accepts optional `width` / `height` and the tab is emulated from creation;
 > omitted `width` defaults to **1280** and omitted `height` to **800** (the standard
 > desktop viewport 1280×800 when both are omitted), and `claimTab` with omitted


### PR DESCRIPTION
Aligns the §5.9 viewport sizing prose with the implemented FE validation bounds (refs #2857; flagged by the fe#1458 verifier).

## What changed

`docs/protocol/methods/files-terminal-browser.md`, §5.9 **Viewport sizing invariant** block only:

- `width` / `height` (everywhere sizes are accepted: `claimTab` / `openTab` / `resizeTab`) are now stated as **integers within 320–3840 CSS px, inclusive** — previously the prose said only "positive integers", while the merged FE `ViewportDimensionSchema` (fe#1458) enforces `z.number().int().min(320).max(3840)`.
- Out-of-range behavior is stated explicitly: fractional, non-finite, or out-of-range values are validation errors reported inside the per-action `{ action, success: false, error }` result envelope.

No other contract semantics changed.

## Verification

- Cross-checked against the merged FE schema: `src/features/browser/main/browser-action-executor.ts` — `const ViewportDimensionSchema = z.number().int().min(320).max(3840);`, applied to `openTab` (both optional), `claimTab` (`width` required), and `resizeTab` (`width` required).
- Docs-only change; diff is strictly the §5.9 sizing prose.
