### PR TITLE
docs: link the self-checking renderer readiness hook from the FE developer guide

### DIFF
--- a/docs/fe/DEVELOPER_GUIDE.md
+++ b/docs/fe/DEVELOPER_GUIDE.md
@@ -162,6 +162,8 @@ window.__INTENT_PREVIEW__.current();
 no named preview is ready. Wait for `[data-preview-ready=true]` before inspection or
 capture.
 
+For a cold renderer launch, use the [self-checking readiness hook](../../packages/cloudlands-fe/.agents/skills/electron/SKILL.md#wait-for-renderer-readiness) instead of polling or rescheduling an expired hook.
+
 For an agent, run the long-lived command through a workspace service script. Call
 `ws.browser.listTabs` before opening the URL and reuse a matching tab. A new
 `ws.browser.openTab` tab is hidden by default, but DOM, accessibility, evaluation, and

--- a/docs/fe/DEVELOPER_GUIDE.md
+++ b/docs/fe/DEVELOPER_GUIDE.md
@@ -162,7 +162,7 @@ window.__INTENT_PREVIEW__.current();
 no named preview is ready. Wait for `[data-preview-ready=true]` before inspection or
 capture.
 
-For a cold renderer launch, use the [self-checking readiness hook](../../packages/cloudlands-fe/.agents/skills/electron/SKILL.md#wait-for-renderer-readiness) instead of polling or rescheduling an expired hook.
+For a cold renderer launch, use the [self-checking readiness hook](https://github.com/intent-hq/cloudlands-fe/blob/main/.agents/skills/electron/SKILL.md#wait-for-renderer-readiness) instead of polling or rescheduling an expired hook.
 
 For an agent, run the long-lived command through a workspace service script. Call
 `ws.browser.listTabs` before opening the URL and reuse a matching tab. A new


### PR DESCRIPTION
## Summary

- link the FE developer guide to the self-checking renderer readiness hook
- direct cold-launch checks away from polling and expired-hook rescheduling

## Dependency

The target heading lands with intent-hq/cloudlands-fe#2082. The monorepo submodule pin will follow automatically after that PR merges; no manual pin bump is needed.

## Verification

- git diff --check
- verified the target heading in the cloudlands-fe#2082 diff