### PR TITLE
feat: add blessed iOS xcodebuild make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,8 @@ FE_BUILD_HEAP_MB ?= 16384
 	build build-intentd build-sidecar gate test test-intentd coverage-e2e coverage-all \
 	fmt clippy check clean clean-dev \
 	sweep sweep-all seed-dev-providers seed-dev-workspaces dev-daemon release-daemon \
-	run-intentd dev-ui dev-fe fe-launch run-fe-local uds-to-unauthed-wss-bridge dev-web-live dev dev-prod ios-open ios-info dist-mac
+	run-intentd dev-ui dev-fe fe-launch run-fe-local uds-to-unauthed-wss-bridge dev-web-live dev dev-prod \
+	ios-open ios-info ios-build-ios ios-build-visionos ios-test dist-mac
 
 all: build
 
@@ -667,6 +668,48 @@ ios-open: ensure-ios-submodule ## Open the iOS Xcode project (packages/ios/Inten
 		exit 1; \
 	fi
 	open "$(IOS_DIR)/Intent.xcodeproj"
+
+# Blessed xcodebuild wrappers — every iOS build/test runs through the ios
+# repo's single entry point (scripts/xcodebuild.sh, from intent-hq/ios#219) so
+# destinations, signing flags, and SDK selection cannot diverge. The
+# missing-script guard covers a recorded iOS pin that still predates that PR:
+# `ensure-ios-submodule` only initializes the submodule at the recorded pin,
+# it does not advance it.
+ios-build-ios: ensure-ios-submodule ## Build the iOS app for the iOS Simulator (blessed xcodebuild entry point)
+	@if [ "$$(uname -s)" != "Darwin" ]; then \
+		echo "[ios-build-ios] ERROR: requires macOS (xcodebuild). Detected $$(uname -s)."; \
+		exit 1; \
+	fi
+	@if [ ! -x "$(IOS_DIR)/scripts/xcodebuild.sh" ]; then \
+		echo "[ios-build-ios] ERROR: $(IOS_DIR)/scripts/xcodebuild.sh not found — the recorded iOS pin predates intent-hq/ios#219."; \
+		echo "[ios-build-ios] Wait for auto-bump-submodules to advance the pin, or check out a newer ios ref: git -C $(IOS_DIR) fetch origin && git -C $(IOS_DIR) checkout origin/main"; \
+		exit 1; \
+	fi
+	cd $(IOS_DIR) && scripts/xcodebuild.sh build-ios
+
+ios-build-visionos: ensure-ios-submodule ## Build the iOS app for the visionOS Simulator (blessed xcodebuild entry point)
+	@if [ "$$(uname -s)" != "Darwin" ]; then \
+		echo "[ios-build-visionos] ERROR: requires macOS (xcodebuild). Detected $$(uname -s)."; \
+		exit 1; \
+	fi
+	@if [ ! -x "$(IOS_DIR)/scripts/xcodebuild.sh" ]; then \
+		echo "[ios-build-visionos] ERROR: $(IOS_DIR)/scripts/xcodebuild.sh not found — the recorded iOS pin predates intent-hq/ios#219."; \
+		echo "[ios-build-visionos] Wait for auto-bump-submodules to advance the pin, or check out a newer ios ref: git -C $(IOS_DIR) fetch origin && git -C $(IOS_DIR) checkout origin/main"; \
+		exit 1; \
+	fi
+	cd $(IOS_DIR) && scripts/xcodebuild.sh build-visionos
+
+ios-test: ensure-ios-submodule ## Run the iOS unit tests on a simulator (blessed xcodebuild entry point)
+	@if [ "$$(uname -s)" != "Darwin" ]; then \
+		echo "[ios-test] ERROR: requires macOS (xcodebuild). Detected $$(uname -s)."; \
+		exit 1; \
+	fi
+	@if [ ! -x "$(IOS_DIR)/scripts/xcodebuild.sh" ]; then \
+		echo "[ios-test] ERROR: $(IOS_DIR)/scripts/xcodebuild.sh not found — the recorded iOS pin predates intent-hq/ios#219."; \
+		echo "[ios-test] Wait for auto-bump-submodules to advance the pin, or check out a newer ios ref: git -C $(IOS_DIR) fetch origin && git -C $(IOS_DIR) checkout origin/main"; \
+		exit 1; \
+	fi
+	cd $(IOS_DIR) && scripts/xcodebuild.sh test-ios
 
 ios-info: ## Print how to point the iOS app at the local dev daemon
 	@if [ "$$(uname -s)" != "Darwin" ]; then \

--- a/Makefile
+++ b/Makefile
@@ -681,8 +681,12 @@ ios-build-ios: ensure-ios-submodule ## Build the iOS app for the iOS Simulator (
 		exit 1; \
 	fi
 	@if [ ! -x "$(IOS_DIR)/scripts/xcodebuild.sh" ]; then \
