### PR TITLE
docs: document the website release-notes PR step in stable promotion

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -209,6 +209,12 @@ guardrails) lives in [docs/RELEASING.md](./docs/RELEASING.md). The agent-facing 
   block a turn polling.
 - Monorepo-only work (docs, Makefile, CI, scripts) ships nothing to the alpha channel,
   so it needs no release monitoring or shipped-version status message.
+- **Website release notes after a stable promotion**: a cloudlands-fe stable promotion
+  is followed by a PR on `intent-hq/intentapp.dev` updating the docs Updates section
+  (Latest Release + Release History in `src/pages/docs.astro`). Agents propose that PR
+  for review and never merge it (the never-merge-without-permission rule above
+  applies); the procedure and copy prompt are in
+  [docs/fe/RELEASING.md § Promoting to Stable](./docs/fe/RELEASING.md#promoting-to-stable).
 
 ## Filing Issues
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -115,7 +115,9 @@ cloudlands-fe).
   untouched (same caveat as intentd: the guard enforces the beta-not-behind
   invariant, not that the promoted version itself ever occupied beta). The optional
   `skip_beta_check` boolean dispatch input (default `false`) bypasses the guard for
-  emergencies, logged as a warning.
+  emergencies, logged as a warning. After the stable feed is verified, propose the
+  website release notes PR on `intent-hq/intentapp.dev` for human review (see
+  [fe/RELEASING.md § Promoting to Stable](./fe/RELEASING.md#promoting-to-stable)).
 
 ## Release notifier
 
@@ -158,7 +160,10 @@ merge → tag + cargo-dist build → alpha manifest publish →
 (`auto-cut-alpha.yml` push trigger) → promote each component's stable → monorepo
 pins advance automatically via the auto-bump workflow (no manual bump PR). Every
 link is fail-soft: when one is missing (e.g. `FE_DISPATCH_TOKEN` unset on intentd),
-the crons (:15 pin bump, :30 cut) keep everything working at cron cadence.
+the crons (:15 pin bump, :30 cut) keep everything working at cron cadence. A
+cloudlands-fe stable promotion is followed by a website release notes PR on
+`intent-hq/intentapp.dev`, proposed for human review and outside the pipeline (see
+[fe/RELEASING.md § Promoting to Stable](./fe/RELEASING.md#promoting-to-stable)).
 
 ## Gotchas
 

--- a/docs/fe/RELEASING.md
+++ b/docs/fe/RELEASING.md
@@ -149,13 +149,13 @@ After verifying a beta release, promote it to the stable channel using the **Rel
 
    Once the stable feed is verified, update the Updates section of the website docs at `src/pages/docs.astro` in [intent-hq/intentapp.dev](https://github.com/intent-hq/intentapp.dev). The section is made of `<section id="latest-release">` (Latest Release) and `<section id="release-history">` (Release History). Work on a feature branch and open a PR for review; do not merge it (a human merges it).
 
-   1. **Gather inputs.** You need the previous stable version and the newly promoted version. The aggregated notes on the rolling `stable` release of `intent-hq/cloudlands-releases` already span `(prevStable, VERSION]`, including the intentd delta:
+   1. **Gather inputs.** You need the previous stable version, the newly promoted version, and the aggregated notes body. The notes on the rolling `stable` release of `intent-hq/cloudlands-releases` already span `(prevStable, VERSION]`, including the intentd delta:
 
       ```bash
-      gh release view stable --repo intent-hq/cloudlands-releases
+      gh release view stable --repo intent-hq/cloudlands-releases --json body --jq .body
       ```
 
-   2. **Generate the copy** with this prompt:
+   2. **Generate the copy.** The prompt below carries no release context on its own and is not sufficient by itself: supply it together with the inputs from the previous step (the previous stable version, the promoted version, and the aggregated notes body). The copy must be grounded in those notes only; anything not in them is out of scope. Use this prompt:
 
       ```text
       What major updates went out from the last stable release to this current one?
@@ -173,15 +173,17 @@ After verifying a beta release, promote it to the stable channel using the **Rel
       Move the previous Latest release notes into the archive with the release version and date as a subhead.
       ```
 
-   3. **Apply the edit.** Replace the body of the Latest Release section with the new copy, keeping the existing HTML structure: a leading `<p><strong>vX.Y.Z.</strong> ...</p>`, `<p class="body-subheadline">` subheads, and `<ul>` lists. Move the previous Latest Release body into the Release History section, directly below its intro paragraph and above any older entries, under a subhead `<p class="body-subheadline">vA.B.C (YYYY-MM-DD)</p>`. The date is the publish date of that version's release on `intent-hq/cloudlands-releases`:
+   3. **Apply the edit.** Replace the body of the Latest Release section with the new copy, keeping the existing HTML structure: a leading `<p><strong>vX.Y.Z.</strong> ...</p>`, `<p class="body-subheadline">` subheads, and `<ul>` lists. Move the previous Latest Release body into the Release History section, directly below its intro paragraph and above any older entries, under a subhead `<p class="body-subheadline">vA.B.C (YYYY-MM-DD)</p>`. The date is the day that version's `vA.B.C` release was published on `intent-hq/cloudlands-releases`, which is its alpha release date, since a promotion does not create a new release. This prints it as `YYYY-MM-DD` directly:
 
       ```bash
-      gh release view vA.B.C --repo intent-hq/cloudlands-releases --json publishedAt
+      gh release view vA.B.C --repo intent-hq/cloudlands-releases --json publishedAt --jq '.publishedAt[0:10]'
       ```
 
       Release History keeps the newest entry first.
 
    4. **Open the PR** with a conventional-commit title (e.g. `docs: release notes for vX.Y.Z`), request review, and leave the merge to a human.
+
+   Keep at most one open site release-notes PR at a time, and always branch from the current `main` of `intent-hq/intentapp.dev`. Before opening a new one, check for an open release-notes PR on that repo (`gh pr list --repo intent-hq/intentapp.dev --search "release notes"`). If one exists, either update it instead of opening a second (rebase it on `main`, make the newest stable the Latest Release, and archive every intermediate stable in Release History, newest first) or close it as superseded and open a fresh PR from `main`. The site must never end up showing an older release as Latest.
 
    The site PR is review-only and independent of the release pipeline: a delayed or missing site PR never blocks or reverts a promotion.
 
@@ -293,6 +295,8 @@ If the automated **Release Stable** workflow fails and cannot be fixed by re-run
    ```bash
    gh release edit stable --repo intent-hq/cloudlands-releases --notes-file aggregated-notes.md
    ```
+
+After a manual promotion, step 4 of [Promoting to Stable](#promoting-to-stable) (the website release notes PR) still applies.
 
 ## Channel Switching in the App
 

--- a/docs/fe/RELEASING.md
+++ b/docs/fe/RELEASING.md
@@ -83,9 +83,9 @@ The following secrets must be configured in the `intent-hq/cloudlands-fe` reposi
    ```
 
 4. **Verify the rolling beta channel**
-   
+
    The workflow also updates the rolling `beta` release tag:
-   
+
    ```bash
    # Check the beta feeds (latest-mac.yml shown; repeat for latest.yml,
    # latest-linux.yml, latest-linux-arm64.yml)
@@ -144,6 +144,46 @@ After verifying a beta release, promote it to the stable channel using the **Rel
    # View aggregated release notes
    gh release view stable --repo intent-hq/cloudlands-releases
    ```
+
+4. **Propose the website release notes PR**
+
+   Once the stable feed is verified, update the Updates section of the website docs at `src/pages/docs.astro` in [intent-hq/intentapp.dev](https://github.com/intent-hq/intentapp.dev). The section is made of `<section id="latest-release">` (Latest Release) and `<section id="release-history">` (Release History). Work on a feature branch and open a PR for review; do not merge it (a human merges it).
+
+   1. **Gather inputs.** You need the previous stable version and the newly promoted version. The aggregated notes on the rolling `stable` release of `intent-hq/cloudlands-releases` already span `(prevStable, VERSION]`, including the intentd delta:
+
+      ```bash
+      gh release view stable --repo intent-hq/cloudlands-releases
+      ```
+
+   2. **Generate the copy** with this prompt:
+
+      ```text
+      What major updates went out from the last stable release to this current one?
+
+      Respond with accessible, concise, and clear copy for the latest release section of the Intent Website docs.
+
+      1. Match the writing style and formatting of the rest of the Intent docs
+      2. Don't include emojis
+      3. Don't ever use em-dashes
+      4. Don't use staccato pairs (short clipped two-part rhythms like "Not bigger. Better." or "It's fast. It's simple.")
+      5. Don't use antithesis reframe / negative parallelism ("It's not about X, it's about Y" or "This isn't a bug, it's a feature")
+      6. Don't use isocolon metaphor-pairs (two parallel-structured metaphor clauses like "Data is the new oil, and attention is the new currency")
+
+      Replace the latest release section of the Intent docs on the Website with this one.
+      Move the previous Latest release notes into the archive with the release version and date as a subhead.
+      ```
+
+   3. **Apply the edit.** Replace the body of the Latest Release section with the new copy, keeping the existing HTML structure: a leading `<p><strong>vX.Y.Z.</strong> ...</p>`, `<p class="body-subheadline">` subheads, and `<ul>` lists. Move the previous Latest Release body into the Release History section, directly below its intro paragraph and above any older entries, under a subhead `<p class="body-subheadline">vA.B.C (YYYY-MM-DD)</p>`. The date is the publish date of that version's release on `intent-hq/cloudlands-releases`:
+
+      ```bash
+      gh release view vA.B.C --repo intent-hq/cloudlands-releases --json publishedAt
+      ```
+
+      Release History keeps the newest entry first.
+
+   4. **Open the PR** with a conventional-commit title (e.g. `docs: release notes for vX.Y.Z`), request review, and leave the merge to a human.
+
+   The site PR is review-only and independent of the release pipeline: a delayed or missing site PR never blocks or reverts a promotion.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

Adds a website release-notes step to the cloudlands-fe stable promotion process so each stable promotion is followed by a review PR on `intent-hq/intentapp.dev` that refreshes the docs Updates section.

- `docs/fe/RELEASING.md`: new step 4 "Propose the website release notes PR" under Promoting to Stable. Targets `src/pages/docs.astro` (`#latest-release`, `#release-history`), gathers inputs from the aggregated `stable` release notes, includes the release-notes prompt verbatim, replaces the Latest Release body, moves the previous copy into Release History under a version + date subhead, and opens a conventional-commit PR for human review. The site PR is review-only and never blocks or reverts a promotion.
- `docs/RELEASING.md`: pointers from the cloudlands-fe Stable bullet and Coordinated Release Ordering.
- `AGENTS.md`: Release Process bullet stating agents propose the website PR for review and never merge it.

Docs-only monorepo change; nothing ships to a release channel.
