### PR TITLE
ci: add needs-info completeness loop to issue triage

### DIFF
--- a/.github/scripts/issue-triage/fixtures/blank-near-empty.md
+++ b/.github/scripts/issue-triage/fixtures/blank-near-empty.md
@@ -1,0 +1,3 @@
+app broken pls fix
+
+![screenshot](https://user-images.example.com/attachments/12345/broken.png)

--- a/.github/scripts/issue-triage/fixtures/bug-fenced-repro.md
+++ b/.github/scripts/issue-triage/fixtures/bug-fenced-repro.md
@@ -1,0 +1,25 @@
+### Component
+
+intentd (backend daemon)
+
+### Description
+
+App crashes on launch with the new build.
+
+### Reproduction steps
+
+```
+make run
+click the button
+```
+
+### Expected vs actual
+
+```
+Expected: app opens.
+Actual: crash dialog with "thread 'main' panicked".
+```
+
+### Version
+
+v1.2.3 (alpha)

--- a/.github/scripts/issue-triage/fixtures/bug-incomplete.md
+++ b/.github/scripts/issue-triage/fixtures/bug-incomplete.md
@@ -1,0 +1,24 @@
+### Description
+
+The app is broken and I cannot use it anymore since the update.
+
+### Reproduction steps
+
+1. ...
+2. ...
+
+### Expected vs actual
+
+n/a
+
+### Component
+
+- [x] cloudlands-fe (Electron + SvelteKit desktop frontend)
+
+### Severity
+
+P1 — broken feature; app still usable but with significant workaround required
+
+### Agent-filed
+
+- [ ] This issue was filed by an AI agent (the `agent-filed` label is applied automatically)

--- a/.github/scripts/issue-triage/needs-info.js
+++ b/.github/scripts/issue-triage/needs-info.js
@@ -1,0 +1,128 @@
+// Needs-info completeness loop for the triage workflow (pass 1).
+//
+// Detects incomplete bug reports (empty/placeholder "Reproduction steps" or
+// "Expected vs actual" sections) and near-empty blank-issue bodies, and
+// carries the pure decision logic for the one-nudge loop:
+//   - shouldNudge:          post the templated nudge + `needs-info` at most
+//                           once per issue (hidden HTML marker comment is the
+//                           idempotency guard, same precedent as
+//                           packages/intentd/scripts/notify-fixed-issues.sh)
+//   - shouldClearNeedsInfo: only the issue author's reply clears the label
+//
+// Pure and dependency-free so it can be unit-tested with `node --test`
+// and required from actions/github-script.
+
+'use strict';
+
+const { splitSections } = require('./parse-issue.js');
+
+const NEEDS_INFO_LABEL = 'needs-info';
+
+// Hidden marker embedded in the nudge comment; its presence anywhere in the
+// issue's comments means the nudge was already posted (re-runs never
+// double-post, even after the label was removed).
+const NEEDS_INFO_MARKER = '<!-- issue-triage: needs-info -->';
+
+// Bug-template sections that must carry real content.
+const REQUIRED_BUG_SECTIONS = ['Reproduction steps', 'Expected vs actual'];
+
+// Words that alone convey no information ("tbd", "n/a", ...).
+const PLACEHOLDER_WORDS = new Set(['tbd', 'todo', 'none', 'nil', 'na', 'idk', 'unknown']);
+
+// Minimum meaningful characters for a free-form (non-template) body.
+const NEAR_EMPTY_MIN_CHARS = 30;
+
+// True when a section's content is empty, "_No response_", or contains no
+// meaningful words (only punctuation, list numbering, or placeholder words —
+// e.g. the template's untouched "1. ...\n2. ..." placeholder).
+function isPlaceholderSection(lines) {
+  const text = (lines || []).join('\n').trim();
+  if (!text || /^_no response_$/i.test(text)) return true;
+  const tokens = (text.match(/[A-Za-z]{2,}/g) || [])
+    .map((t) => t.toLowerCase())
+    .filter((t) => !PLACEHOLDER_WORDS.has(t));
+  return tokens.length === 0;
+}
+
+// Meaningful character count of a free-form body: markdown images/links and
+// bare URLs are stripped first so a body that is only a screenshot or a link
+// still counts as near-empty.
+function meaningfulLength(body) {
+  const stripped = String(body || '')
+    .replace(/!?\[[^\]]*\]\([^)]*\)/g, ' ')
+    .replace(/https?:\/\/\S+/g, ' ');
+  const tokens = stripped.match(/[A-Za-z0-9]{2,}/g) || [];
+  return tokens.join('').length;
+}
+
+// Assess an issue body's completeness. Returns { incomplete, reasons }.
+//   - Bodies with the bug template's repro/expected sections must have real
+//     content in both.
+//   - Bodies with no template sections at all (blank issues) must clear a
+//     minimal meaningful-content bar.
+//   - Everything else (e.g. feature requests) is never flagged.
+function assessCompleteness(body) {
+  const reasons = [];
+  const sections = splitSections(body || '');
+  const isBugTemplate = REQUIRED_BUG_SECTIONS.some((name) => sections[name]);
+  if (isBugTemplate) {
+    for (const name of REQUIRED_BUG_SECTIONS) {
+      if (!sections[name] || isPlaceholderSection(sections[name])) {
+        reasons.push(`the "${name}" section is empty or placeholder-only`);
+      }
+    }
+  } else if (Object.keys(sections).length === 0) {
+    if (meaningfulLength(body) < NEAR_EMPTY_MIN_CHARS) {
+      reasons.push(
+        'the issue body has almost no content — please describe what happened, ' +
+          'how to reproduce it, and what you expected'
+      );
+    }
+  }
+  return { incomplete: reasons.length > 0, reasons };
+}
+
+// The one templated nudge comment, marker included.
+function buildNudgeComment(reasons) {
+  const bullets = reasons.map((r) => `- ${r}`).join('\n');
+  return [
+    'Thanks for the report! To triage it we need a bit more detail — right now:',
+    '',
+    bullets,
+    '',
+    'Could you reply to this issue with the missing details? The `needs-info`',
+    'label is removed automatically on your next comment and triage re-runs.',
+    '',
+    NEEDS_INFO_MARKER,
+  ].join('\n');
+}
+
+// Nudge at most once: never when the body is complete, the label is already
+// present, or any existing comment carries the marker (i.e. we nudged before,
+// even if the label was since removed).
+function shouldNudge({ assessment, labels, commentBodies }) {
+  if (!assessment || !assessment.incomplete) return false;
+  if ((labels || []).includes(NEEDS_INFO_LABEL)) return false;
+  const bodies = commentBodies || [];
+  if (bodies.some((b) => typeof b === 'string' && b.includes(NEEDS_INFO_MARKER))) return false;
+  return true;
+}
+
+// Clear `needs-info` only when the ISSUE AUTHOR comments on a labeled issue.
+// Comments from anyone else — including our own marker-carrying nudge — do
+// not clear it.
+function shouldClearNeedsInfo({ labels, issueAuthor, commentAuthor, commentBody }) {
+  if (!(labels || []).includes(NEEDS_INFO_LABEL)) return false;
+  if (!issueAuthor || !commentAuthor || commentAuthor !== issueAuthor) return false;
+  if (typeof commentBody === 'string' && commentBody.includes(NEEDS_INFO_MARKER)) return false;
+  return true;
+}
+
+module.exports = {
+  NEEDS_INFO_LABEL,
+  NEEDS_INFO_MARKER,
+  assessCompleteness,
+  buildNudgeComment,
+  shouldNudge,
+  shouldClearNeedsInfo,
+};

