### PR TITLE
fix(scripts): accept nextest retry suffix in resumable gate pass events

### DIFF
--- a/scripts/resumable_nextest.py
+++ b/scripts/resumable_nextest.py
@@ -19,6 +19,7 @@ SCHEMA_VERSION = 1
 MAX_AGE_SECONDS = 7 * 24 * 60 * 60
 KEY_RE = re.compile(r"^[0-9a-f]{64}$")
 RUST_FLAG_ENV = {"RUSTFLAGS", "CARGO_ENCODED_RUSTFLAGS", "CARGO_BUILD_RUSTFLAGS"}
+RETRY_SUFFIX_RE = re.compile(r"#[0-9]+$")
 
 
 def run(command: list[str], cwd: Path, env: dict[str, str] | None = None) -> str:
@@ -153,6 +154,7 @@ def parse_passed_event(
     suite, separator, test = event.get("name", "").partition("$")
     if not separator or not suite or not test:
         raise RuntimeError(f"unexpected nextest test identifier: {event.get('name')!r}")
+    test = RETRY_SUFFIX_RE.sub("", test)
     binary_id = binary_ids.get((suite, test))
     if binary_id is None:
         raise RuntimeError(f"nextest test identifier was not listed: {event.get('name')!r}")

--- a/scripts/test_resumable_nextest.py
+++ b/scripts/test_resumable_nextest.py
@@ -49,6 +49,25 @@ class ResumableNextestTests(unittest.TestCase):
             gate.parse_passed_event('{"type":"test","event":"failed"}', binary_ids)
         )
 
+    def test_pass_event_strips_retry_suffix(self):
+        binary_ids = {("intentd::e2e", "module::passes"): "intentd::e2e"}
+        retried = json.dumps(
+            {"type": "test", "event": "ok", "name": "intentd::e2e$module::passes#2"}
+        )
+        self.assertEqual(
+            gate.parse_passed_event(retried, binary_ids), ("intentd::e2e", "module::passes")
+        )
+        unlisted = json.dumps(
+            {"type": "test", "event": "ok", "name": "intentd::e2e$module::missing#2"}
+        )
+        with self.assertRaisesRegex(RuntimeError, "was not listed"):
+            gate.parse_passed_event(unlisted, binary_ids)
+        not_a_suffix = json.dumps(
+            {"type": "test", "event": "ok", "name": "intentd::e2e$module::passes#2x"}
+        )
+        with self.assertRaisesRegex(RuntimeError, "was not listed"):
+            gate.parse_passed_event(not_a_suffix, binary_ids)
+
     def test_list_metadata_maps_target_kinds_to_canonical_binary_ids(self):
         listing = json.dumps(
             {


### PR DESCRIPTION
## Summary

nextest names retried attempts `<suite>$<test>#<attempt>` in the libtest-json event stream. `scripts/resumable_nextest.py` looked the raw name up in the map built from `nextest list`, so a FLAKY-but-passed test (e.g. `intentd::e2e_wss_agent_watch$report_progress_keeps_original_watch_for_terminal_completion_over_wss#2`) aborted the whole gate with `nextest test identifier was not listed`.

`parse_passed_event` now strips a trailing `#<digits>` fragment from the test part before the lookup and records the **base** test name as passed, so a later `RESUME=1` filters it correctly. A name that genuinely is not in the list output still raises — there is no blanket swallowing of unknown identifiers, and the strip only applies to a trailing `#<digits>` fragment.

Refs intent-hq/intent#4367 (defect 1; the intentd test flakiness itself is tracked separately).

## Changes

- `scripts/resumable_nextest.py`: add `RETRY_SUFFIX_RE` and strip it in `parse_passed_event`.
- `scripts/test_resumable_nextest.py`: regression test `test_pass_event_strips_retry_suffix` — a `...$module::passes#2` event resolves to the same `(binary_id, "module::passes")` as the un-suffixed event; an unlisted `...$module::missing#2` still raises; a non-numeric trailer (`#2x`) is not stripped.

## Verification

- `python3 -m py_compile scripts/resumable_nextest.py` — OK
- `python3 -m unittest scripts/test_resumable_nextest.py -v` — 9 tests, OK
