### PR TITLE
docs: document A2A send refusal discriminator, delivery outcome, and replacePending

### DIFF
--- a/docs/protocol/methods/agents.md
+++ b/docs/protocol/methods/agents.md
@@ -343,11 +343,12 @@ sends. **MCP-only surface changes** (§6.8 principle) — no new wire methods; t
   fromAgentName? }` — sender attribution is **lifted to top level** from the entry's
   `agent_message` auto-tag (`messageMetadata.fromAgentId`/`fromAgentName`, §5.5
   `agent.sendMessage`) and is absent for user-sent entries. Note the MCP presentation differs
-  cosmetically from the services-layer snapshot the guard refusal and `agent.diagnostics`
-  embed: both truncate `content` to 200 chars (with a `…` ellipsis) and drop the bulky
-  `imageBlocks`/`fileBlocks` payloads, but the MCP view lifts attribution top-level while
-  the internal snapshot leaves it inside `messageMetadata` — same entries, same order,
-  different attribution placement.
+  cosmetically from the services-layer snapshot `agent.diagnostics` embeds (the guard
+  refusal embeds this presented view, not the internal snapshot): both truncate `content`
+  to 200 chars (with a `…` ellipsis) and drop the bulky `imageBlocks`/`fileBlocks`
+  payloads, but the MCP view lifts attribution top-level while the internal snapshot
+  leaves it inside `messageMetadata` — same entries, same order, different attribution
+  placement.
 - **Queue merged into `ws.agent.status`** — the target's pending queue rides the status
   result inline as `queue` + `queueLength` (same entry shape and drain-order sorting as
   `ws.agent.getQueue`, `content` truncated to 200 chars), so one status call shows both

--- a/docs/protocol/methods/agents.md
+++ b/docs/protocol/methods/agents.md
@@ -368,12 +368,53 @@ sends. **MCP-only surface changes** (§6.8 principle) — no new wire methods; t
   agent-origin send while the caller already has a pending entry on the target's queue is
   **refused** (agent-origin sends only: FE/user sends and internal wakes are unaffected;
   `priority: "interrupt"` is included — no bypass; `editing: true` entries don't count,
-  the drain skips them). The refusal echoes the target's full queue plus remediation:
-  keep the pending message, or retract it via `ws.agent.removeQueuedMessage` and resend —
-  noting a retract-and-resend lands at the END of the queue. Different senders may still
+  the drain skips them). The refusal is a successful tool result with `ok: false` and —
+  since [intentd#1439](https://github.com/intent-hq/intentd/pull/1439) — the unmissable
+  `refused: true` discriminator (present only on guard refusals, so a naive sender can
+  tell "refused, act on the instruction" apart from other `ok: false` shapes), echoing
+  the target's presented queue (drain order, content truncated), the caller's pending
+  entry id as `pendingMessageId`, and a remediation `instruction`: keep the existing
+  entry as-is, or re-send ONE message combining everything with `replacePending: true`
+  (below). Manual `ws.agent.removeQueuedMessage` + re-send still works but is **NOT
+  atomic** — the pending entry is gone even if the re-send then fails — and either way a
+  re-sent message lands at the END of the queue. Different senders may still
   each have one pending entry; the guard is per sender/target pair, and is advisory
   check-then-send hygiene (not an atomically enforced invariant — concurrent sends from
-  one caller can race past it).
+  one caller can race past it). *(Refusal shape clarified in
+  [intentd#1440](https://github.com/intent-hq/intentd/pull/1440).)*
+- **`replacePending` replace-and-send *([intentd#1445](https://github.com/intent-hq/intentd/pull/1445))*** —
+  `replacePending: true` (options-object third argument on `ws.agent.send` /
+  `ws.agent.sendToTask`) turns the guard refusal into a **lossless replace**: the NEW
+  message is sent FIRST and the pending entry retracted after, so a failed send never
+  discards the pending entry. The result reports the outcome: retraction success →
+  `replaced: true` + `replacedMessageId` (the retracted entry's id); otherwise
+  `replaced: false` + `replaceOutcome` — `"drained"` (the entry delivered between the
+  guard check and the retraction — nothing left to retract), `"none"` (nothing to
+  replace: the option was passed but the caller had no pending entry), `"reassigned"`
+  (`sendToTask` only: the task's assignee changed mid-call, so the new message went to
+  the new assignee while the pending entry was left untouched in the old assignee's
+  queue), or `"error"` (the retraction failed for a reason other than draining — logged,
+  never masquerading as a drained race). The new message is sent in every arm, so the
+  caller never has to re-drive the sequence; an agent caller passing the option always
+  gets a replace report (fall-through paths report `replaceOutcome: "none"` rather than
+  silently ignoring it). The refusal `instruction` recommends `replacePending` as the
+  atomic remediation over manual remove + re-send.
+- **`delivery` outcome on send success *([intentd#1439](https://github.com/intent-hq/intentd/pull/1439))*** —
+  every successful `ws.agent.send` / `ws.agent.sendToTask` result carries a top-level
+  `delivery: "delivered" | "queued" | "held"` classification, so `ok: true` +
+  silently-queued is unambiguous even to a sender that only glances at the result:
+  `"held"` = parked behind the target's question hold (`heldForQuestions`, "Question
+  hold" below); `"queued"` = parked in the target's queue (busy target / non-interrupt
+  send — but ALSO the indefinite parks `quarantined: true` and `archivedParked: true`,
+  whose underlying flags stay in the result for callers that need the distinction);
+  `"delivered"` = the message is driving a turn now — claimed only on a `turnId`-bearing
+  result (plus the interrupt dedup replay, `deduplicated: true`, whose original delivery
+  did run), so the store-only fallback's persist-only success (`queued: false`, no
+  `turnId`) gets NO `delivery` claim rather than a false "delivered". Non-success shapes
+  (guard refusals, sendToTask's "No agent assigned to task") carry no `delivery` field.
+  Like the guard itself, all three are **MCP-only surface changes** (§6.8 principle) —
+  the wire `agent.sendMessage` / `agent.sendToTask` RPCs and their result shapes are
+  unchanged.
 - **Dequeue-wait annotation** — every drain path (worker drain arms, pre-release drain,
   `agent.sendQueuedMessageNow`) appends a deterministic system note to the delivered
   content — `[SYSTEM NOTE] This message was queued at <queuedAt> and waited <duration>


