### PR TITLE
docs(protocol): runningSubAgents counts only in-flight children

### DIFF
--- a/docs/protocol/methods/agents.md
+++ b/docs/protocol/methods/agents.md
@@ -479,8 +479,10 @@ are persisted.
   `agentWatches` (the caller's active outgoing completion watches, §Completion-watch
   persistence), `queuedMessages` (pending entries in the caller's OWN delivery queue),
   `eventSubscriptions` (the caller's active workspace event subscriptions, §5.5
-  `agent.subscribe`), `runningSubAgents` (delegated children not yet settled — counted over
-  the caller's `parent_agent_id` children **unscoped by workspace**, so a chief parent's
+  `agent.subscribe`), `runningSubAgents` (delegated children genuinely in flight — status
+  `pending`/`active`/`Processing`/`Waiting`; idle/restorable children do **not** count
+  ([intentd#1457](https://github.com/intent-hq/intentd/pull/1457), monorepo#3384) — counted
+  over the caller's `parent_agent_id` children **unscoped by workspace**, so a chief parent's
   cross-workspace delegates count too), `numQuestionsAsked` (structured questions still
   pending presentation/answer, §5.5 question hold), and `pendingAttention`
   (`"blocker"` / `"discussion"` when the caller has an unresolved attention request, §5.5


### PR DESCRIPTION
Aligns the `ws.agent.snapshot()` protocol documentation with [intentd#1457](https://github.com/intent-hq/intentd/pull/1457) (fix for intent-hq/monorepo#3384): `runningSubAgents` now counts only delegated children genuinely in flight (`pending`/`active`/`Processing`/`Waiting`) — idle/restorable children no longer count, so the field matches its name instead of measuring unsettled lifecycle state.

Docs-only change; no code touched. Should merge after intentd#1457 lands (intentd-first rule for protocol changes).
