### PR TITLE
docs: add issue-assignment instruction to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -230,10 +230,10 @@ for all components.
 
 ## Working on Issues
 
-- **Assign on start**: when you begin work on an existing `intent-hq/intent` issue,
-  assign it to the human driving the work (never a bot) before the first commit or
-  branch push: `gh issue edit <N> --repo intent-hq/intent --add-assignee @me`.
-- **Already assigned to someone else**: leave the assignee as-is and tell the user.
+- **Assign on start**: when you begin work on an `intent-hq/intent` issue, assign it to
+  the human driving the work before the first commit:
+  `gh issue edit <N> --repo intent-hq/intent --add-assignee @me`.
+- **Already assigned to someone else**: leave it and tell the user.
 
 ## Terminology
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -228,6 +228,13 @@ for all components.
   notifier comments on it once a release contains the complete fix (see Release
   Process).
 
+## Working on Issues
+
+- **Assign on start**: when you begin work on an existing `intent-hq/intent` issue,
+  assign it to the human driving the work (never a bot) before the first commit or
+  branch push: `gh issue edit <N> --repo intent-hq/intent --add-assignee @me`.
+- **Already assigned to someone else**: leave the assignee as-is and tell the user.
+
 ## Terminology
 
 Do **not** use "wave" / "Wave N" terminology in committed documentation. It is


### PR DESCRIPTION
Adds a terse "Working on Issues" section to AGENTS.md: when starting work on an intent-hq/intent issue, assign it to the human driving the work (gh issue edit <N> --add-assignee @me); if already assigned to someone else, leave it and tell the user.

Docs-only, monorepo-only change (+7 lines).