### PR DESCRIPTION
Documents the final landed state of three intentd PRs in the §5.5 agent-facing queue visibility & sender hygiene block of `docs/protocol/methods/agents.md`:

- [intent-hq/intentd#1439](https://github.com/intent-hq/intentd/pull/1439) — the `refused: true` discriminator on the single-pending-message guard refusal (present only on guard refusals, distinguishing them from other `ok: false` shapes), plus the canonical `delivery: "delivered" | "queued" | "held"` outcome field on every successful `ws.agent.send` / `ws.agent.sendToTask` result (with the persist-only-success no-claim rule and the interrupt-dedup "delivered" carve-out).
- [intent-hq/intentd#1440](https://github.com/intent-hq/intentd/pull/1440) — refusal-shape clarifications: `pendingMessageId`, the presented queue echo, and the caveat that manual `ws.agent.removeQueuedMessage` + re-send is NOT atomic (the pending entry is gone even if the re-send then fails).
- [intent-hq/intentd#1445](https://github.com/intent-hq/intentd/pull/1445) — the atomic `replacePending: true` option (options-object third argument): send-first, retract-after (lossless — a failed send never discards the pending entry), reporting `replaced` / `replacedMessageId` on success and `replaceOutcome: "drained" | "none" | "reassigned" | "error"` otherwise; the refusal `instruction` now recommends it as the atomic remediation.

All three are **MCP-only surface changes** (§6.8 principle) — the wire `agent.sendMessage` / `agent.sendToTask` RPCs and their result shapes are unchanged, which the doc states explicitly.

Docs-only PR: no submodule pin change is included (the auto-bump workflow owns pin advancement). Shapes verified against the landed code in `packages/intentd/crates/intent-acp/src/mcp_server/bindings/agent.rs` at intentd main (`e1532b4a`).
