### PR TITLE
docs: update beta-cut references to alpha naming

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,7 +105,7 @@ rolling bump PR may cover both submodule refs); do not file a manual bump PR.
 - **Merging**: agents must **NEVER merge a PR or arm auto-merge — in this repo or any
   submodule repo — without explicit permission from a human**. Approved + green checks
   is not enough. Repo-owned automation is exempt (auto-bump-submodules,
-  auto-pin-intentd, auto-cut-beta, and the release PR workflows merge their own
+  auto-pin-intentd, auto-cut-alpha, and the release PR workflows merge their own
   rolling PRs). The repository allows squash and rebase merges; no merge queue is
   enabled. Once a human has given permission, merge with `gh pr merge --squash`
   (optionally `--auto` to merge once checks pass). The GraphQL `enqueuePullRequest`

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -6,8 +6,7 @@ and must not do around releases), see the root [AGENTS.md](../AGENTS.md) → Rel
 Process.
 
 Releases are per-component and channel-based: merging a release PR publishes to the
-rolling **alpha** channel (several workflows are historically named "beta" but publish
-to alpha); **beta** and **stable** are promotions of existing releases (no new build),
+rolling **alpha** channel; **beta** and **stable** are promotions of existing releases (no new build),
 each triggered by a manual workflow dispatch (`promote-beta.yml` /
 `promote-stable.yml` on intentd, `promote-beta.yml` / `release-stable.yml` on
 cloudlands-fe).
@@ -59,7 +58,7 @@ cloudlands-fe).
   release, then immediately pin-bumps `intentd.version` in cloudlands-fe via a manual
   PR (verify with `node scripts/fetch-sidecar.cjs` from that directory) and cuts the
   cloudlands-fe release.
-- release-please maintains a release PR. Merging it cuts the tag and `release-beta.yml`
+- release-please maintains a release PR. Merging it cuts the tag and `release-alpha.yml`
   publishes to `intent-hq/cloudlands-releases`. All release assets — installers,
   update feeds, and `release-manifest.json` — live **only** on the
   [intent-hq/cloudlands-releases](https://github.com/intent-hq/cloudlands-releases)
@@ -69,7 +68,7 @@ cloudlands-fe).
   distribution repo, not the source repo. (intentd differs: cargo-dist publishes
   daemon archives to the source repo's releases, and its channel manifests are
   dual-published — see the intentd section above.)
-- The Release PR merge is automated by `auto-cut-beta.yml`, which is event-chained
+- The Release PR merge is automated by `auto-cut-alpha.yml`, which is event-chained
   with an hourly cron backstop: the pin-bump squash merge (a push to `main` touching
   `intentd.version`, made with `RELEASE_PAT` so it triggers workflows) chains straight
   into a cut run that polls (30s interval, up to 15 min) for release-please to refresh
@@ -139,7 +138,7 @@ The pipeline is event-chained, with hourly crons as backstops: intentd release P
 merge → tag + cargo-dist build → alpha manifest publish →
 `intentd-alpha-published` dispatch → cloudlands-fe pin bump
 (`auto-pin-intentd.yml`) → pin push to `main` → chained cloudlands-fe cut
-(`auto-cut-beta.yml` push trigger) → promote each component's stable → monorepo
+(`auto-cut-alpha.yml` push trigger) → promote each component's stable → monorepo
 pins advance automatically via the auto-bump workflow (no manual bump PR). Every
 link is fail-soft: when one is missing (e.g. `FE_DISPATCH_TOKEN` unset on intentd),
 the crons (:15 pin bump, :30 cut) keep everything working at cron cadence.

--- a/docs/fe/DEPLOYING.md
+++ b/docs/fe/DEPLOYING.md
@@ -35,7 +35,7 @@ version number by hand.
 1. On every push to `main`, release-please opens (or updates) a **Release PR**
    that bumps `package.json` and regenerates `CHANGELOG.md` from the
    conventional commits since the last `v*` tag.
-2. The Release PR is auto-merged by `auto-cut-beta.yml` when it is green —
+2. The Release PR is auto-merged by `auto-cut-alpha.yml` when it is green —
    that is the release timing gate. The workflow is event-chained with an
    hourly cron backstop: a sidecar pin-bump squash merge (a push to `main`
    touching `intentd.version`) chains straight into a cut run that polls