-		echo "[ios-build-ios] ERROR: $(IOS_DIR)/scripts/xcodebuild.sh not found — the recorded iOS pin predates intent-hq/ios#219."; \
-		echo "[ios-build-ios] Wait for auto-bump-submodules to advance the pin, or check out a newer ios ref: git -C $(IOS_DIR) fetch origin && git -C $(IOS_DIR) checkout origin/main"; \
+		if [ -e "$(IOS_DIR)/scripts/xcodebuild.sh" ]; then \
+			echo "[ios-build-ios] ERROR: $(IOS_DIR)/scripts/xcodebuild.sh exists but is not executable — fix with: chmod +x $(IOS_DIR)/scripts/xcodebuild.sh"; \
+		else \
+			echo "[ios-build-ios] ERROR: $(IOS_DIR)/scripts/xcodebuild.sh not found — the recorded iOS pin predates intent-hq/ios#219."; \
+			echo "[ios-build-ios] Wait for auto-bump-submodules to advance the pin, or check out a newer ios ref: git -C $(IOS_DIR) fetch origin && git -C $(IOS_DIR) checkout origin/main"; \
+		fi; \
 		exit 1; \
 	fi
 	cd $(IOS_DIR) && scripts/xcodebuild.sh build-ios
@@ -693,8 +697,12 @@ ios-build-visionos: ensure-ios-submodule ## Build the iOS app for the visionOS S
 		exit 1; \
 	fi
 	@if [ ! -x "$(IOS_DIR)/scripts/xcodebuild.sh" ]; then \
-		echo "[ios-build-visionos] ERROR: $(IOS_DIR)/scripts/xcodebuild.sh not found — the recorded iOS pin predates intent-hq/ios#219."; \
-		echo "[ios-build-visionos] Wait for auto-bump-submodules to advance the pin, or check out a newer ios ref: git -C $(IOS_DIR) fetch origin && git -C $(IOS_DIR) checkout origin/main"; \
+		if [ -e "$(IOS_DIR)/scripts/xcodebuild.sh" ]; then \
+			echo "[ios-build-visionos] ERROR: $(IOS_DIR)/scripts/xcodebuild.sh exists but is not executable — fix with: chmod +x $(IOS_DIR)/scripts/xcodebuild.sh"; \
+		else \
+			echo "[ios-build-visionos] ERROR: $(IOS_DIR)/scripts/xcodebuild.sh not found — the recorded iOS pin predates intent-hq/ios#219."; \
+			echo "[ios-build-visionos] Wait for auto-bump-submodules to advance the pin, or check out a newer ios ref: git -C $(IOS_DIR) fetch origin && git -C $(IOS_DIR) checkout origin/main"; \
+		fi; \
 		exit 1; \
 	fi
 	cd $(IOS_DIR) && scripts/xcodebuild.sh build-visionos
@@ -705,8 +713,12 @@ ios-test: ensure-ios-submodule ## Run the iOS unit tests on a simulator (blessed
 		exit 1; \
 	fi
 	@if [ ! -x "$(IOS_DIR)/scripts/xcodebuild.sh" ]; then \
-		echo "[ios-test] ERROR: $(IOS_DIR)/scripts/xcodebuild.sh not found — the recorded iOS pin predates intent-hq/ios#219."; \
-		echo "[ios-test] Wait for auto-bump-submodules to advance the pin, or check out a newer ios ref: git -C $(IOS_DIR) fetch origin && git -C $(IOS_DIR) checkout origin/main"; \
+		if [ -e "$(IOS_DIR)/scripts/xcodebuild.sh" ]; then \
+			echo "[ios-test] ERROR: $(IOS_DIR)/scripts/xcodebuild.sh exists but is not executable — fix with: chmod +x $(IOS_DIR)/scripts/xcodebuild.sh"; \
+		else \
+			echo "[ios-test] ERROR: $(IOS_DIR)/scripts/xcodebuild.sh not found — the recorded iOS pin predates intent-hq/ios#219."; \
+			echo "[ios-test] Wait for auto-bump-submodules to advance the pin, or check out a newer ios ref: git -C $(IOS_DIR) fetch origin && git -C $(IOS_DIR) checkout origin/main"; \
+		fi; \
 		exit 1; \
 	fi
 	cd $(IOS_DIR) && scripts/xcodebuild.sh test-ios


### PR DESCRIPTION
Adds three monorepo Makefile wrappers so agents and devs discover the blessed iOS xcodebuild entry point via `make help`:

- `ios-build-ios` → `scripts/xcodebuild.sh build-ios`
- `ios-build-visionos` → `scripts/xcodebuild.sh build-visionos`
- `ios-test` → `scripts/xcodebuild.sh test-ios`

Each target depends on `ensure-ios-submodule`, guards on macOS like `ios-open`, and fails with a clear message pointing at intent-hq/ios#219 when `packages/ios/scripts/xcodebuild.sh` is absent (i.e. the recorded iOS pin predates that PR).

## Landing order

intent-hq/ios#219 (the script itself) is merged. This PR should land **after** the monorepo iOS pin advances past #219 — until then the targets fail with the guard message by design. Do not merge without explicit human permission.

## Verification

- `make -n ios-build-ios ios-build-visionos ios-test` shows the expected recipes; `make help` lists all three.
- With ios @ 79ab001 (the #219 head) checked out in `packages/ios`:
  - `make ios-build-ios` → BUILD SUCCEEDED
  - `make ios-build-visionos` → BUILD SUCCEEDED
  - `make ios-test` → TEST EXECUTE SUCCEEDED (1789 tests in 115 suites)
- With the submodule restored to the recorded pin (2b3c8ab, script absent): each target fails with the clear missing-script message, not a shell error.