--- a/.github/scripts/issue-triage/needs-info.js
+++ b/.github/scripts/issue-triage/needs-info.js
@@ -97,15 +97,21 @@ function buildNudgeComment(reasons) {
   ].join('\n');
 }
 
-// Nudge at most once: never when the body is complete, the label is already
-// present, or any existing comment carries the marker (i.e. we nudged before,
-// even if the label was since removed).
-function shouldNudge({ assessment, labels, commentBodies }) {
-  if (!assessment || !assessment.incomplete) return false;
-  if ((labels || []).includes(NEEDS_INFO_LABEL)) return false;
+// Nudge at most once. The marker comment is the terminal idempotency guard:
+// once it exists, nothing is posted or labeled again (so an author reply that
+// removed the label can never see it re-applied). Until the marker exists the
+// two actions are decided independently — apply the label first, then post
+// the comment — so a partial failure (label applied, comment failed) is
+// recovered on the next run instead of getting stuck half-nudged.
+function nudgeActions({ assessment, labels, commentBodies }) {
+  const nothing = { addLabel: false, postComment: false };
+  if (!assessment || !assessment.incomplete) return nothing;
   const bodies = commentBodies || [];
-  if (bodies.some((b) => typeof b === 'string' && b.includes(NEEDS_INFO_MARKER))) return false;
-  return true;
+  if (bodies.some((b) => typeof b === 'string' && b.includes(NEEDS_INFO_MARKER))) return nothing;
+  return {
+    addLabel: !(labels || []).includes(NEEDS_INFO_LABEL),
+    postComment: true,
+  };
 }
 
 // Clear `needs-info` only when the ISSUE AUTHOR comments on a labeled issue.
@@ -123,6 +129,6 @@ module.exports = {
   NEEDS_INFO_MARKER,
   assessCompleteness,
   buildNudgeComment,
-  shouldNudge,
+  nudgeActions,
   shouldClearNeedsInfo,
 };

--- a/.github/scripts/issue-triage/needs-info.js
+++ b/.github/scripts/issue-triage/needs-info.js
@@ -17,6 +17,7 @@
 const { splitSections } = require('./parse-issue.js');
 
 const NEEDS_INFO_LABEL = 'needs-info';
+const NEEDS_TRIAGE_LABEL = 'needs-triage';
 
 // Hidden marker embedded in the nudge comment; its presence anywhere in the
 // issue's comments means the nudge was already posted (re-runs never
@@ -63,7 +64,9 @@ function meaningfulLength(body) {
 //   - Everything else (e.g. feature requests) is never flagged.
 function assessCompleteness(body) {
   const reasons = [];
-  const sections = splitSections(body || '');
+  // Keep fenced content: a repro/log/stack-trace code block is real content
+  // here, even though label derivation rightly ignores it.
+  const sections = splitSections(body || '', { includeFenced: true });
   const isBugTemplate = REQUIRED_BUG_SECTIONS.some((name) => sections[name]);
   if (isBugTemplate) {
     for (const name of REQUIRED_BUG_SECTIONS) {
@@ -103,15 +106,29 @@ function buildNudgeComment(reasons) {
 // two actions are decided independently — apply the label first, then post
 // the comment — so a partial failure (label applied, comment failed) is
 // recovered on the next run instead of getting stuck half-nudged.
-function nudgeActions({ assessment, labels, commentBodies }) {
+//
+// Outside the `opened` event the nudge is also gated on `needs-triage` still
+// being present, so touching an old, already-triaged issue (edited/reopened
+// after pass 2 or a human retired needs-triage) never nudges retroactively.
+function nudgeActions({ assessment, labels, commentBodies, isOpened }) {
   const nothing = { addLabel: false, postComment: false };
   if (!assessment || !assessment.incomplete) return nothing;
   const bodies = commentBodies || [];
   if (bodies.some((b) => typeof b === 'string' && b.includes(NEEDS_INFO_MARKER))) return nothing;
+  if (!isOpened && !(labels || []).includes(NEEDS_TRIAGE_LABEL)) return nothing;
   return {
     addLabel: !(labels || []).includes(NEEDS_INFO_LABEL),
     postComment: true,
   };
+}
+
+// True when a body carries the marker as its own line — i.e. it IS the nudge
+// (or a bot-authored copy of it), not a "Quote reply" to it: quoted lines
+// keep their "> " prefix, so a genuine author quote-reply does not match.
+function isNudgeComment(body) {
+  return String(body || '')
+    .split(/\r?\n/)
+    .some((line) => line.trim() === NEEDS_INFO_MARKER);
 }
 
 // Clear `needs-info` only when the ISSUE AUTHOR comments on a labeled issue.
@@ -120,8 +137,18 @@ function nudgeActions({ assessment, labels, commentBodies }) {
 function shouldClearNeedsInfo({ labels, issueAuthor, commentAuthor, commentBody }) {
   if (!(labels || []).includes(NEEDS_INFO_LABEL)) return false;
   if (!issueAuthor || !commentAuthor || commentAuthor !== issueAuthor) return false;
-  if (typeof commentBody === 'string' && commentBody.includes(NEEDS_INFO_MARKER)) return false;
+  if (isNudgeComment(commentBody)) return false;
   return true;
+}
+
+// Clear `needs-info` when a body EDIT completed the issue: the assessment is
+// now complete, the label is present, and the marker comment exists (we — not
+// a human — applied the label, so removing it here is ours to do).
+function shouldClearOnEdit({ assessment, labels, commentBodies }) {
+  if (!assessment || assessment.incomplete) return false;
+  if (!(labels || []).includes(NEEDS_INFO_LABEL)) return false;
+  const bodies = commentBodies || [];
+  return bodies.some((b) => typeof b === 'string' && b.includes(NEEDS_INFO_MARKER));
 }
 
 module.exports = {
@@ -131,4 +158,5 @@ module.exports = {
   buildNudgeComment,
   nudgeActions,
   shouldClearNeedsInfo,
+  shouldClearOnEdit,
 };

--- a/.github/scripts/issue-triage/needs-info.test.js
+++ b/.github/scripts/issue-triage/needs-info.test.js
@@ -13,7 +13,7 @@ const {
   NEEDS_INFO_MARKER,
   assessCompleteness,
   buildNudgeComment,
-  shouldNudge,
+  nudgeActions,
   shouldClearNeedsInfo,
 } = require('./needs-info.js');
 
@@ -78,39 +78,51 @@ test('nudge comment lists each reason and embeds the hidden marker', () => {
   assert.ok(comment.includes(NEEDS_INFO_LABEL));
 });
 
-// --- shouldNudge (marker idempotency) ----------------------------------------
+// --- nudgeActions (marker idempotency) ----------------------------------------
 
 const incomplete = { incomplete: true, reasons: ['x'] };
+const NOTHING = { addLabel: false, postComment: false };
 
-test('fresh incomplete issue gets a nudge', () => {
-  assert.strictEqual(
-    shouldNudge({ assessment: incomplete, labels: ['bug'], commentBodies: [] }),
-    true
+test('fresh incomplete issue gets both the label and the nudge comment', () => {
+  assert.deepStrictEqual(
+    nudgeActions({ assessment: incomplete, labels: ['bug'], commentBodies: [] }),
+    { addLabel: true, postComment: true }
   );
 });
 
 test('complete issue never gets a nudge', () => {
-  assert.strictEqual(
-    shouldNudge({ assessment: { incomplete: false, reasons: [] }, labels: [], commentBodies: [] }),
-    false
+  assert.deepStrictEqual(
+    nudgeActions({ assessment: { incomplete: false, reasons: [] }, labels: [], commentBodies: [] }),
+    NOTHING
   );
 });
 
-test('needs-info label already present suppresses the nudge', () => {
-  assert.strictEqual(
-    shouldNudge({ assessment: incomplete, labels: ['bug', NEEDS_INFO_LABEL], commentBodies: [] }),
-    false
+test('label present without marker still posts the comment (recovers a failed comment)', () => {
+  assert.deepStrictEqual(
+    nudgeActions({ assessment: incomplete, labels: ['bug', NEEDS_INFO_LABEL], commentBodies: [] }),
+    { addLabel: false, postComment: true }
   );
 });
 
-test('marker comment suppresses re-nudge even after the label was removed', () => {
-  assert.strictEqual(
-    shouldNudge({
+test('marker comment suppresses everything, even after the label was removed', () => {
+  assert.deepStrictEqual(
+    nudgeActions({
       assessment: incomplete,
       labels: ['bug'],
       commentBodies: ['unrelated', `Thanks!\n\n${NEEDS_INFO_MARKER}`],
     }),
-    false
+    NOTHING
+  );
+});
+
+test('marker comment plus label present changes nothing (fully nudged)', () => {
+  assert.deepStrictEqual(
+    nudgeActions({
+      assessment: incomplete,
+      labels: ['bug', NEEDS_INFO_LABEL],
+      commentBodies: [buildNudgeComment(['x'])],
+    }),
+    NOTHING
   );
 });
 

--- a/.github/scripts/issue-triage/needs-info.test.js
+++ b/.github/scripts/issue-triage/needs-info.test.js
@@ -1,0 +1,163 @@
+// Fixture-driven tests for the needs-info completeness loop.
+// Run locally with:  node --test .github/scripts/issue-triage/needs-info.test.js
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const {
+  NEEDS_INFO_LABEL,
+  NEEDS_INFO_MARKER,
+  assessCompleteness,
+  buildNudgeComment,
+  shouldNudge,
+  shouldClearNeedsInfo,
+} = require('./needs-info.js');
+
+const fixture = (name) =>
+  fs.readFileSync(path.join(__dirname, 'fixtures', name), 'utf8');
+
+// --- assessCompleteness -----------------------------------------------------
+
+test('bug with placeholder repro and n/a expected-vs-actual is incomplete', () => {
+  const a = assessCompleteness(fixture('bug-incomplete.md'));
+  assert.strictEqual(a.incomplete, true);
+  assert.deepStrictEqual(a.reasons, [
+    'the "Reproduction steps" section is empty or placeholder-only',
+    'the "Expected vs actual" section is empty or placeholder-only',
+  ]);
+});
+
+test('bug with real repro and expected-vs-actual is complete', () => {
+  assert.strictEqual(assessCompleteness(fixture('bug-full.md')).incomplete, false);
+});
+
+test('bug with _No response_ expected-vs-actual is incomplete on that section only', () => {
+  const a = assessCompleteness(fixture('no-selections.md'));
+  assert.strictEqual(a.incomplete, true);
+  assert.deepStrictEqual(a.reasons, [
+    'the "Expected vs actual" section is empty or placeholder-only',
+  ]);
+});
+
+test('placeholder-word-only sections (tbd/todo) are incomplete', () => {
+  const body = '### Reproduction steps\n\ntbd\n\n### Expected vs actual\n\nTODO\n';
+  assert.strictEqual(assessCompleteness(body).incomplete, true);
+});
+
+test('feature request (no repro sections) is never flagged', () => {
+  assert.strictEqual(assessCompleteness(fixture('feature-request.md')).incomplete, false);
+});
+
+test('blank issue with substantial free-form content is complete', () => {
+  assert.strictEqual(assessCompleteness(fixture('blank-issue.md')).incomplete, false);
+});
+
+test('near-empty blank issue is incomplete (image/link URLs do not count)', () => {
+  const a = assessCompleteness(fixture('blank-near-empty.md'));
+  assert.strictEqual(a.incomplete, true);
+  assert.strictEqual(a.reasons.length, 1);
+});
+
+test('empty and non-string bodies are incomplete', () => {
+  assert.strictEqual(assessCompleteness('').incomplete, true);
+  assert.strictEqual(assessCompleteness(null).incomplete, true);
+  assert.strictEqual(assessCompleteness(undefined).incomplete, true);
+});
+
+// --- buildNudgeComment ------------------------------------------------------
+
+test('nudge comment lists each reason and embeds the hidden marker', () => {
+  const reasons = ['the "Reproduction steps" section is empty or placeholder-only'];
+  const comment = buildNudgeComment(reasons);
+  assert.ok(comment.includes(`- ${reasons[0]}`));
+  assert.ok(comment.includes(NEEDS_INFO_MARKER));
+  assert.ok(comment.includes(NEEDS_INFO_LABEL));
+});
+
+// --- shouldNudge (marker idempotency) ----------------------------------------
+
+const incomplete = { incomplete: true, reasons: ['x'] };
+
+test('fresh incomplete issue gets a nudge', () => {
+  assert.strictEqual(
+    shouldNudge({ assessment: incomplete, labels: ['bug'], commentBodies: [] }),
+    true
+  );
+});
+
+test('complete issue never gets a nudge', () => {
+  assert.strictEqual(
+    shouldNudge({ assessment: { incomplete: false, reasons: [] }, labels: [], commentBodies: [] }),
+    false
+  );
+});
+
+test('needs-info label already present suppresses the nudge', () => {
+  assert.strictEqual(
+    shouldNudge({ assessment: incomplete, labels: ['bug', NEEDS_INFO_LABEL], commentBodies: [] }),
+    false
+  );
+});
+
+test('marker comment suppresses re-nudge even after the label was removed', () => {
+  assert.strictEqual(
+    shouldNudge({
+      assessment: incomplete,
+      labels: ['bug'],
+      commentBodies: ['unrelated', `Thanks!\n\n${NEEDS_INFO_MARKER}`],
+    }),
+    false
+  );
+});
+
+// --- shouldClearNeedsInfo (author vs non-author) ------------------------------
+
+const labeled = ['bug', NEEDS_INFO_LABEL];
+
+test('issue author comment on a needs-info issue clears the label', () => {
+  assert.strictEqual(
+    shouldClearNeedsInfo({
+      labels: labeled, issueAuthor: 'alice', commentAuthor: 'alice', commentBody: 'here are the steps',
+    }),
+    true
+  );
+});
+
+test('non-author comment does not clear the label', () => {
+  assert.strictEqual(
+    shouldClearNeedsInfo({
+      labels: labeled, issueAuthor: 'alice', commentAuthor: 'bob', commentBody: 'me too',
+    }),
+    false
+  );
+});
+
+test('comment on an unlabeled issue clears nothing', () => {
+  assert.strictEqual(
+    shouldClearNeedsInfo({
+      labels: ['bug'], issueAuthor: 'alice', commentAuthor: 'alice', commentBody: 'update',
+    }),
+    false
+  );
+});
+
+test('the marker-carrying nudge comment itself never clears the label', () => {
+  assert.strictEqual(
+    shouldClearNeedsInfo({
+      labels: labeled, issueAuthor: 'alice', commentAuthor: 'alice',
+      commentBody: buildNudgeComment(['x']),
+    }),
+    false
+  );
+});
+
+test('missing author information never clears the label', () => {
+  assert.strictEqual(
+    shouldClearNeedsInfo({ labels: labeled, issueAuthor: undefined, commentAuthor: undefined, commentBody: 'hi' }),
+    false
+  );
+});

--- a/.github/scripts/issue-triage/needs-info.test.js
+++ b/.github/scripts/issue-triage/needs-info.test.js
@@ -15,6 +15,7 @@ const {
   buildNudgeComment,
   nudgeActions,
   shouldClearNeedsInfo,
+  shouldClearOnEdit,
 } = require('./needs-info.js');
 
 const fixture = (name) =>
@@ -33,6 +34,15 @@ test('bug with placeholder repro and n/a expected-vs-actual is incomplete', () =
 
 test('bug with real repro and expected-vs-actual is complete', () => {
   assert.strictEqual(assessCompleteness(fixture('bug-full.md')).incomplete, false);
+});
+
+test('bug whose repro and expected-vs-actual are fenced code blocks is complete', () => {
+  assert.strictEqual(assessCompleteness(fixture('bug-fenced-repro.md')).incomplete, false);
+});
+
+test('a fence containing only placeholder words is still incomplete', () => {
+  const body = '### Reproduction steps\n\n```\ntbd\n```\n\n### Expected vs actual\n\nn/a\n';
+  assert.strictEqual(assessCompleteness(body).incomplete, true);
 });
 
 test('bug with _No response_ expected-vs-actual is incomplete on that section only', () => {
@@ -83,23 +93,27 @@ test('nudge comment lists each reason and embeds the hidden marker', () => {
 const incomplete = { incomplete: true, reasons: ['x'] };
 const NOTHING = { addLabel: false, postComment: false };
 
-test('fresh incomplete issue gets both the label and the nudge comment', () => {
+test('fresh incomplete issue (opened) gets both the label and the nudge comment', () => {
   assert.deepStrictEqual(
-    nudgeActions({ assessment: incomplete, labels: ['bug'], commentBodies: [] }),
+    nudgeActions({ assessment: incomplete, labels: ['bug'], commentBodies: [], isOpened: true }),
     { addLabel: true, postComment: true }
   );
 });
 
 test('complete issue never gets a nudge', () => {
   assert.deepStrictEqual(
-    nudgeActions({ assessment: { incomplete: false, reasons: [] }, labels: [], commentBodies: [] }),
+    nudgeActions({ assessment: { incomplete: false, reasons: [] }, labels: [], commentBodies: [], isOpened: true }),
     NOTHING
   );
 });
 
 test('label present without marker still posts the comment (recovers a failed comment)', () => {
   assert.deepStrictEqual(
-    nudgeActions({ assessment: incomplete, labels: ['bug', NEEDS_INFO_LABEL], commentBodies: [] }),
+    nudgeActions({
+      assessment: incomplete,
+      labels: ['bug', 'needs-triage', NEEDS_INFO_LABEL],
+      commentBodies: [],
+    }),
     { addLabel: false, postComment: true }
   );
 });
@@ -110,6 +124,7 @@ test('marker comment suppresses everything, even after the label was removed', (
       assessment: incomplete,
       labels: ['bug'],
       commentBodies: ['unrelated', `Thanks!\n\n${NEEDS_INFO_MARKER}`],
+      isOpened: true,
     }),
     NOTHING
   );
@@ -121,8 +136,28 @@ test('marker comment plus label present changes nothing (fully nudged)', () => {
       assessment: incomplete,
       labels: ['bug', NEEDS_INFO_LABEL],
       commentBodies: [buildNudgeComment(['x'])],
+      isOpened: true,
     }),
     NOTHING
+  );
+});
+
+test('edited/reopened issue without needs-triage is never nudged retroactively', () => {
+  assert.deepStrictEqual(
+    nudgeActions({ assessment: incomplete, labels: ['bug'], commentBodies: [], isOpened: false }),
+    NOTHING
+  );
+});
+
+test('edited issue still in the needs-triage queue is nudged', () => {
+  assert.deepStrictEqual(
+    nudgeActions({
+      assessment: incomplete,
+      labels: ['bug', 'needs-triage'],
+      commentBodies: [],
+      isOpened: false,
+    }),
+    { addLabel: true, postComment: true }
   );
 });
 
@@ -170,6 +205,53 @@ test('the marker-carrying nudge comment itself never clears the label', () => {
 test('missing author information never clears the label', () => {
   assert.strictEqual(
     shouldClearNeedsInfo({ labels: labeled, issueAuthor: undefined, commentAuthor: undefined, commentBody: 'hi' }),
+    false
+  );
+});
+
+test('an author "Quote reply" to the nudge (marker quoted with "> ") clears the label', () => {
+  const quoted = buildNudgeComment(['x'])
+    .split('\n')
+    .map((l) => `> ${l}`)
+    .join('\n');
+  assert.strictEqual(
+    shouldClearNeedsInfo({
+      labels: labeled, issueAuthor: 'alice', commentAuthor: 'alice',
+      commentBody: `${quoted}\n\nHere are the actual repro steps: run make dev, click Save.`,
+    }),
+    true
+  );
+});
+
+// --- shouldClearOnEdit (body edit completes the issue) -------------------------
+
+const complete = { incomplete: false, reasons: [] };
+const nudgeBody = buildNudgeComment(['x']);
+
+test('edit to a complete body clears needs-info when we nudged (marker present)', () => {
+  assert.strictEqual(
+    shouldClearOnEdit({ assessment: complete, labels: labeled, commentBodies: [nudgeBody] }),
+    true
+  );
+});
+
+test('edit clears nothing when needs-info was applied by a human (no marker)', () => {
+  assert.strictEqual(
+    shouldClearOnEdit({ assessment: complete, labels: labeled, commentBodies: ['unrelated'] }),
+    false
+  );
+});
+
+test('still-incomplete edit clears nothing', () => {
+  assert.strictEqual(
+    shouldClearOnEdit({ assessment: incomplete, labels: labeled, commentBodies: [nudgeBody] }),
+    false
+  );
+});
+
+test('edit on an unlabeled issue clears nothing', () => {
+  assert.strictEqual(
+    shouldClearOnEdit({ assessment: complete, labels: ['bug'], commentBodies: [nudgeBody] }),
     false
   );
 });

--- a/.github/scripts/issue-triage/parse-issue.js
+++ b/.github/scripts/issue-triage/parse-issue.js
@@ -26,10 +26,14 @@ const COMPONENT_PREFIXES = [
 
 // Split a rendered issue-form body into { sectionLabel: contentLines }.
 // Issue forms render each field as a `### <label>` heading. Lines inside
-// fenced code blocks (``` / ~~~) are skipped entirely so template markdown
-// pasted into a fence (logs, "here's my template output") cannot derive
-// spurious headings or checkboxes.
-function splitSections(body) {
+// fenced code blocks (``` / ~~~) never derive headings or checkboxes, so
+// template markdown pasted into a fence (logs, "here's my template output")
+// cannot produce spurious sections. By default fenced lines are dropped from
+// section content too (right for label derivation); `includeFenced: true`
+// keeps them as plain content (right for completeness assessment, where a
+// repro/log code block is real content).
+function splitSections(body, opts) {
+  const includeFenced = Boolean(opts && opts.includeFenced);
   const sections = Object.create(null);
   let current = null;
   let inFence = false;
@@ -38,7 +42,10 @@ function splitSections(body) {
       inFence = !inFence;
       continue;
     }
-    if (inFence) continue;
+    if (inFence) {
+      if (includeFenced && current) sections[current].push(line);
+      continue;
+    }
     const heading = line.match(/^###\s+(.+?)\s*$/);
     if (heading) {
       current = heading[1];

--- a/.github/scripts/issue-triage/parse-issue.js
+++ b/.github/scripts/issue-triage/parse-issue.js
@@ -102,4 +102,4 @@ function labelsForIssueBody(body) {
   return [...new Set(labels)];
 }
 
-module.exports = { labelsForIssueBody };
+module.exports = { labelsForIssueBody, splitSections };

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,4 +75,4 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-      - run: node --test .github/scripts/issue-triage/parse-issue.test.js
+      - run: node --test .github/scripts/issue-triage/parse-issue.test.js .github/scripts/issue-triage/needs-info.test.js

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -167,16 +167,29 @@ jobs:
               per_page: 100,
             });
             const commentBodies = comments.map((c) => c.body || '');
-            if (!needsInfo.shouldNudge({ assessment, labels, commentBodies })) {
-              core.info('Already nudged (needs-info label or marker comment present); skipping.');
+            const actions = needsInfo.nudgeActions({ assessment, labels, commentBodies });
+            if (!actions.postComment && !actions.addLabel) {
+              core.info('Already nudged (marker comment present); skipping.');
               return;
             }
 
             const comment = needsInfo.buildNudgeComment(assessment.reasons);
             if (dryRun) {
-              core.notice(`[dry-run] Would comment the needs-info nudge on #${issueNumber} and add ${needsInfo.NEEDS_INFO_LABEL}`);
+              core.notice(`[dry-run] Would ${actions.addLabel ? `add ${needsInfo.NEEDS_INFO_LABEL} and ` : ''}post the needs-info nudge on #${issueNumber}`);
               core.info(comment);
               return;
+            }
+            // Label first, comment second: if the comment fails after the
+            // label was applied, the next run still posts it (the marker is
+            // the comment's own idempotency guard, not the label's).
+            if (actions.addLabel) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                labels: [needsInfo.NEEDS_INFO_LABEL],
+              });
+              core.info(`Added ${needsInfo.NEEDS_INFO_LABEL}.`);
             }
             await github.rest.issues.createComment({
               owner: context.repo.owner,
@@ -184,13 +197,7 @@ jobs:
               issue_number: issueNumber,
               body: comment,
             });
-            await github.rest.issues.addLabels({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: issueNumber,
-              labels: [needsInfo.NEEDS_INFO_LABEL],
-            });
-            core.info(`Posted nudge comment and added ${needsInfo.NEEDS_INFO_LABEL}.`);
+            core.info('Posted the nudge comment.');
 
   # Author reply on a needs-info issue: remove the label and re-run the
   # pass-1 label derivation on the current body. Non-author comments (and
@@ -212,12 +219,21 @@ jobs:
             const { labelsForIssueBody } = require(path.join(scriptsDir, 'parse-issue.js'));
             const needsInfo = require(path.join(scriptsDir, 'needs-info.js'));
 
-            const issue = context.payload.issue;
+            const issueNumber = context.payload.issue.number;
             const comment = context.payload.comment;
-            const labels = issue.labels.map((l) => (typeof l === 'string' ? l : l.name));
+
+            // Re-fetch the issue: the event payload's label snapshot can
+            // predate the labeling run (e.g. the author comments right after
+            // opening, before the opened-triage run added needs-info).
+            const { data: fresh } = await github.rest.issues.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+            });
+            const labels = fresh.labels.map((l) => (typeof l === 'string' ? l : l.name));
             const clear = needsInfo.shouldClearNeedsInfo({
               labels,
-              issueAuthor: issue.user && issue.user.login,
+              issueAuthor: fresh.user && fresh.user.login,
               commentAuthor: comment.user && comment.user.login,
               commentBody: comment.body || '',
             });
@@ -230,7 +246,7 @@ jobs:
               await github.rest.issues.removeLabel({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                issue_number: issue.number,
+                issue_number: issueNumber,
                 name: needsInfo.NEEDS_INFO_LABEL,
               });
               core.info(`Removed ${needsInfo.NEEDS_INFO_LABEL} (author reply).`);
@@ -241,11 +257,6 @@ jobs:
 
             // Re-run the pass-1 parse on the current body (add-only, and
             // never re-adds needs-triage or needs-info).
-            const { data: fresh } = await github.rest.issues.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: issue.number,
-            });
             const derived = labelsForIssueBody(fresh.body || '');
             const current = new Set(
               fresh.labels.map((l) => (typeof l === 'string' ? l : l.name))
@@ -256,7 +267,7 @@ jobs:
             await github.rest.issues.addLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: issue.number,
+              issue_number: issueNumber,
               labels: toAdd,
             });
             core.info(`Added labels: ${toAdd.join(', ')}`);

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -16,10 +16,21 @@ name: Issue triage
 # `needs-triage` is added only on `opened` (or an explicit
 # `apply_needs_triage` dispatch), never re-added on `edited`/`reopened`
 # once removed.
+#
+# Needs-info completeness loop: incomplete bug reports (placeholder
+# repro/expected-vs-actual sections) and near-empty blank issues get ONE
+# templated nudge comment + `needs-info`. The nudge comment embeds a hidden
+# HTML marker (same idempotency precedent as notify-fixed-issues.sh), so
+# edits/re-runs never double-post or re-apply the label once nudged. The
+# issue AUTHOR's next comment removes `needs-info` and re-runs the pass-1
+# label derivation; comments from anyone else do not.
 
 on:
   issues:
     types: [opened, edited, reopened]
+  # Needs-info loop: an author reply clears the label and re-triggers pass 1.
+  issue_comment:
+    types: [created]
   # Manual runs double as a dry-run mode: they print the intended label
   # operations without writing unless dry_run is unset.
   workflow_dispatch:
@@ -47,6 +58,7 @@ concurrency:
 
 jobs:
   triage:
+    if: github.event_name != 'issue_comment'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -109,6 +121,142 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: issueNumber,
+              labels: toAdd,
+            });
+            core.info(`Added labels: ${toAdd.join(', ')}`);
+
+      - name: Needs-info completeness check
+        uses: actions/github-script@v7
+        env:
+          ISSUE_NUMBER: ${{ github.event.issue.number || inputs.issue_number }}
+          DRY_RUN: ${{ inputs.dry_run == true }}
+        with:
+          script: |
+            const path = require('path');
+            const needsInfo = require(
+              path.join(process.env.GITHUB_WORKSPACE, '.github/scripts/issue-triage/needs-info.js')
+            );
+
+            const issueNumber = Number(process.env.ISSUE_NUMBER);
+            if (!Number.isInteger(issueNumber) || issueNumber <= 0) {
+              core.setFailed(`Invalid issue number: ${JSON.stringify(process.env.ISSUE_NUMBER)}`);
+              return;
+            }
+            const dryRun = process.env.DRY_RUN === 'true';
+
+            const { data: issue } = await github.rest.issues.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+            });
+            if (issue.state !== 'open') {
+              core.info(`issue #${issueNumber} is ${issue.state}; skipping completeness check.`);
+              return;
+            }
+
+            const assessment = needsInfo.assessCompleteness(issue.body || '');
+            core.info(`completeness: ${assessment.incomplete ? 'incomplete' : 'ok'}` +
+              (assessment.reasons.length ? ` — ${assessment.reasons.join('; ')}` : ''));
+            if (!assessment.incomplete) return;
+
+            const labels = issue.labels.map((l) => (typeof l === 'string' ? l : l.name));
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              per_page: 100,
+            });
+            const commentBodies = comments.map((c) => c.body || '');
+            if (!needsInfo.shouldNudge({ assessment, labels, commentBodies })) {
+              core.info('Already nudged (needs-info label or marker comment present); skipping.');
+              return;
+            }
+
+            const comment = needsInfo.buildNudgeComment(assessment.reasons);
+            if (dryRun) {
+              core.notice(`[dry-run] Would comment the needs-info nudge on #${issueNumber} and add ${needsInfo.NEEDS_INFO_LABEL}`);
+              core.info(comment);
+              return;
+            }
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              body: comment,
+            });
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              labels: [needsInfo.NEEDS_INFO_LABEL],
+            });
+            core.info(`Posted nudge comment and added ${needsInfo.NEEDS_INFO_LABEL}.`);
+
+  # Author reply on a needs-info issue: remove the label and re-run the
+  # pass-1 label derivation on the current body. Non-author comments (and
+  # our own marker-carrying nudge) change nothing.
+  needs-info-reply:
+    if: github.event_name == 'issue_comment' && !github.event.issue.pull_request
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: false
+
+      - name: Clear needs-info on author reply and re-run pass 1
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const path = require('path');
+            const scriptsDir = path.join(process.env.GITHUB_WORKSPACE, '.github/scripts/issue-triage');
+            const { labelsForIssueBody } = require(path.join(scriptsDir, 'parse-issue.js'));
+            const needsInfo = require(path.join(scriptsDir, 'needs-info.js'));
+
+            const issue = context.payload.issue;
+            const comment = context.payload.comment;
+            const labels = issue.labels.map((l) => (typeof l === 'string' ? l : l.name));
+            const clear = needsInfo.shouldClearNeedsInfo({
+              labels,
+              issueAuthor: issue.user && issue.user.login,
+              commentAuthor: comment.user && comment.user.login,
+              commentBody: comment.body || '',
+            });
+            if (!clear) {
+              core.info('Not an issue-author reply on a needs-info issue; nothing to do.');
+              return;
+            }
+
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                name: needsInfo.NEEDS_INFO_LABEL,
+              });
+              core.info(`Removed ${needsInfo.NEEDS_INFO_LABEL} (author reply).`);
+            } catch (e) {
+              if (e.status !== 404) throw e;
+              core.info(`${needsInfo.NEEDS_INFO_LABEL} was already removed.`);
+            }
+
+            // Re-run the pass-1 parse on the current body (add-only, and
+            // never re-adds needs-triage or needs-info).
+            const { data: fresh } = await github.rest.issues.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+            });
+            const derived = labelsForIssueBody(fresh.body || '');
+            const current = new Set(
+              fresh.labels.map((l) => (typeof l === 'string' ? l : l.name))
+            );
+            const toAdd = [...new Set(derived)].filter((l) => !current.has(l));
+            core.info(`pass-1 re-run derived: [${derived.join(', ')}]; to add: [${toAdd.join(', ')}]`);
+            if (toAdd.length === 0) return;
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
               labels: toAdd,
             });
             core.info(`Added labels: ${toAdd.join(', ')}`);

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -21,9 +21,12 @@ name: Issue triage
 # repro/expected-vs-actual sections) and near-empty blank issues get ONE
 # templated nudge comment + `needs-info`. The nudge comment embeds a hidden
 # HTML marker (same idempotency precedent as notify-fixed-issues.sh), so
-# edits/re-runs never double-post or re-apply the label once nudged. The
-# issue AUTHOR's next comment removes `needs-info` and re-runs the pass-1
-# label derivation; comments from anyone else do not.
+# edits/re-runs never double-post or re-apply the label once nudged; outside
+# `opened`, nudging also requires `needs-triage` to still be present, so
+# already-triaged issues are never nudged retroactively. The issue AUTHOR's
+# next comment removes `needs-info` and re-runs the pass-1 label derivation
+# (comments from anyone else do not), and a body edit that completes the
+# issue removes the label too (only when the marker shows we applied it).
 
 on:
   issues:
@@ -154,12 +157,14 @@ jobs:
               return;
             }
 
+            const action = context.eventName === 'issues' ? context.payload.action : 'manual';
             const assessment = needsInfo.assessCompleteness(issue.body || '');
             core.info(`completeness: ${assessment.incomplete ? 'incomplete' : 'ok'}` +
               (assessment.reasons.length ? ` — ${assessment.reasons.join('; ')}` : ''));
-            if (!assessment.incomplete) return;
 
             const labels = issue.labels.map((l) => (typeof l === 'string' ? l : l.name));
+            if (!assessment.incomplete && !labels.includes(needsInfo.NEEDS_INFO_LABEL)) return;
+
             const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -167,9 +172,38 @@ jobs:
               per_page: 100,
             });
             const commentBodies = comments.map((c) => c.body || '');
-            const actions = needsInfo.nudgeActions({ assessment, labels, commentBodies });
+
+            // A body edit that completed the issue clears the label — but
+            // only when the marker shows we applied it (a human-applied
+            // needs-info without our nudge is not ours to remove).
+            if (!assessment.incomplete) {
+              if (!needsInfo.shouldClearOnEdit({ assessment, labels, commentBodies })) return;
+              if (dryRun) {
+                core.notice(`[dry-run] Would remove ${needsInfo.NEEDS_INFO_LABEL} from #${issueNumber} (body now complete)`);
+                return;
+              }
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                  name: needsInfo.NEEDS_INFO_LABEL,
+                });
+                core.info(`Removed ${needsInfo.NEEDS_INFO_LABEL} (body now complete).`);
+              } catch (e) {
+                if (e.status !== 404) throw e;
+              }
+              return;
+            }
+
+            const actions = needsInfo.nudgeActions({
+              assessment,
+              labels,
+              commentBodies,
+              isOpened: action === 'opened',
+            });
             if (!actions.postComment && !actions.addLabel) {
-              core.info('Already nudged (marker comment present); skipping.');
+              core.info('No nudge (marker already present, or issue no longer in the needs-triage queue).');
               return;
             }
 


