### PR TITLE
docs: document manual-signed-build intentd_ref input and manual test-build guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,6 +88,30 @@ about submodule PR merges, not monorepo bumps — after both are merged, the
 auto-bump-submodules workflow advances both monorepo pins automatically (a single
 rolling bump PR may cover both submodule refs); do not file a manual bump PR.
 
+### Manual test builds for complex changes
+
+For **complex features/fixes** (intentd and/or cloudlands-fe), pair the stacked PRs
+with a manual test build **before merging anything**: dispatch cloudlands-fe's
+`manual-signed-build.yml` on the cloudlands-fe PR branch to produce a manual `.dmg`
+carrying the full stack, and hold all merges until that `.dmg` has been tested:
+
+```bash
+gh workflow run manual-signed-build.yml --repo intent-hq/cloudlands-fe \
+  --ref <fe-pr-branch> -f build_macos=true -f intentd_ref=<intentd PR head SHA>
+```
+
+`intentd_ref` accepts any intent-hq/intentd git ref (full 40-char commit SHA, branch,
+or tag) and compiles the intentd sidecar from source in-workflow; see
+[docs/fe/DEPLOYING.md](./docs/fe/DEPLOYING.md#manual-signed-build-pr-test-builds).
+**Complex cloudlands-fe-only changes** use the same route — omit `intentd_ref` to get
+the pinned intentd — so PRs are not merged until the full stack is complete and a
+manual `.dmg` is prepped for testing.
+
+**Exception — SQLite schema changes:** features/fixes that add or change intent-store
+migrations must **not** be tested via this manual-install route: running the
+hash-built daemon applies its migrations and mutates the tester's local database,
+with no rollback.
+
 ## Conventions
 
 - **Conventional commits** are required. PR titles are validated by CI

--- a/docs/fe/DEPLOYING.md
+++ b/docs/fe/DEPLOYING.md
@@ -211,6 +211,25 @@ The packaged artifacts (`.dmg`/`.zip`, `.exe`, AppImage/`.deb`) will be in `dist
 
 **Note:** Local builds will not be signed or notarized unless you configure the signing environment variables locally (`CLOUDLANDS_APPLE_ID`, `CLOUDLANDS_APPLE_APP_SPECIFIC_PASSWORD`, `CLOUDLANDS_APPLE_TEAM_ID`, or legacy `APPLE_*` equivalents).
 
+## Manual Signed Build (PR test builds)
+
+`.github/workflows/manual-signed-build.yml` ("Manual Signed Build") is dispatch-only
+and builds any branch/ref — e.g. a PR branch — into platform installers for manual
+testing. Platforms are opt-in (`build_macos` / `build_windows` / `build_linux`);
+`sign` defaults to true (macOS Developer ID + notarization, Windows DigiCert).
+Installers are uploaded as short-lived workflow artifacts (7-day retention),
+version-suffixed `-manual.<run_number>`; nothing is published to
+`intent-hq/cloudlands-releases` and no auto-updater feed is produced.
+
+**`intentd_ref` input:** empty (default) fetches the pinned intentd release from
+`intentd.version`, exactly like `release-alpha.yml`. Non-empty accepts any
+intent-hq/intentd git ref — a full 40-char commit SHA, branch, or tag
+(`actions/checkout` cannot resolve abbreviated SHAs) — and compiles the intentd
+sidecar **from source in-workflow** at that ref on every selected leg (macOS,
+Windows, and both Linux arches), staging it at the same `resources/sidecar/` path.
+The run summary reports the resolved intentd SHA. Expect extra build time: a cold
+cargo build adds roughly 15 minutes per leg (cached across repeat dispatches).
+
 ## Operational Notes
 
 - All release workflows run on GitHub Actions; there are no manual upload scripts


### PR DESCRIPTION
Documents the new `intentd_ref` input on cloudlands-fe's `manual-signed-build.yml` (intent-hq/cloudlands-fe#2023 — the from-source sidecar build) and adds workflow guidance for using it.

## Changes

- **`docs/fe/DEPLOYING.md`** — new "Manual Signed Build (PR test builds)" section: dispatch-only workflow, per-platform opt-in inputs, artifact-only output, and the `intentd_ref` input (default = pinned release from `intentd.version`; any intent-hq/intentd git ref accepted — full 40-char SHA, branch, or tag; sidecar compiled from source in-workflow on all legs; ~15 min extra per leg on a cold cargo build, cached across dispatches).
- **`AGENTS.md`** — new "Manual test builds for complex changes" subsection after Cross-component features:
  - complex features/fixes pair stacked intentd/cloudlands-fe PRs with a manual test build before merging anything (`gh workflow run manual-signed-build.yml --ref <fe-pr-branch> -f build_macos=true -f intentd_ref=<intentd PR head SHA>`); hold all merges until the .dmg has been tested
  - complex cloudlands-fe-only changes use the same route (omit `intentd_ref` → pinned intentd)
  - exception: changes adding/altering intent-store SQLite migrations must not go through the manual-install route (the hash-built daemon applies migrations to the tester's local database, no rollback)

Docs-only; no cloudlands-fe/intentd changes and no submodule pin changes.
