### PR TITLE
docs: remove Escape stream-stop binding

### DIFF
--- a/docs/fe/KEYBINDINGS.md
+++ b/docs/fe/KEYBINDINGS.md
@@ -108,7 +108,6 @@
 | `Enter`       | Send Message                   | In chat input                |
 | `Mod+Enter`   | Send Message (force/interrupt) | In chat input                |
 | `Shift+Enter` | Insert New Line                | In chat input                |
-| `Escape`      | Stop Agent Generation          | During agent response        |
 | `/`           | Focus Chat Input               | Not in editable element      |
 | `Mod+/`       | Enhance Prompt                 | Chat inputs / prompt editors |
 | `Mod+↑`       | Navigate to Previous Message   | Not in inputs                |


### PR DESCRIPTION
## Summary

- Remove the Escape / Stop Agent Generation row from the frontend keybinding reference.
- Keep all unrelated Escape keybinding documentation unchanged.
- This PR contains only the documentation change. The cloudlands-fe submodule pointer is not included; automated workflows own pin advancement.

## Verification

- Branch diff against intent-hq/intent main: docs/fe/KEYBINDINGS.md only, with one deleted row.
- git diff --check a687aa5e^ a687aa5e: passed.
- Independent review confirmed the removed row matches the frontend behavior change and unrelated Escape rows remain.