### PR DESCRIPTION
Extends the pass-1 issue-triage workflow (#3722) with the needs-info completeness loop from the triage-pipeline spec.

## What

- **Completeness check** (new step in the `triage` job): after label derivation, the issue body is assessed —
  - bug-template bodies must have real content in **Reproduction steps** and **Expected vs actual** (empty, `_No response_`, the untouched `1. ...` placeholder, or filler like `n/a`/`tbd` are flagged);
  - blank issues (no template sections) must clear a minimal meaningful-content bar (markdown image/link URLs don't count);
  - feature requests and other sectioned bodies are never flagged.

  Incomplete issues get **one** polite templated comment + the `needs-info` label. The comment embeds a hidden HTML marker (`<!-- issue-triage: needs-info -->`, same idempotency precedent as `packages/intentd/scripts/notify-fixed-issues.sh`), so edits/re-runs never double-post or re-apply the label once the nudge exists.

- **Author-reply handler** (new `needs-info-reply` job on `issue_comment: created`): when the **issue author** comments on a `needs-info` issue, the label is removed and the pass-1 label derivation re-runs on the current body (add-only, never re-adds `needs-triage`/`needs-info`). Non-author comments — and the marker-carrying nudge itself — change nothing. PR comments are excluded.

- No stale-close of any kind (per spec).

## Files

- `.github/workflows/issue-triage.yml` — completeness step, `issue_comment` trigger + reply job, header docs
- `.github/scripts/issue-triage/needs-info.js` — pure decision logic: `assessCompleteness`, `buildNudgeComment`, `shouldNudge` (marker idempotency), `shouldClearNeedsInfo` (author check)
- `.github/scripts/issue-triage/needs-info.test.js` + 2 new fixtures — 18 tests covering incomplete-body detection, marker idempotency, author-vs-non-author
- `.github/scripts/issue-triage/parse-issue.js` — export `splitSections` (no behavior change)
- `.github/workflows/ci.yml` — `triage-parser-test` also runs the new suite

## Verification

- `node --test .github/scripts/issue-triage/parse-issue.test.js .github/scripts/issue-triage/needs-info.test.js` → 31/31 pass
- `actionlint` on both workflows → clean
- Dry-run path: `gh workflow run issue-triage.yml -f issue_number=<n> -f dry_run=true` now also prints the intended nudge comment/label ops without writing.
