### PR TITLE
chore: reconcile issue-intake labels, severity taxonomy, and contact links

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -30,23 +30,32 @@ body:
     attributes:
       label: Component
       description: >
-        Check all that apply. Checkboxes do not apply labels automatically —
-        a triager will add the matching label (`component:intentd`,
-        `component:fe`, `component:ios`, `docs`).
+        Check all that apply. Labels are applied automatically from the
+        checked boxes (`component:intentd`, `component:fe`, `component:ios`,
+        `docs`).
       options:
         - label: intentd (Rust backend daemon)
         - label: cloudlands-fe (Electron + SvelteKit desktop frontend)
         - label: ios (SwiftUI companion app)
         - label: docs / tooling
+  # Severity → label mapping (each option maps 1:1 onto a priority:* label,
+  # keyed on the leading "Pn" token):
+  #   P0 — … → priority:P0
+  #   P1 — … → priority:P1
+  #   P2 — … → priority:P2
+  #   P3 — … → priority:P3
   - type: dropdown
     id: severity
     attributes:
       label: Severity
-      description: Per the taxonomy in docs/README.md
+      description: >
+        The matching `priority:*` label is applied automatically from your
+        selection.
       options:
-        - P0 — crash, data-loss, or corruption; blocks shipping to external users
+        - P0 — crash, data loss, or corruption; blocks shipping to external users
         - P1 — broken feature; app still usable but with significant workaround required
-        - P2 — papercut; annoying but does not block workflows
+        - P2 — degraded behavior; should be fixed, but impact is limited
+        - P3 — papercut; annoying but does not block workflows
     validations:
       required: true
   - type: checkboxes
@@ -54,4 +63,4 @@ body:
     attributes:
       label: Agent-filed
       options:
-        - label: This issue was filed by an AI agent (a triager will add the `agent-filed` label)
+        - label: This issue was filed by an AI agent (the `agent-filed` label is applied automatically)

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,1 +1,8 @@
 blank_issues_enabled: true
+contact_links:
+  - name: Report a security vulnerability
+    url: https://github.com/intent-hq/intent/security/advisories
+    about: Please report security vulnerabilities privately via GitHub security advisories, not the public issue tracker.
+  - name: Ask a question
+    url: https://github.com/intent-hq/intent/discussions
+    about: Use discussions for questions, ideas, and general help.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: true
 contact_links:
   - name: Report a security vulnerability
-    url: https://github.com/intent-hq/intent/security/advisories
+    url: https://github.com/intent-hq/intent/security/advisories/new
     about: Please report security vulnerabilities privately via GitHub security advisories, not the public issue tracker.
   - name: Ask a question
     url: https://github.com/intent-hq/intent/discussions

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -21,9 +21,9 @@ body:
     attributes:
       label: Component
       description: >
-        Check all that apply. Checkboxes do not apply labels automatically —
-        a triager will add the matching label (`component:intentd`,
-        `component:fe`, `component:ios`, `docs`).
+        Check all that apply. Labels are applied automatically from the
+        checked boxes (`component:intentd`, `component:fe`, `component:ios`,
+        `docs`).
       options:
         - label: intentd (Rust backend daemon)
         - label: cloudlands-fe (Electron + SvelteKit desktop frontend)

--- a/docs/README.md
+++ b/docs/README.md
@@ -92,10 +92,11 @@ removed. Bugs are now filed directly as GitHub issues on `intent-hq/intent`.
 
 Durable conventions carried forward from that phase:
 
-- **Severity taxonomy** for triage:
-  - **P0** — crash, data-loss, or corruption; blocks shipping to external users
+- **Severity taxonomy** for triage (maps 1:1 onto the `priority:P0`–`priority:P3` labels):
+  - **P0** — crash, data loss, or corruption; blocks shipping to external users
   - **P1** — broken feature; app still usable but with significant workaround required
-  - **P2** — papercut; annoying but does not block workflows
+  - **P2** — degraded behavior; should be fixed, but impact is limited
+  - **P3** — papercut; annoying but does not block workflows
 - **Regression coverage** expected with each fix:
   - **intentd**: `make check` + `make test` green
   - **cloudlands-fe**: `pnpm run check` + `pnpm vitest run` green


### PR DESCRIPTION
Intake-surface groundwork for the automatic issue triage pipeline (part of the triage effort; no workflow code in this PR).

## Changes

**Repo labels** (already created via `gh label create`, listed here for the record):
- `needs-triage` — awaiting triage
- `needs-info` — waiting on the reporter; removed on their next comment
- `possible-duplicate` — suspected duplicate, needs confirmation before closing
- `priority:P0` — critical: crash, data loss, or corruption (color `#B60205`, consistent with the existing `priority:*` family)

**`bug_report.yml`**
- Severity dropdown expanded to P0–P3 so options map 1:1 onto `priority:P0|P1|P2|P3` labels (previously P0/P1/P2 vs labels P1/P2/P3, with "papercut" ambiguously on P2). The mapping is documented in a YAML comment; each option is keyed on its leading `Pn` token for mechanical extraction.
- Component and agent-filed disclaimers now say labels are applied automatically from the checked boxes (they will be, by the triage workflow) instead of promising manual labeling.

**`feature_request.yml`**
- Same disclaimer update for the component checkboxes.

**`config.yml`**
- `contact_links` added: private security advisories (private vulnerability reporting is enabled) and repo discussions for questions. `blank_issues_enabled: true` kept.

## Verification
- `gh label list --repo intent-hq/intent` shows all four new labels with descriptions.
- All three template YAML files parse cleanly (`yaml.safe_load`).
