### PR TITLE
feat: add live-daemon web dev command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ FE_BUILD_HEAP_MB ?= 16384
 	build build-intentd build-sidecar test test-intentd coverage-e2e coverage-all \
 	fmt clippy check clean clean-dev \
 	sweep sweep-all seed-dev-providers seed-dev-workspaces dev-daemon release-daemon \
-	run-intentd dev-ui dev-fe fe-launch run-fe-local uds-to-unauthed-wss-bridge dev dev-prod ios-open ios-info dist-mac
+	run-intentd dev-ui dev-fe fe-launch run-fe-local uds-to-unauthed-wss-bridge dev-web-live dev dev-prod ios-open ios-info dist-mac
 
 all: build
 
@@ -519,6 +519,29 @@ uds-to-unauthed-wss-bridge: ## Expose the installed intentd's UDS as an UNAUTHEN
 		echo "[uds-to-unauthed-wss-bridge] Bridging installed daemon socket: $$socket"; \
 		echo "[uds-to-unauthed-wss-bridge] WARNING: this exposes the FULL UNAUTHENTICATED daemon API as plain ws:// on 127.0.0.1:$(BRIDGE_PORT) — no TLS, no auth. Loopback-only by design; any process on this machine can drive the daemon while the bridge runs."; \
 		INTENTD_SOCKET="$$socket" BRIDGE_PORT=$(BRIDGE_PORT) node scripts/uds-ws-bridge.mjs
+
+dev-web-live: ensure-fe-submodule ## Run the web FE against the installed daemon through the loopback-only UDS bridge
+	@[ -d $(FE_DIR)/node_modules ] || (echo "[dev-web-live] installing FE deps (corepack pnpm install)" && cd $(FE_DIR) && corepack pnpm install --frozen-lockfile)
+	@bridge_pid=""; \
+		cleanup() { \
+			if [ -n "$$bridge_pid" ] && kill -0 "$$bridge_pid" 2>/dev/null; then kill "$$bridge_pid" 2>/dev/null || true; fi; \
+			if [ -n "$$bridge_pid" ]; then wait "$$bridge_pid" 2>/dev/null || true; fi; \
+		}; \
+		trap 'exit 130' INT; \
+		trap 'exit 143' HUP TERM; \
+		trap cleanup EXIT; \
+		BRIDGE_HOST=127.0.0.1 BRIDGE_PORT=$(BRIDGE_PORT) node scripts/uds-ws-bridge.mjs & \
+		bridge_pid=$$!; \
+		attempt=0; \
+		until node -e 'const net = require("node:net"); const socket = net.connect(Number(process.argv[1]), "127.0.0.1", () => { socket.end(); process.exit(0); }); socket.on("error", () => process.exit(1)); setTimeout(() => process.exit(1), 250).unref();' "$(BRIDGE_PORT)" 2>/dev/null; do \
+			if ! kill -0 "$$bridge_pid" 2>/dev/null; then wait "$$bridge_pid"; exit $$?; fi; \
+			attempt=$$((attempt + 1)); \
+			if [ "$$attempt" -ge 100 ]; then echo "[dev-web-live] ERROR: bridge did not listen on 127.0.0.1:$(BRIDGE_PORT) within 10 seconds."; exit 1; fi; \
+			sleep 0.1; \
+		done; \
+		if ! kill -0 "$$bridge_pid" 2>/dev/null; then wait "$$bridge_pid"; exit $$?; fi; \
+		echo "[dev-web-live] Bridge is ready; starting the web FE with VITE_INTENTD_WS_URL=ws://127.0.0.1:$(BRIDGE_PORT)/ws"; \
+		cd $(FE_DIR) && VITE_INTENTD_WS_URL="ws://127.0.0.1:$(BRIDGE_PORT)/ws" pnpm run dev:web
 
 build-sidecar: ensure-intentd-submodule ensure-fe-submodule ## Build intentd release + stage the sidecar binary for FE packaging
 	# Builds the intentd release binary (may take several minutes on first build) and

--- a/docs/fe/DEVELOPER_GUIDE.md
+++ b/docs/fe/DEVELOPER_GUIDE.md
@@ -59,6 +59,10 @@ corepack pnpm run test:unit     # Vitest suite
 corepack pnpm run test:playwright
 ```
 
+For Loop A work against the installed daemon, run `make dev-web-live` from the
+monorepo root. It starts the loopback-only UDS bridge, waits for it, and starts
+`dev:web`; Ctrl-C stops both processes.
+
 ## Fast UI Preview Workflow
 
 Open a named preview after the server prints its URL. These examples use the isolated

--- a/scripts/uds-ws-bridge.mjs
+++ b/scripts/uds-ws-bridge.mjs
@@ -352,9 +352,17 @@ function main() {
     console.error('[uds-ws-bridge] if you really must, pass --unsafe-allow-non-loopback or BRIDGE_UNSAFE_NON_LOOPBACK=1.');
     process.exit(2);
   }
-  if (!fs.existsSync(socketPath)) {
+  let socketStat;
+  try {
+    socketStat = fs.statSync(socketPath);
+  } catch {
     console.error(`[uds-ws-bridge] error: intentd UDS socket not found at ${socketPath}`);
     console.error('[uds-ws-bridge] is intentd running? Override with INTENTD_SOCKET or --socket.');
+    process.exit(1);
+  }
+  if (!socketStat.isSocket()) {
+    console.error(`[uds-ws-bridge] error: intentd UDS path is not a Unix domain socket: ${socketPath}`);
+    console.error('[uds-ws-bridge] start intentd or point INTENTD_SOCKET/--socket at its socket.');
     process.exit(1);
   }
   const bridge = createBridge({ socketPath, host, port });

--- a/scripts/uds-ws-bridge.test.mjs
+++ b/scripts/uds-ws-bridge.test.mjs
@@ -337,6 +337,20 @@ test('non-loopback host is refused at startup without the unsafe opt-out', async
   assert.match(stderr, /--unsafe-allow-non-loopback/);
 });
 
+test('existing non-socket paths are refused at startup', async () => {
+  for (const socketPath of [process.execPath, os.tmpdir()]) {
+    const child = spawn(process.execPath, [BRIDGE_PATH, '--socket', socketPath, '--port', '0']);
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (d) => (stdout += d));
+    child.stderr.on('data', (d) => (stderr += d));
+    const [code] = await once(child, 'exit');
+    assert.equal(code, 1);
+    assert.match(stderr, /not a Unix domain socket/);
+    assert.doesNotMatch(stdout, /listening on/);
+  }
+});
+
 test('UDS connect failure closes the WS client with a clear reason', async (t) => {
   const bridge = createBridge({ socketPath: tmpSockPath(), host: '127.0.0.1', port: 0 });
   await new Promise((resolve) => bridge.listen(resolve));


### PR DESCRIPTION
## Summary
- add make dev-web-live in the monorepo that owns the UDS bridge
- wait for the loopback bridge before starting dev:web with the matching VITE_INTENTD_WS_URL
- stop and reap the bridge on exit or Ctrl-C, and document the one-command Loop A flow

## Verification
- node --test scripts/uds-ws-bridge.test.mjs (16 passed)
- pnpm run check in packages/cloudlands-fe (0 errors)
- live run on isolated ports: bridge HTTP 400 and Vite HTTP 200
- SIGINT cleanup: bridge and Vite listener ports both closed
- startup failure cleanup with a missing UDS socket
- make -n dev-web-live, make help, and git diff --check