### PR TITLE
feat(triage): auto-assign issue Types in templates and agentic triage

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,7 @@
 name: Bug report
 description: Report a bug in intentd, cloudlands-fe, ios, or docs/tooling
 labels: ["bug"]
+type: Bug
 body:
   - type: textarea
     id: description

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,7 @@
 name: Feature request
 description: Propose an enhancement or new capability
 labels: ["enhancement"]
+type: Feature
 body:
   - type: textarea
     id: problem

--- a/.github/scripts/issue-triage/agentic-triage.js
+++ b/.github/scripts/issue-triage/agentic-triage.js
@@ -471,9 +471,25 @@ function fetchIssueTypeContext(repo, issueNumber) {
 
 // Set the Type via `updateIssue(issueTypeId)`. Returns true on success;
 // a failure (e.g. a token that cannot set Types) is a warning, not an
-// abort — the rest of the pass still completes.
+// abort — the rest of the pass still completes. The planning read is a
+// point-in-time snapshot and `updateIssue` replaces unconditionally, so
+// the Type is re-read immediately before the write: a Type set by a human
+// in the meantime (or during the label write) is left alone.
 function setIssueType(issueNodeId, issueType) {
   try {
+    const fresh = ghJson([
+      'api', 'graphql',
+      '-f', 'query=query($id: ID!) { node(id: $id) { ... on Issue { issueType { name } } } }',
+      '-f', `id=${issueNodeId}`,
+    ]);
+    const node = fresh && fresh.data && fresh.data.node;
+    if (!node) throw new Error('empty node in pre-write re-read');
+    if (node.issueType && node.issueType.name) {
+      console.log(
+        `issue Type is now ${node.issueType.name} (set since the plan was made); leaving it unchanged.`
+      );
+      return false;
+    }
     gh([
       'api', 'graphql',
       '-f', 'query=mutation($id: ID!, $typeId: ID!) {'

--- a/.github/scripts/issue-triage/agentic-triage.js
+++ b/.github/scripts/issue-triage/agentic-triage.js
@@ -4,10 +4,12 @@
 // LLM judgment pass over a newly opened issue, run after the deterministic
 // pass 1: duplicate-candidate detection, component/type inference when the
 // template checkboxes left the issue unlabeled, priority suggestion with
-// escalation, and ONE auditable summary comment. Suggest-don't-destroy: it
-// only ever ADDS labels and comments — it never closes issues, never edits
-// bodies, and the only label it removes is `needs-triage` (the triage
-// queue marker) after a successful pass.
+// escalation, the issue Type field (Bug / Feature / Task) when the issue
+// has none, and ONE auditable summary comment. Suggest-don't-destroy: it
+// only ever ADDS labels and comments and only ever FILLS an empty Type —
+// it never closes issues, never edits bodies, never overwrites an existing
+// Type, and the only label it removes is `needs-triage` (the triage queue
+// marker) after a successful pass.
 //
 // The summary comment embeds a hidden HTML marker (same idempotency
 // precedent as packages/cloudlands-fe/scripts/notify-fixed-issues.sh):
@@ -21,7 +23,7 @@
 // label vocabulary and sanitized before it reaches a public comment.
 //
 // Usage: agentic-triage.js [--dry-run] <issue-number>
-//   --dry-run prints the full plan (labels + comment) without writing.
+//   --dry-run prints the full plan (labels + Type + comment) without writing.
 // Env: TRIAGE_REPO (default intent-hq/intent); GH_TOKEN for gh; auggie
 // auth via AUGMENT_SESSION_AUTH (CI) or an interactive login (local).
 //
@@ -45,6 +47,11 @@ const SECURITY_REPORT_URL =
 const COMPONENTS = ['intentd', 'fe', 'ios'];
 const TYPES = ['bug', 'enhancement', 'question'];
 const PRIORITIES = ['P0', 'P1', 'P2', 'P3'];
+
+// Type label → GitHub issue Type name. The repo enables exactly Task, Bug,
+// and Feature (no "Question" Type), so questions map to Task. Type IDs are
+// resolved at runtime from `repository.issueTypes`, never hardcoded.
+const ISSUE_TYPE_BY_LABEL = { bug: 'Bug', enhancement: 'Feature', question: 'Task' };
 
 const MAX_ISSUE_BODY_CHARS = 4000;
 const MAX_CANDIDATE_BODY_CHARS = 400;
@@ -255,8 +262,15 @@ function parseTriageResponse(text) {
 //   - needs-triage is removed when present (this pass completes triage) —
 //     unless needs-info is also present: an incomplete issue stays in the
 //     triage queue, and the needs-info re-nudge gate outside `opened`
-//     requires needs-triage to survive.
-function planActions({ response, currentLabels, candidateNumbers }) {
+//     requires needs-triage to survive,
+//   - the issue Type is set only when the issue has none (see planIssueType).
+function planActions({
+  response,
+  currentLabels,
+  candidateNumbers,
+  currentIssueType = null,
+  issueTypes = [],
+}) {
   const current = new Set(currentLabels || []);
   const addLabels = [];
   const labelReasons = [];
@@ -305,14 +319,46 @@ function planActions({ response, currentLabels, candidateNumbers }) {
     labelReasons,
     duplicates,
     security: response.security,
+    issueType: planIssueType({ response, currentLabels, currentIssueType, issueTypes }),
     removeNeedsTriage:
       current.has(NEEDS_TRIAGE_LABEL) && !current.has(NEEDS_INFO_LABEL),
+  };
+}
+
+// Decide the issue Type (Bug / Feature / Task) to set, or null. Pure, so
+// the gating is unit-testable:
+//   - an existing Type always wins (never overwritten, suggest-don't-destroy),
+//   - the source is the effective type label: an existing bug/enhancement/
+//     question label (pass 1 / human) first, else the model's inference,
+//   - the name maps through ISSUE_TYPE_BY_LABEL and must resolve to an
+//     enabled Type in `issueTypes` (the runtime `repository.issueTypes`
+//     list) — an empty list (lookup failed, Types disabled) sets nothing.
+function planIssueType({ response, currentLabels, currentIssueType, issueTypes }) {
+  if (currentIssueType) return null;
+  const current = new Set(currentLabels || []);
+  const existingLabel = TYPES.find((t) => current.has(t));
+  const typeLabel = existingLabel || (response && response.type) || null;
+  if (!typeLabel) return null;
+  const name = ISSUE_TYPE_BY_LABEL[typeLabel];
+  const match = (issueTypes || []).find(
+    (t) => t && t.name === name && t.isEnabled !== false && t.id
+  );
+  if (!match) return null;
+  return {
+    id: match.id,
+    name,
+    reason: existingLabel
+      ? `from the \`${existingLabel}\` label`
+      : (response.reasons && response.reasons.type) || 'inferred from the issue text',
   };
 }
 
 // The one auditable, marker-idempotent summary comment.
 function buildSummaryComment(plan) {
   const lines = ['### Automated triage', ''];
+  if (plan.issueType) {
+    lines.push(`Type set: **${plan.issueType.name}** — ${plan.issueType.reason}`, '');
+  }
   if (plan.labelReasons.length > 0) {
     lines.push('Labels applied:');
     for (const { label, reason } of plan.labelReasons) {
@@ -347,7 +393,7 @@ function buildSummaryComment(plan) {
     );
   }
   lines.push(
-    '<sub>Automated agentic triage (pass 2). Labels are suggestions — maintainers may adjust them.</sub>',
+    '<sub>Automated agentic triage (pass 2). Labels and Type are suggestions — maintainers may adjust them.</sub>',
     '',
     AGENTIC_MARKER
   );
@@ -356,6 +402,7 @@ function buildSummaryComment(plan) {
 
 module.exports = {
   AGENTIC_MARKER,
+  ISSUE_TYPE_BY_LABEL,
   NEEDS_INFO_LABEL,
   NEEDS_TRIAGE_LABEL,
   POSSIBLE_DUPLICATE_LABEL,
@@ -364,6 +411,7 @@ module.exports = {
   extractSearchQueries,
   parseTriageResponse,
   planActions,
+  planIssueType,
   sanitizeText,
 };
 
@@ -389,6 +437,55 @@ function gh(args, opts = {}) {
 
 function ghJson(args) {
   return JSON.parse(gh(args));
+}
+
+// One repository-scoped GraphQL read for everything the Type decision
+// needs: the enabled Types (IDs resolved at runtime, never hardcoded), the
+// issue's current Type, and its node id for the mutation. Repository scope
+// (not `organization.issueTypes`) is what the Actions token's
+// `issues: write` can read. Fail-soft: on any error the caller gets an
+// empty Type list, so planIssueType sets nothing and triage continues.
+function fetchIssueTypeContext(repo, issueNumber) {
+  const [owner, name] = repo.split('/');
+  try {
+    const data = ghJson([
+      'api', 'graphql',
+      '-f', 'query=query($owner: String!, $name: String!, $number: Int!) {'
+        + ' repository(owner: $owner, name: $name) {'
+        + ' issueTypes(first: 50) { nodes { id name isEnabled } }'
+        + ' issue(number: $number) { id issueType { name } } } }',
+      '-f', `owner=${owner}`, '-f', `name=${name}`, '-F', `number=${issueNumber}`,
+    ]);
+    const repository = data && data.data && data.data.repository;
+    if (!repository || !repository.issue) throw new Error('empty repository/issue in response');
+    return {
+      issueNodeId: repository.issue.id,
+      currentIssueType: repository.issue.issueType ? repository.issue.issueType.name : null,
+      issueTypes: (repository.issueTypes && repository.issueTypes.nodes) || [],
+    };
+  } catch (e) {
+    warn(`could not read issue Types (Type assignment skipped): ${e.message}`);
+    return { issueNodeId: null, currentIssueType: null, issueTypes: [] };
+  }
+}
+
+// Set the Type via `updateIssue(issueTypeId)`. Returns true on success;
+// a failure (e.g. a token that cannot set Types) is a warning, not an
+// abort — the rest of the pass still completes.
+function setIssueType(issueNodeId, issueType) {
+  try {
+    gh([
+      'api', 'graphql',
+      '-f', 'query=mutation($id: ID!, $typeId: ID!) {'
+        + ' updateIssue(input: { id: $id, issueTypeId: $typeId }) {'
+        + ' issue { issueType { name } } } }',
+      '-f', `id=${issueNodeId}`, '-f', `typeId=${issueType.id}`,
+    ]);
+    return true;
+  } catch (e) {
+    warn(`could not set issue Type ${issueType.name} (fail-soft): ${e.message}`);
+    return false;
+  }
 }
 
 // Merge the `gh issue list --search` results for each query, excluding the
@@ -572,26 +669,34 @@ function main() {
     process.exit(1);
   }
 
+  const typeContext = fetchIssueTypeContext(repo, issueNumber);
   const plan = planActions({
     response,
     currentLabels,
     candidateNumbers: candidates.map((c) => c.number),
+    currentIssueType: typeContext.currentIssueType,
+    issueTypes: typeContext.issueTypes,
   });
-  const comment = buildSummaryComment(plan);
 
   console.log(`labels to add: [${plan.addLabels.join(', ') || 'none'}]`);
+  console.log(
+    `issue Type: ${typeContext.currentIssueType || 'none'}` +
+      (plan.issueType ? ` → set ${plan.issueType.name}` : ' (unchanged)')
+  );
   console.log(`remove ${NEEDS_TRIAGE_LABEL}: ${plan.removeNeedsTriage}`);
   if (dryRun) {
     console.log(`--- would comment on ${repo}#${issueNumber}: ---`);
-    console.log(comment);
+    console.log(buildSummaryComment(plan));
     console.log('dry-run: nothing written');
     return;
   }
 
-  // Order matters for partial-failure recovery: labels, then the summary
-  // comment (the audit record + idempotency marker), and only then retire
-  // needs-triage — a failure before that point leaves the issue in the
-  // triage queue for a re-run or a human.
+  // Order matters for partial-failure recovery: labels, then the Type,
+  // then the summary comment (the audit record + idempotency marker), and
+  // only then retire needs-triage — a failure before that point leaves the
+  // issue in the triage queue for a re-run or a human. The comment is built
+  // after the Type write so a fail-soft Type failure is not reported as
+  // applied.
   if (plan.addLabels.length > 0) {
     gh([
       'issue', 'edit', String(issueNumber), '--repo', repo,
@@ -599,6 +704,14 @@ function main() {
     ]);
     console.log(`added labels: ${plan.addLabels.join(', ')}`);
   }
+  if (plan.issueType) {
+    if (setIssueType(typeContext.issueNodeId, plan.issueType)) {
+      console.log(`set issue Type: ${plan.issueType.name}`);
+    } else {
+      plan.issueType = null;
+    }
+  }
+  const comment = buildSummaryComment(plan);
   gh(
     ['issue', 'comment', String(issueNumber), '--repo', repo, '--body-file', '-'],
     { input: comment }

--- a/.github/scripts/issue-triage/agentic-triage.test.js
+++ b/.github/scripts/issue-triage/agentic-triage.test.js
@@ -1,5 +1,6 @@
 // Fixture-driven tests for the pass-2 agentic triage logic: model-output
-// parsing, the label allowlist, action gating, and comment building.
+// parsing, the label allowlist, action gating, issue Type gating, and
+// comment building.
 // Run locally with:  node --test .github/scripts/issue-triage/agentic-triage.test.js
 
 'use strict';
@@ -11,17 +12,26 @@ const path = require('node:path');
 
 const {
   AGENTIC_MARKER,
+  ISSUE_TYPE_BY_LABEL,
   POSSIBLE_DUPLICATE_LABEL,
   buildPrompt,
   buildSummaryComment,
   extractSearchQueries,
   parseTriageResponse,
   planActions,
+  planIssueType,
   sanitizeText,
 } = require('./agentic-triage.js');
 
 const fixture = (name) =>
   fs.readFileSync(path.join(__dirname, 'fixtures', name), 'utf8');
+
+// Shape of `repository.issueTypes.nodes` as resolved at runtime.
+const ISSUE_TYPES = [
+  { id: 'IT_task', name: 'Task', isEnabled: true },
+  { id: 'IT_bug', name: 'Bug', isEnabled: true },
+  { id: 'IT_feature', name: 'Feature', isEnabled: true },
+];
 
 test('parse: fenced JSON with surrounding prose parses fully', () => {
   const r = parseTriageResponse(fixture('agentic-response-clean.txt'));
@@ -124,6 +134,94 @@ test('plan: existing labels gate inference; needs-triage retired; dup allowlist 
   assert.deepStrictEqual(gated.addLabels, []);
   assert.deepStrictEqual(gated.duplicates, []);
   assert.strictEqual(gated.removeNeedsTriage, false);
+  // Without a resolved Type list nothing is set.
+  assert.strictEqual(plan.issueType, null);
+  assert.strictEqual(gated.issueType, null);
+});
+
+test('type: untyped issue gets the Type from the model inference; IDs come from the runtime list', () => {
+  const response = parseTriageResponse(fixture('agentic-response-clean.txt'));
+  const plan = planActions({
+    response,
+    currentLabels: ['needs-triage'],
+    candidateNumbers: [],
+    currentIssueType: null,
+    issueTypes: ISSUE_TYPES,
+  });
+  assert.deepStrictEqual(plan.issueType, {
+    id: 'IT_bug',
+    name: 'Bug',
+    reason: 'Reports a panic, clearly a defect',
+  });
+});
+
+test('type: existing type label wins over the model; question maps to Task', () => {
+  const response = parseTriageResponse(fixture('agentic-response-clean.txt'));
+  const fromLabel = planIssueType({
+    response,
+    currentLabels: ['enhancement'],
+    currentIssueType: null,
+    issueTypes: ISSUE_TYPES,
+  });
+  assert.strictEqual(fromLabel.name, 'Feature');
+  assert.strictEqual(fromLabel.id, 'IT_feature');
+  assert.ok(fromLabel.reason.includes('`enhancement` label'));
+
+  response.type = 'question';
+  const question = planIssueType({
+    response,
+    currentLabels: [],
+    currentIssueType: null,
+    issueTypes: ISSUE_TYPES,
+  });
+  assert.strictEqual(question.name, 'Task');
+  assert.strictEqual(question.id, 'IT_task');
+  assert.deepStrictEqual(ISSUE_TYPE_BY_LABEL, {
+    bug: 'Bug', enhancement: 'Feature', question: 'Task',
+  });
+});
+
+test('type: an existing Type is never overwritten', () => {
+  const response = parseTriageResponse(fixture('agentic-response-clean.txt'));
+  const plan = planActions({
+    response,
+    currentLabels: ['enhancement'],
+    candidateNumbers: [],
+    currentIssueType: 'Task',
+    issueTypes: ISSUE_TYPES,
+  });
+  assert.strictEqual(plan.issueType, null);
+});
+
+test('type: nothing is set without a signal, a matching enabled Type, or a resolved list', () => {
+  const noSignal = parseTriageResponse('{"security": false}');
+  assert.strictEqual(
+    planIssueType({ response: noSignal, currentLabels: [], currentIssueType: null, issueTypes: ISSUE_TYPES }),
+    null
+  );
+  const response = parseTriageResponse(fixture('agentic-response-clean.txt'));
+  assert.strictEqual(
+    planIssueType({ response, currentLabels: [], currentIssueType: null, issueTypes: [] }),
+    null
+  );
+  assert.strictEqual(
+    planIssueType({
+      response,
+      currentLabels: [],
+      currentIssueType: null,
+      issueTypes: [{ id: 'IT_bug', name: 'Bug', isEnabled: false }],
+    }),
+    null
+  );
+  assert.strictEqual(
+    planIssueType({
+      response,
+      currentLabels: [],
+      currentIssueType: null,
+      issueTypes: [{ id: 'IT_task', name: 'Task', isEnabled: true }],
+    }),
+    null
+  );
 });
 
 test('plan: needs-info keeps needs-triage in place', () => {
@@ -173,7 +271,19 @@ test('comment: lists labels, candidates, and security redirect; always carries t
   assert.ok(comment.includes('`component:intentd`'));
   assert.ok(comment.includes('#101'));
   assert.ok(comment.includes('security/advisories'));
+  assert.ok(!comment.includes('Type set:'));
   assert.ok(comment.endsWith(AGENTIC_MARKER));
+
+  const typed = buildSummaryComment(
+    planActions({
+      response,
+      currentLabels: ['needs-triage'],
+      candidateNumbers: [],
+      currentIssueType: null,
+      issueTypes: ISSUE_TYPES,
+    })
+  );
+  assert.ok(typed.includes('Type set: **Bug** — Reports a panic, clearly a defect'));
 
   const empty = buildSummaryComment(
     planActions({

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -32,10 +32,19 @@ name: Issue triage
 # pass 1, an LLM pass (Auggie CLI) suggests duplicate candidates,
 # component/type labels when pass 1 derived none, and a priority; it posts
 # one marker-idempotent summary comment and retires `needs-triage`.
-# Fail-soft: continue-on-error, and skipped with a warning when the
-# AUGMENT_SESSION_AUTH secret is absent. Suggest-don't-destroy — it only
-# adds labels/comments, never closes or edits anything. Logic + local
-# dry-run CLI: .github/scripts/issue-triage/agentic-triage.js.
+# It also fills the issue Type field (Bug / Feature / Task) when the issue
+# has none — from the effective type label (bug -> Bug, enhancement ->
+# Feature, question -> Task), Type IDs resolved at runtime from
+# `repository.issueTypes`. Template-filed issues already carry a Type
+# (`type:` in .github/ISSUE_TEMPLATE/*.yml), so this mostly covers blank
+# issues; an existing Type is never overwritten. The Type write uses the
+# job's `github.token` (`issues: write`) via GraphQL `updateIssue` and is
+# guarded: a failure only logs a warning and the rest of the pass
+# completes. Fail-soft: continue-on-error, and skipped with a warning when
+# the AUGMENT_SESSION_AUTH secret is absent. Suggest-don't-destroy — it
+# only adds labels/comments and fills an empty Type, never closes or edits
+# anything. Logic + local dry-run CLI:
+# .github/scripts/issue-triage/agentic-triage.js.
 
 on:
   issues:
@@ -52,7 +61,7 @@ on:
         required: true
         type: string
       dry_run:
-        description: Print intended label operations without applying them
+        description: Print intended label/Type operations without applying them
         type: boolean
         default: true
       apply_needs_triage:
@@ -323,9 +332,13 @@ jobs:
   # end to end: the whole job is continue-on-error (an LLM hiccup never
   # marks the run failed), and a missing AUGMENT_SESSION_AUTH secret skips
   # it with a warning (same convention as MONOREPO_ISSUES_TOKEN /
-  # SUBMODULE_BUMP_TOKEN elsewhere). The issue number is the only event
-  # data that reaches the shell — the script fetches title/body itself and
-  # passes them around as argv/stdin data, never shell-interpolated.
+  # SUBMODULE_BUMP_TOKEN elsewhere). The issue Type write (GraphQL
+  # `updateIssue` with `issueTypeId`, repository-scoped `issueTypes`
+  # lookup) needs only the job's `issues: write` on `github.token`; the
+  # script guards both the lookup and the write so a permission error
+  # degrades to a warning. The issue number is the only event data that
+  # reaches the shell — the script fetches title/body itself and passes
+  # them around as argv/stdin data, never shell-interpolated.
   agentic-triage:
     needs: triage
     if: >-


### PR DESCRIPTION
## Summary

New issues get a GitHub issue Type (Bug / Feature / Task) automatically: template-filed issues at creation, everything else via the pass-2 agentic triage.

### Templates
- `.github/ISSUE_TEMPLATE/bug_report.yml` → `type: Bug`
- `.github/ISSUE_TEMPLATE/feature_request.yml` → `type: Feature`

### Agentic triage (`.github/scripts/issue-triage/agentic-triage.js`)
- New pure `planIssueType()` (wired into `planActions` as `plan.issueType`) decides the Type for an **untyped** issue:
  - source is the effective type label — an existing `bug` / `enhancement` / `question` label (pass 1 / human) first, else the model's `type` inference;
  - mapping `bug → Bug`, `enhancement → Feature`, `question → Task` (the repo has no Question Type);
  - Type IDs are resolved at runtime from a repository-scoped `repository.issueTypes` GraphQL read — nothing is hardcoded; an empty/failed list sets nothing.
- **Never overwrites an existing Type** (suggest-don't-destroy).
- Write is GraphQL `updateIssue(input: { id, issueTypeId })`; both the lookup and the write are guarded and degrade to a warning (fail-soft), the rest of the pass still completes.
- Write order: labels → Type → summary comment → retire `needs-triage`; the comment is built after the Type write so a failed write is never reported as applied. The comment gains a `Type set: **Bug** — <reason>` line.
- `--dry-run` prints `issue Type: none → set Bug` / `(unchanged)` plus the would-be comment and writes nothing.

### Workflow (`.github/workflows/issue-triage.yml`)
- Comments describe the new behavior and the fail-soft guard; `dry_run` input description updated. No permission change: `issues: write` on `github.token` covers the repo-scoped query and the mutation.

## Verification
- `node --test .github/scripts/issue-triage/*.test.js` → **58 pass, 0 fail** (4 new tests: model-inferred Type, label-wins + `question → Task`, never-overwrite, and no-signal / disabled / missing Type / empty list → null; plus comment assertions).
- Local `--dry-run` against real issues (closed, pre-pass-2 ones, since the open untyped issues were already backfilled):
  - #470 (untyped, no type label) → `issue Type: none → set Bug` from model inference
  - #468 (untyped, `bug` label) → `Type set: **Bug** — from the \`bug\` label`
  - #473 (already Bug) → `issue Type: Bug (unchanged)`, no Type line in the comment

## Follow-up
No live Type write was performed from this branch. The first real `opened`-issue CI run confirms the `github.token` `updateIssue` write path end to end; if the token cannot set Types, the run logs a warning and completes the rest of the pass.
