### PR TITLE
docs: reposition README intro around large-scale agent coordination

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Intent
 
-**Intent** is a local-first agentic coding platform. A Rust daemon (`intentd`)
-runs on your machine and owns everything — workspaces, notes, tasks, coding
-agents, git, terminals, and events — exposing it all through a JSON-RPC API.
-A desktop app (Electron + SvelteKit) and an iOS companion app connect to the
-daemon as thin clients.
+**Intent** is a platform for coordinating coding agents at scale. A Rust
+daemon (`intentd`) runs on your machine and owns everything — workspaces,
+notes, tasks, coding agents, git, terminals, and events — exposing it all
+through a JSON-RPC API. A desktop app (Electron + SvelteKit) and an iOS
+companion app connect to the daemon as thin clients.
 
 <!-- TODO: screenshot/demo -->
 


### PR DESCRIPTION
Replaces the README's opening line — "a local-first agentic coding platform" — with "a platform for coordinating coding agents at scale", leading with Intent's agent-coordination positioning. The rest of the intro (daemon architecture, thin clients) is unchanged.