@@ -117,9 +117,9 @@ Release workflows require the following secrets configured on `intent-hq/cloudla
 Windows builds require no signing secrets — they ship **unsigned** (see
 [Platform builds and runners](#platform-builds-and-runners)).
 
-## Beta Release Workflow
+## Alpha Release Workflow
 
-The beta release workflow is defined in `.github/workflows/release-beta.yml`.
+The alpha release workflow is defined in `.github/workflows/release-alpha.yml`.
 
 **Trigger:** Push of a `v*.*.*` tag (created by release-please when its Release PR is merged). A `workflow_dispatch` fallback is available to (re)build an **existing** tag.
 
@@ -168,7 +168,7 @@ The rollback workflow will restore a previous versioned release to a channel's r
 
 ## Platform Builds and Runners
 
-Each release ships four platform builds, produced by parallel jobs in `release-beta.yml`:
+Each release ships four platform builds, produced by parallel jobs in `release-alpha.yml`:
 
 | Platform      | Runner                                                         | Artifacts                                           | Feed file                |
 | ------------- | -------------------------------------------------------------- | --------------------------------------------------- | ------------------------ |

--- a/docs/fe/RELEASING.md
+++ b/docs/fe/RELEASING.md
@@ -4,7 +4,7 @@ This document describes the end-to-end release process for Intent (cloudlands-fe
 
 ## Overview
 
-Releases are built and published by the **Release Beta** workflow in GitHub Actions. The `intentd` sidecar is **not built from source** — it is downloaded from the pinned `intent-hq/intentd` GitHub Release recorded in the `intentd.version` file (intentd releases on its own cycle). The workflow:
+Releases are built and published by the **Release Alpha** workflow in GitHub Actions. The `intentd` sidecar is **not built from source** — it is downloaded from the pinned `intent-hq/intentd` GitHub Release recorded in the `intentd.version` file (intentd releases on its own cycle). The workflow:
 
 1. Reads the pinned intentd version from `intentd.version` and fetches the matching release asset via `scripts/fetch-sidecar.cjs` (sha256-verified, staged at `resources/sidecar/intentd`); it fails fast if the pinned release or its assets don't exist
 2. Builds the app for all four platforms in parallel jobs — macOS (arm64), Windows (x64), Linux (x64), Linux (arm64) — each with its staged `intentd` sidecar
@@ -44,11 +44,11 @@ The following secrets must be configured in the `intent-hq/cloudlands-fe` reposi
 
 1. **Merge the release-please Release PR**
 
-   The **Release Beta** workflow triggers automatically when a `v*.*.*` tag is pushed. Tags are created by release-please when its Release PR (which bumps `package.json` and updates the changelog) is merged — releasing is a matter of merging that PR, not typing a version.
+   The **Release Alpha** workflow triggers automatically when a `v*.*.*` tag is pushed. Tags are created by release-please when its Release PR (which bumps `package.json` and updates the changelog) is merged — releasing is a matter of merging that PR, not typing a version.
 
    The workflow validates the tag format, verifies the tag matches the `package.json` version at the tagged commit, and fails if a `v{version}` release already exists on `intent-hq/cloudlands-releases`.
 
-   To rebuild an **existing** tag (e.g., after a transient build failure), use the `workflow_dispatch` fallback: go to [Actions > Release Beta](https://github.com/intent-hq/cloudlands-fe/actions/workflows/release-beta.yml), click "Run workflow", and enter the existing tag (e.g., `v2.1.0`). Note the duplicate-release guard: delete the failed `v{version}` release on `cloudlands-releases` first if it was partially published.
+   To rebuild an **existing** tag (e.g., after a transient build failure), use the `workflow_dispatch` fallback: go to [Actions > Release Alpha](https://github.com/intent-hq/cloudlands-fe/actions/workflows/release-alpha.yml), click "Run workflow", and enter the existing tag (e.g., `v2.1.0`). Note the duplicate-release guard: delete the failed `v{version}` release on `cloudlands-releases` first if it was partially published.
 
    The bundled intentd version comes from the `intentd.version` pin at the tagged commit — there are no intentd-related workflow inputs. Make sure the pinned release exists on `intent-hq/intentd` (with assets for the build targets) before releasing, or the workflow will fail fast at the fetch step.
 


### PR DESCRIPTION
## Summary

Docs-only follow-up to the cross-repo beta→alpha workflow renames:

- intentd: intent-hq/intentd#1345 (`auto-cut-beta.yml` → `auto-cut-alpha.yml`)
- cloudlands-fe: intent-hq/cloudlands-fe#1519 (`auto-cut-beta.yml` → `auto-cut-alpha.yml`, `release-beta.yml` → `release-alpha.yml`)

These workflows always served the rolling **alpha** channel; the "beta" names were historical.

## Changes

- `AGENTS.md` — merging-exemption list: `auto-cut-beta` → `auto-cut-alpha`
- `docs/RELEASING.md` — workflow references updated; the "(several workflows are historically named beta but publish to alpha)" caveat removed
- `docs/fe/RELEASING.md` — "Release Beta" → "Release Alpha" (workflow name + Actions link)
- `docs/fe/DEPLOYING.md` — "Beta Release Workflow" section retitled "Alpha Release Workflow"; filename references updated

No functional/CI change in this repo. Should merge after (or together with) the two component PRs since it documents the new filenames.
