### PR TITLE
docs: warn against quoting the breaking-change footer token in commits and PRs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,9 +95,10 @@ rolling bump PR may cover both submodule refs); do not file a manual bump PR.
 - **Never quote the literal breaking-change footer token.** release-please/release-plz
   treat `BREAKING CHANGE:` / `BREAKING-CHANGE:` (and `Release-As:`) appearing anywhere
   in a commit body as a real footer — a commit that merely *quotes* the token causes a
-  false major bump (this accidentally cut cloudlands-fe v3.0.0; see
-  intent-hq/monorepo#2988). Squash merges include every branch commit message in the
-  squash body, so the token in any branch commit still lands on main. Never write the
+  false major bump (or, for `Release-As:`, a forced pinned version); this accidentally
+  cut cloudlands-fe v3.0.0 — see intent-hq/monorepo#2988. Squash merges include every
+  branch commit message in the squash body, so the token in any branch commit still
+  lands on main. Never write the
   literal token in commit messages, PR titles/bodies, or review comments unless an
   actual breaking change is intended; when describing the mechanism, write "the
   breaking-change footer token" or similar instead.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,6 +92,15 @@ rolling bump PR may cover both submodule refs); do not file a manual bump PR.
 - **Conventional commits** are required. PR titles are validated by CI
   (`amannn/action-semantic-pull-request`) against: `feat`, `fix`, `chore`, `docs`,
   `refactor`, `test`, `ci`, `perf`.
+- **Never quote the literal breaking-change footer token.** release-please/release-plz
+  treat `BREAKING CHANGE:` / `BREAKING-CHANGE:` (and `Release-As:`) appearing anywhere
+  in a commit body as a real footer — a commit that merely *quotes* the token causes a
+  false major bump (this accidentally cut cloudlands-fe v3.0.0; see
+  intent-hq/monorepo#2988). Squash merges include every branch commit message in the
+  squash body, so the token in any branch commit still lands on main. Never write the
+  literal token in commit messages, PR titles/bodies, or review comments unless an
+  actual breaking change is intended; when describing the mechanism, write "the
+  breaking-change footer token" or similar instead.
 - **Merging**: agents must **NEVER merge a PR or arm auto-merge — in this repo or any
   submodule repo — without explicit permission from a human**. Approved + green checks
   is not enough. Repo-owned automation is exempt (auto-bump-submodules,


### PR DESCRIPTION
## What

Adds a Conventions bullet to AGENTS.md documenting the breaking-change footer footgun: release tooling (release-please / release-plz) treats the literal footer token (and its hyphenated variant, and the release-as footer) appearing anywhere in a commit body as a real footer, so a commit that merely quotes the token causes a false major bump — this accidentally cut cloudlands-fe v3.0.0. Squash merges fold every branch commit message into the squash body, so the token in any branch commit still lands on main.

## Rule documented

Never write the literal token in commit messages, PR titles/bodies, or review comments unless an actual breaking change is intended; when describing the mechanism, write "the breaking-change footer token" or similar. This PR's own commits and body follow the rule — the token is spelled explicitly only inside the documented file, which release tooling does not parse.

Companion PRs mirroring the rule in the submodule AGENTS.md files: https://github.com/intent-hq/intentd/pull/1343 and https://github.com/intent-hq/cloudlands-fe/pull/1516

Fixes intent-hq/monorepo#2988
