### PR TITLE
docs(protocol): update current harness version to 2.3 (intent-hq/intentd#1713)

### DIFF
--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -38,7 +38,7 @@ served on the `AgentSession` and `AgentLite` projections (shapes in
 [protocol/methods/agents.md](./protocol/methods/agents.md) §5.5):
 
 - **`harnessVersion`** — the harness version current at creation
-  (`intent_core::CURRENT_HARNESS_VERSION`, today `"2.0"`). There is no
+  (`intent_core::CURRENT_HARNESS_VERSION`, today `"2.3"`). There is no
   upgrade/migration/pinning operation; new sessions always get the latest
   version. The stamp depends only on creation time, never on the creator: a
   delegated child mints the current version regardless of the parent's pin,

--- a/docs/protocol/methods/agents.md
+++ b/docs/protocol/methods/agents.md
@@ -224,7 +224,7 @@ served on the `AgentSession` (`agent.getSession`) and `AgentLite` (`agent.list` 
 `agent.get` / `agent.create` / `agent.update` results) projections:
 
 - `harnessVersion` (string, always present) — the harness version the session was
-  created under, currently `"2.0"`. **Immutable for the session's life**: a daemon
+  created under, currently `"2.3"`. **Immutable for the session's life**: a daemon
   upgrade never changes it, and there is no upgrade/migration/pinning op — new sessions
   always get the latest version. The stamp depends only on creation time, never on the
   creator: a delegated child mints the CURRENT version regardless of the delegating


### PR DESCRIPTION
## Summary

intent-hq/intentd#1713 landed harness v2.3 on intentd `main` (`CURRENT_HARNESS_VERSION = "2.3"` in `crates/intent-core/src/model.rs`). The §5.5 "Harness versioning" paragraph in `docs/protocol/methods/agents.md` still described the current version as `"2.0"`.

This PR updates that one mention to `"2.3"`. The remaining `"1.0"` references in the same section describe the legacy backfill / legacy-import stamp and remain correct.

Docs-only change; no submodule pointers are touched.

Refs: intent-hq/intentd#1713
