### PR TITLE
docs: update monorepo README Network & privacy section

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,9 @@ update checks against public GitHub Releases and actions you take yourself:
 
 - **Desktop app auto-updates** — the packaged app checks for and downloads
   updates from GitHub Releases on
-  [intent-hq/cloudlands-releases](https://github.com/intent-hq/cloudlands-releases).
+  [intent-hq/cloudlands-releases](https://github.com/intent-hq/cloudlands-releases),
+  and fetches release notes for the installed version from the same repo's
+  GitHub Releases API.
 - **intentd sitter self-update** — the sitter (see [Install](#install))
   downloads the daemon and checks the channel manifests published on the
   public
@@ -166,19 +168,17 @@ update checks against public GitHub Releases and actions you take yourself:
   [intentd releases page](https://github.com/intent-hq/intentd/releases). The
   mirror is the permanent public distribution channel, kept even after the
   intentd repo goes public.
-- **Auggie binary download (on demand)** — installing the Auggie CLI from the
-  desktop app downloads the pre-built binary from the latest public release of
-  [augmentcode/auggie](https://github.com/augmentcode/auggie).
 - **Provider sign-ins (user-initiated)** — signing in to a coding-agent
   provider (Auggie, Claude Code, Codex, OpenCode, Droid, Grok, Pi) runs that
-  provider's own CLI sign-in flow; each provider CLI talks to its own vendor
-  service when you sign in.
+  provider's own CLI/OAuth sign-in flow through the daemon; each provider
+  talks to its own vendor service when you sign in.
 - **User-configured integrations** — connecting GitHub (OAuth device flow or
-  personal access token), Linear (API key), or Sentry calls the respective
-  service's API with credentials you provide. Sentry is opt-in in two places:
-  the desktop app talks to the sentry.io API when you connect a Sentry
-  account, and the daemon's Sentry integration uses an API token you
-  configure. Nothing is sent to any of these services unless you connect them.
+  personal access token), Linear (API key), or Sentry (API token) has the
+  daemon call the respective service's API with credentials you provide.
+  Nothing is sent to any of these services unless you connect them.
+- **User-configured MCP servers** — the daemon connects to the MCP servers
+  you configure (including when testing a server's connection as you set it
+  up) and to no others.
 
 Coding agents you run are external programs and may access the network
 according to their own provider's behavior.


### PR DESCRIPTION
Brings the monorepo README's **Network & privacy** section in line with current behavior so it no longer contradicts the cloudlands-fe README (intent-hq/cloudlands-fe#1595).

## Changes

- **Auggie binary download bullet dropped** — the desktop app no longer downloads the Auggie binary; the section now describes only what the stack does today (no "removed" wording).
- **Sentry corrected to daemon-side only** — the app-side sentry.io API claim is gone; GitHub, Linear, and Sentry are described as user-configured integrations whose APIs the **daemon** calls with credentials you provide.
- **Provider sign-ins** — clarified that the CLI/OAuth sign-in flow runs through the daemon.
- **User-configured MCP servers added** — the daemon connects to the MCP servers you configure (including the connection test), and to no others.
- **Auto-updates bullet** — now also mentions the release-notes fetch from the `intent-hq/cloudlands-releases` GitHub Releases API.

## Scope

`README.md` Network & privacy section only — no other sections, no code, not a pin bump.
