### PR TITLE
docs: document system.status fileWatch coverage fields and Linux inotify host tuning

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -864,6 +864,64 @@ sweep, not every path that can reclaim an idle tree. A seat still hitting the
 accumulation path should reach for `idleReapMinutes` first, then
 `memoryBudgetMb`.
 
+## File watching: shared OS watchers & Linux host limits
+
+Wire contract: PROTOCOL.md §5 (`system.status` — file-watch coverage fields).
+File events (`file:*`, plus the skills/specialists rescans) come from recursive
+`notify` watchers over watch roots. Watchers are **shared streams**: one OS
+watcher serves many roots, with a demux narrowing each event to the
+subscriber's own root. Grouping is per platform — on macOS (FSEvents) roots
+group per parent directory; on **Linux (inotify) ALL roots share a single
+global stream** ([intent-hq/intentd#1550](https://github.com/intent-hq/intentd/pull/1550)).
+That matters because every `notify` watcher costs one inotify **instance**
+(one fd, capped by `fs.inotify.max_user_instances`, default 128): the earlier
+per-parent-directory grouping made the instance count scale with the workspace
+count and exhausted the cap on multi-workspace hosts
+([intent-hq/intent#3708](https://github.com/intent-hq/intent/issues/3708));
+the single global stream keeps it at one instance total.
+
+Recursive **watches** still scale with directory count: on Linux each watched
+directory consumes one slot of `fs.inotify.max_user_watches` (default 8192 on
+many distros, 65536 on newer kernels) regardless of how streams are grouped,
+so a host with many or large checkouts can exhaust the watch cap even with a
+single inotify instance.
+
+**Tuning a multi-workspace Linux host:**
+
+- Raise `fs.inotify.max_user_watches` — e.g. `1048576` (each slot costs ~1 KB
+  of kernel memory only while in use):
+
+  ```bash
+  sudo sysctl fs.inotify.max_user_watches=1048576
+  echo fs.inotify.max_user_watches=1048576 | sudo tee /etc/sysctl.d/60-inotify.conf
+  ```
+
+- Check the daemon's open-file limit (`ulimit -n` / `nofile`): the global
+  watch group holds inotify instances at one, but sockets, PTYs, and child
+  pipes still consume fds — a low `nofile` (1024 on some distros) surfaces as
+  the same class of resource failures on busy multi-workspace hosts.
+
+**Symptoms of exhausted limits.** Watch-coverage degradation is WARN-logged;
+the creation/registration WARNs carry the live `/proc/sys/fs/inotify` limits
+(as `os_watch_limits: inotify max_user_instances=… max_user_watches=…`) so an
+operator can judge at a glance whether a failure is cap exhaustion:
+
+- `"shared watcher creation failed; roots in this group are unwatched until a
+  retry succeeds"` — the OS watcher itself could not be created (e.g. inotify
+  instance exhaustion). Creation is retried with capped exponential backoff
+  (about once a minute at the cap), and the group's roots are re-registered
+  once it succeeds.
+- `"shared watch registration failed"` — one root's recursive registration
+  failed (e.g. `ENOSPC` watch-slot exhaustion, or the directory vanished).
+- `"shared watcher callback error; events may be missed"` — the live watcher
+  reported an error on its event stream (e.g. `notify`'s "OS file watch limit
+  reached").
+
+The same degradation is surfaced on the wire as the `system.status`
+`fileWatch` object (`failedRoots > 0`, or `activeStreams` below the expected
+count — `0` while `totalRoots > 0` under creation failure), so coverage loss
+is visible to clients, not just in the daemon log.
+
 ## Read-path performance principles
 
 Hot read RPCs — the methods clients poll or fan out on focus (`workspace.list`

--- a/docs/protocol/05-method-catalog.md
+++ b/docs/protocol/05-method-catalog.md
@@ -183,6 +183,27 @@ The `system.status` result also includes **additive** routing fields so an authe
 - `prettyHostname` ([intent-hq/intentd#1466](https://github.com/intent-hq/intentd/pull/1466)) is the OS "pretty" device name (macOS Computer Name, e.g. "Clement's Mac Studio"), falling back to `hostname` when no pretty name is available — matching `server.pairingInfo` / `host.status`. Served from the same background-refreshed cache as `localIps`/`hostname`.
 - These fields are **additive** response fields shipped without a version bump (the method surface is unchanged); clients must detect them by **presence**, not by protocol version. Rationale: the caller already holds the bearer token, so serving the listen addresses on `system.status` lets a remote client (e.g. the iOS app) refresh its stored alternative routes for reconnect racing on every successful connect, while `server.pairingInfo` / `pairing.getInfo` (which also carry the token and cert fingerprint) stay local-only.
 
+#### `system.status` — file-watch coverage fields (additive)
+
+The `system.status` result additionally reports the daemon's live **file-watch coverage** — whether the roots the daemon *wants* watched (workspace checkouts and other watch roots) are actually registered with the OS ([intent-hq/intent#3708](https://github.com/intent-hq/intent/issues/3708), [intent-hq/intentd#1550](https://github.com/intent-hq/intentd/pull/1550)):
+
+```jsonc
+{
+  "fileWatch": {
+    "activeStreams": 1, // shared OS watch streams whose watcher is actually live
+    "totalRoots": 12,   // watch roots currently requested, whatever their registration state
+    "failedRoots": 0    // roots whose OS registration failed; 0 when coverage is healthy
+  }
+  // ...existing status fields (running, listenMode, transports, port, ...)
+}
+```
+
+- `fileWatch` follows the **presence-detection convention** at object granularity: the whole object is **absent** — never `null` — until the watcher registry attaches shortly after daemon start (registry init is backgrounded so it cannot delay the UDS bind), and again once the registry is dropped at shutdown. Once attached it is **always present**, healthy or degraded — a degraded reading is a real value, never an absence — so clients must presence-detect the object, then read the counts.
+- `activeStreams` counts the shared OS watch streams (groups; one `notify` watcher each) whose watcher is **actually created**. A stream stuck in the watcher-creation retry loop is NOT counted, so it reads `0` while `totalRoots > 0` under creation failure — the degradation this object exists to surface. On Linux all roots share a single global stream, so a healthy Linux daemon reads `activeStreams: 1`; on macOS streams group per parent directory, so the healthy count scales with distinct parent directories.
+- `totalRoots` counts the watch roots currently requested across every stream, whatever their registration state.
+- `failedRoots` counts roots whose OS registration settled as **failed** (watcher creation failure, `ENOSPC` watch-slot exhaustion, a vanished directory); a still-pending registration is not a failure. `failedRoots > 0` — or `activeStreams` below the expected count — means **degraded watch coverage**: file events under the affected roots are silently missed until a retry recovers them (the daemon retries watcher creation with capped exponential backoff and re-registers roots on recovery). On Linux the usual cause is inotify limit exhaustion — see the host-tuning guidance in [docs/ARCHITECTURE.md](../ARCHITECTURE.md#file-watching-shared-os-watchers--linux-host-limits).
+- All of this is **additive** optional response content shipped without a version bump (the method surface is unchanged); clients must detect it by **presence**, not by protocol version.
+
 #### `system.importLegacy` (UDS-only, v2.2)
 
 Runs the daemon's legacy workspace import over RPC — the same engine behind the `intentd import-legacy` CLI and the first-boot hook — so a client can trigger a recovery import without shell access. Scans the default legacy roots and imports per-directory legacy workspaces (notes, comments, agent sessions, assets) into the live store.


### PR DESCRIPTION
Documents the daemon-side file-watch observability and the host tuning that goes with it. Companion docs PR for the intentd fix on [intent-hq/intentd#1550](https://github.com/intent-hq/intentd/pull/1550) (branch `fix/shared-watch-registrar-retry`); references intent-hq/intent#3708 (the intentd PR carries the `Fixes` footer — this PR must not auto-close the issue).

## Changes

- **`docs/protocol/05-method-catalog.md`** — new `system.status — file-watch coverage fields (additive)` subsection, following the existing additive-field section precedent: the optional `fileWatch` object `{ activeStreams, totalRoots, failedRoots }`, absent (never `null`) until the watcher registry attaches shortly after daemon start, then always present healthy or degraded — clients presence-detect; `activeStreams` counts only streams whose OS watcher is actually live (reads `0` while `totalRoots > 0` under creation failure), `failedRoots > 0` means degraded watch coverage. Field names and semantics taken from the implementation (`crates/intent-transport/src/control.rs` `status_json` / `FileWatchStatus`, `crates/intent-services/src/events/shared_watch.rs` `WatchHealth`), pinned by a WSS e2e in the intentd PR.
- **`docs/ARCHITECTURE.md`** — new `File watching: shared OS watchers & Linux host limits` section: the shared-stream grouping (macOS per parent directory; Linux one global inotify instance post-#1550), why recursive watches still consume `fs.inotify.max_user_watches` per directory, recommended tuning for multi-workspace Linux hosts (raise `max_user_watches`, e.g. `1048576`; check `nofile`), the WARN log shapes to look for ("shared watcher creation failed …", "shared watch registration failed", "shared watcher callback error … OS file watch limit reached") with the note that the creation/registration WARNs now log the live `/proc/sys/fs/inotify` limits, and the pointer that the same degradation surfaces on `system.status` `fileWatch`.

## Merge ordering

Per the cross-component workflow (protocol changes land daemon-first): **do not merge until [intent-hq/intentd#1550](https://github.com/intent-hq/intentd/pull/1550) is confirmed merged.**
