### PR TITLE
feat: cap Rust make-target parallelism and add local coverage targets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,7 +125,10 @@ rolling bump PR may cover both submodule refs); do not file a manual bump PR.
   non-conventional commits from landing on main (e.g., PR #102 incident).
 - **Changelogs** are generated with `git-cliff` (see `cliff.toml`).
 - **Rust**: run the package gates before opening a PR — `make check` / `make test`
-  from the monorepo root; see `packages/intentd/AGENTS.md` → Gates.
+  from the monorepo root; see `packages/intentd/AGENTS.md` → Gates. Coverage runs
+  on CI (the `coverage-e2e` / `coverage-all` jobs in intentd's ci.yml) and can be
+  reproduced locally with `make coverage-e2e` / `make coverage-all` — `make test`
+  deliberately excludes these slow instrumented runs.
 
 ## Release Process
 

--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,16 @@ BRIDGE_PLATFORM ?= $(shell uname -s)
 WORKSPACES_DIR ?= $(HOME)/intent/workspaces
 SWEEP_DAYS ?= 3
 
+# Parallelism caps shared by the Rust test/coverage targets. Negative values
+# mean "logical CPUs minus N" (clamped to at least 1): cargo-nextest accepts
+# them for test threads (NEXTEST_TEST_THREADS / --test-threads) and cargo for
+# build jobs (CARGO_BUILD_JOBS / --jobs) — verified with cargo 1.97 and
+# nextest 0.9.143. The -2 defaults leave two cores of headroom so local runs
+# do not saturate a laptop; override for full speed, e.g.
+# `make coverage-all TEST_THREADS=num-cpus BUILD_JOBS=default`.
+TEST_THREADS ?= -2
+BUILD_JOBS ?= -2
+
 # Node heap ceiling (MB) for the FE production build. The renderer's vite build
 # OOMs at Node's default heap (~2-4 GB) and often still OOMs at 8 GB on this
 # app; default to 16 GB. dist-mac exports this via NODE_OPTIONS so every child
@@ -93,7 +103,8 @@ FE_BUILD_HEAP_MB ?= 16384
 
 .PHONY: all help ensure-submodules ensure-intentd-submodule ensure-fe-submodule ensure-ios-submodule \
 	update \
-	build build-intentd build-sidecar test test-intentd fmt clippy check clean clean-dev \
+	build build-intentd build-sidecar test test-intentd coverage-e2e coverage-all \
+	fmt clippy check clean clean-dev \
 	sweep sweep-all seed-dev-providers seed-dev-workspaces dev-daemon release-daemon \
 	run-intentd dev-ui dev-fe fe-launch run-fe-local uds-to-unauthed-wss-bridge dev dev-prod ios-open ios-info dist-mac
 
@@ -257,6 +268,25 @@ test-intentd: ensure-intentd-submodule
 		exit 1; \
 	}
 	cd $(INTENTD_DIR) && cargo nextest run --workspace
+
+# Local reproduction of the CI coverage jobs (packages/intentd
+# .github/workflows/ci.yml: coverage-e2e / coverage-all), wrapping the same
+# scripts CI runs. These are instrumented (cargo-llvm-cov) full-suite runs —
+# slow, and deliberately NOT part of `make test`. The scripts install
+# cargo-llvm-cov / cargo-nextest / llvm-tools if missing.
+# NEXTEST_TEST_THREADS / CARGO_BUILD_JOBS carry the $(TEST_THREADS) /
+# $(BUILD_JOBS) caps into the scripts so local coverage runs also leave CPU
+# headroom by default (override e.g. TEST_THREADS=num-cpus BUILD_JOBS=default).
+# Optional COVERAGE_FLOOR passes the scripts' positional fail-under-lines
+# floor (CI uses 40), e.g. `make coverage-e2e COVERAGE_FLOOR=40`; when unset
+# it expands to nothing and no floor is enforced locally.
+coverage-e2e: ensure-intentd-submodule ## Reproduce CI e2e coverage locally (slow, instrumented; not part of make test)
+	cd $(INTENTD_DIR) && NEXTEST_TEST_THREADS=$(TEST_THREADS) CARGO_BUILD_JOBS=$(BUILD_JOBS) \
+		./scripts/coverage-e2e.sh $(COVERAGE_FLOOR)
+
+coverage-all: ensure-intentd-submodule ## Reproduce CI full-workspace coverage locally (slow, instrumented; not part of make test)
+	cd $(INTENTD_DIR) && NEXTEST_TEST_THREADS=$(TEST_THREADS) CARGO_BUILD_JOBS=$(BUILD_JOBS) \
+		./scripts/coverage-all.sh $(COVERAGE_FLOOR)
 
 clean: ## Remove cargo build artifacts (packages/intentd/target)
 	rm -rf $(INTENTD_DIR)/target

--- a/Makefile
+++ b/Makefile
@@ -84,13 +84,15 @@ BRIDGE_PLATFORM ?= $(shell uname -s)
 WORKSPACES_DIR ?= $(HOME)/intent/workspaces
 SWEEP_DAYS ?= 3
 
-# Parallelism caps shared by the Rust test/coverage targets. Negative values
-# mean "logical CPUs minus N" (clamped to at least 1): cargo-nextest accepts
-# them for test threads (NEXTEST_TEST_THREADS / --test-threads) and cargo for
-# build jobs (CARGO_BUILD_JOBS / --jobs) — verified with cargo 1.97 and
-# nextest 0.9.143. The -2 defaults leave two cores of headroom so local runs
-# do not saturate a laptop; override for full speed, e.g.
-# `make coverage-all TEST_THREADS=num-cpus BUILD_JOBS=default`.
+# Parallelism caps shared by the Rust build/test/coverage targets
+# (build-intentd, clippy, test-intentd, coverage-e2e, coverage-all).
+# Negative values mean "logical CPUs minus N" (clamped to at least 1):
+# cargo-nextest accepts them for test threads (NEXTEST_TEST_THREADS /
+# --test-threads) and cargo for build jobs (CARGO_BUILD_JOBS / --jobs) —
+# verified with cargo 1.97 and nextest 0.9.143. The -2 defaults leave two
+# cores of headroom so local runs do not saturate a laptop; override for
+# full speed, e.g. `make test TEST_THREADS=num-cpus BUILD_JOBS=default`
+# or `make coverage-all TEST_THREADS=num-cpus BUILD_JOBS=default`.
 TEST_THREADS ?= -2
 BUILD_JOBS ?= -2
 
@@ -246,28 +248,31 @@ update: ## git pull --rebase monorepo + each submodule onto its .gitmodules bran
 build: build-intentd ## Build the Rust workspace (packages/intentd)
 
 build-intentd: ensure-intentd-submodule
-	cd $(INTENTD_DIR) && cargo build --workspace
+	cd $(INTENTD_DIR) && cargo build --workspace --jobs $(BUILD_JOBS)
 
 fmt: ensure-intentd-submodule ## cargo fmt --check
 	cd $(INTENTD_DIR) && cargo fmt --check
 
 clippy: ensure-intentd-submodule ## cargo clippy --all-targets -- -D warnings
-	cd $(INTENTD_DIR) && cargo clippy --workspace --all-targets -- -D warnings
+	cd $(INTENTD_DIR) && cargo clippy --workspace --all-targets --jobs $(BUILD_JOBS) -- -D warnings
 
 check: fmt clippy ## fmt + clippy
 
-test: test-intentd ## Run the Rust test suite (cargo nextest; needs cargo-nextest)
+test: test-intentd ## Run the Rust test suite (cargo nextest, CPUs-2 by default; override TEST_THREADS/BUILD_JOBS)
 
 # Runs under nextest so local full-suite runs pick up the same
 # .config/nextest.toml protections CI uses (timing-serial test group,
 # retries, slow-timeout). nextest does not run doctests; the workspace has
 # none, so nothing is lost.
+# Capped to $(TEST_THREADS) test threads / $(BUILD_JOBS) build jobs (CPUs-2
+# by default) so a local run leaves CPU headroom; override for full speed,
+# e.g. `make test TEST_THREADS=num-cpus BUILD_JOBS=default`.
 test-intentd: ensure-intentd-submodule
 	@cargo nextest --version >/dev/null 2>&1 || { \
 		echo "[test-intentd] ERROR: cargo-nextest is not installed — run 'cargo install cargo-nextest --locked'"; \
 		exit 1; \
 	}
-	cd $(INTENTD_DIR) && cargo nextest run --workspace
+	cd $(INTENTD_DIR) && cargo nextest run --workspace --build-jobs $(BUILD_JOBS) --test-threads $(TEST_THREADS)
 
 # Local reproduction of the CI coverage jobs (packages/intentd
 # .github/workflows/ci.yml: coverage-e2e / coverage-all), wrapping the same

--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,8 @@ SWEEP_DAYS ?= 3
 # Negative values mean "logical CPUs minus N" (clamped to at least 1):
 # cargo-nextest accepts them for test threads (NEXTEST_TEST_THREADS /
 # --test-threads) and cargo for build jobs (CARGO_BUILD_JOBS / --jobs) —
-# verified with cargo 1.97 and nextest 0.9.143. The -2 defaults leave two
+# verified with the pinned cargo 1.96.0 (packages/intentd/rust-toolchain.toml)
+# and nextest 0.9.143. The -2 defaults leave two
 # cores of headroom so local runs do not saturate a laptop; override for
 # full speed, e.g. `make test TEST_THREADS=num-cpus BUILD_JOBS=default`
 # or `make coverage-all TEST_THREADS=num-cpus BUILD_JOBS=default`.


### PR DESCRIPTION
## Summary

Two quality-of-life changes to the root Makefile (monorepo-only; no submodule, script, or CI changes):

### CPU headroom for local Rust targets
- New overridable knobs: TEST_THREADS ?= -2 and BUILD_JOBS ?= -2 (negative = logical CPUs minus N, min 1 — supported natively by cargo and cargo-nextest).
- Wired into 'make test' (nextest --test-threads/--build-jobs), 'make build' (cargo build --jobs), and 'make check' clippy (cargo clippy --jobs), so a local run no longer saturates every core (laptops especially).
- Full speed stays one override away, e.g. 'make test TEST_THREADS=num-cpus BUILD_JOBS=default'.
- 'fmt' and the packaging builds (build-sidecar, dev, dist-mac) are deliberately uncapped; packages/intentd/.config/nextest.toml and CI workflows are untouched (CI keeps its own NEXTEST_TEST_THREADS).

### Local coverage repro targets
- 'make coverage-e2e' / 'make coverage-all' wrap the existing CI scripts (packages/intentd/scripts/coverage-{e2e,all}.sh) behind ensure-intentd-submodule, exporting the same headroom knobs (NEXTEST_TEST_THREADS / CARGO_BUILD_JOBS).
- Optional COVERAGE_FLOOR passes the positional floor arg, e.g. 'make coverage-e2e COVERAGE_FLOOR=40' reproduces the CI gate; no floor locally by default.
- AGENTS.md now documents that coverage runs on CI and is reproduced locally via these targets — 'make test' deliberately excludes it.

## Verification
- 'make -n test/build/check' expand the flags with defaults; 'TEST_THREADS=4 BUILD_JOBS=4' overrides both.
- 'make -n coverage-e2e' / 'coverage-all' show correct invocations with and without COVERAGE_FLOOR=40.
- 'make check' green with the --jobs wiring; 215/215 intent-core nextest slice passed under --build-jobs -2 --test-threads -2.
- 'make help' lists the new targets; intentd submodule confirmed clean (no edits).
- Reviewer re-verified all flag forms under the pinned cargo 1.96.0 (rust-toolchain.toml).