### PR TITLE
docs: document host.exec omitted-cwd default and non-evicting hook lastError

### DIFF
--- a/docs/protocol/methods/execution-locus.md
+++ b/docs/protocol/methods/execution-locus.md
@@ -93,7 +93,14 @@ in the bullet under this table).
   then captured vars fill gaps. `cwd` requires `workspaceId` so the daemon can enforce the same lexical
   within-workspace containment guard that `file.*` uses;
   a `cwd` outside the workspace root is rejected with `-32603 "Access denied: cwd outside
-  workspace"`. Missing / invalid params surface as `-32602`. Long-lived / streaming processes
+  workspace"`. When `workspaceId` is present and `cwd` is **omitted**, the child runs from the
+  workspace's filesystem root ([intent-hq/intentd#1410](https://github.com/intent-hq/intentd/pull/1410),
+  monorepo#3231) — previously it inherited the daemon's own process cwd, so relative paths in
+  the command (e.g. `git -C .worktrees/x`) silently resolved against the wrong directory. The
+  default is best-effort and containment-neutral: a workspace with no resolvable filesystem
+  root (remote / skip-worktree rows, or a root missing on disk) falls back to the previous
+  daemon-cwd behavior rather than erroring, and requests with neither `workspaceId` nor `cwd`
+  are unchanged. Missing / invalid params surface as `-32602`. Long-lived / streaming processes
   stay on `script.*` and `terminal.*` (§5.8, §5.13) — `host.exec` is one-shot only.
 - `host.execStream` is the **streaming/interactive** counterpart for FE surfaces (e.g.
   `augment-cli`'s newline-delimited JSON chat) that need live stdout **and** a stdin channel —
@@ -101,7 +108,8 @@ in the bullet under this table).
   workspace-script-lifecycle `script.*` fit. It reuses every `host.exec` guarantee (argv-only,
   process-group + `kill_on_drop` + `timeoutMs` reap, the child-env contract above — caller
   `env` > daemon process env > captured credential gap-fill, plus enriched PATH,
-  workspace-containment on `cwd`, secret-safe env) and adds the streaming shape from
+  workspace-containment on `cwd` and the omitted-`cwd` workspace-root default,
+  secret-safe env) and adds the streaming shape from
   `git.clone` / `search.*` (§5.6 / §5.15 / §6.5): the method returns
   `{ requestId }` immediately (a `hexec-<uuid>` is minted when the caller omits one) and the
   daemon publishes one bus frame per output chunk plus one terminal exit frame, all correlated

--- a/docs/protocol/methods/hooks.md
+++ b/docs/protocol/methods/hooks.md
@@ -53,7 +53,13 @@ expiresAt?, lastRunAt?, nextRunAt?, runCount, perpetual, dispatchCount, lastErro
 lastLogs?, lastState? }` with
 `state ∈ scheduled | running | dispatched | evicted | cancelled | expired`
 (`scheduled`/`running` are the active states;
-`runCount` includes the schedule-time validation run; `lastError` is set on eviction).
+`runCount` includes the schedule-time validation run; `lastError` is set on eviction —
+and, from [intent-hq/intentd#1410](https://github.com/intent-hq/intentd/pull/1410)
+(monorepo#3231), also on a **non-evicting** run whose in-script host exec calls failed
+(nonzero exit code or timeout without a script throw): the run completes as the script
+decided, but a capped failure summary — at most 5 lines of command / exit-or-timeout /
+stderr snippet — persists to `lastError` on the still-active hook so a silently broken
+check is observable, and a later run whose execs all succeed clears it).
 `perpetual` (bool) and `dispatchCount` (number) are the perpetual-hook fields
 ([intent-hq/intentd#979](https://github.com/intent-hq/intentd/pull/979)): `dispatchCount`
 counts **fires so far** for every hook created or updated from v6.0 on — a one-shot hook's


### PR DESCRIPTION
Documents the protocol-visible behavior changes from [intent-hq/intentd#1410](https://github.com/intent-hq/intentd/pull/1410) (fixes for intent-hq/monorepo#3231 — in-hook `git fetch` failed silently):

- `docs/protocol/methods/execution-locus.md` (`host.exec` / `host.execStream`): when `workspaceId` is present and `cwd` is omitted, the child now runs from the workspace's filesystem root instead of inheriting the daemon's own process cwd. Best-effort and containment-neutral: rootless workspaces fall back to the previous daemon-cwd behavior; the explicit-`cwd` containment guard is unchanged.
- `docs/protocol/methods/hooks.md` (Hook shape): `lastError` is no longer eviction-only — a non-evicting run whose in-script host exec calls failed (nonzero exit / timeout without a throw) persists a capped failure summary to `lastError` on the still-active hook, cleared by a later all-healthy run.

Refs intent-hq/monorepo#3231 (the fix itself lands via the intentd PR; this is the paired wire-contract doc update).
