### PR TITLE
docs(protocol): document proposeSibling attach semantics

### DIFF
--- a/docs/protocol/methods/workspace.md
+++ b/docs/protocol/methods/workspace.md
@@ -174,6 +174,33 @@ parentless background agents remain blocked and have no parent-report path. This
 binding over the existing `workspace.create` flow, not a JSON-RPC method, and does not
 change Chief of Staff `ws.app.workspaces.create` behavior.
 
+**Attach semantics.** Proposals emitted by a `workspace_api` call attach to that call's
+`tool_result` regardless of the script's return value. When the binding runs, the MCP
+dispatch layer mints a `tar-` nonce, stamps it into the proposal's resource item, and
+collects the item for the §7.1 `AtToolResult` turn-attachment registry
+([07-agent-streaming.md](../07-agent-streaming.md)); the collected batch is registered when
+the script finishes — before the result returns to the provider — whether the script
+returned the proposal envelope, returned something else (e.g. `{ ok: true }`), or threw.
+When the provider reports the call completed, the daemon claims the batch either by finding
+a member's nonce in the echoed tool output or, when no nonce matches, by claiming the agent's
+oldest pending `AtToolResult` batch — the FIFO fallback, gated on the completed call's
+recorded tool name containing `workspace_api`. Scripts therefore need not return the
+proposal envelope and may emit several proposals in one call: all resource items of one
+call register as one batch and attach together. The completed `agent:tool:call` event
+carries the claimed batch as `registeredAttachments` and the ids of the standalone blocks
+as `proposalBlockIds`; the transcript gets one standalone
+`application/vnd.intent.proposal+json` resource block per proposal right after the
+`tool_result` (§7.1). The recorded tool name is derived provider-independently: when the
+ACP title carries no tool identifier — auggie titles the call with the model-authored
+`summary`, sends no `name`, and reports `kind: other` — an input holding exactly a
+non-empty string `code` plus a string `summary` (a daemon-stamped `_acpTitle` echo is
+tolerated) identifies `workspace_api` before the `<name>: <description>` title split runs
+(`intent-acp::session::is_workspace_api_input`;
+[intent-hq/intent#4491](https://github.com/intent-hq/intent/issues/4491),
+[intent-hq/intentd#1762](https://github.com/intent-hq/intentd/pull/1762)). Explicitly
+namespaced MCP titles (`mcp.<server>.<tool>`, `mcp__<server>__<tool>`) stay authoritative,
+so a foreign tool whose arguments happen to be `{ code, summary }` keeps its own name.
+
 ```json
 // → request
 { "jsonrpc": "2.0", "id": 1, "method": "workspace.list", "params": { "includeArchived": false } }


### PR DESCRIPTION
## Summary

Adds an **Attach semantics** paragraph to the `proposeSibling` section of `docs/protocol/methods/workspace.md`, documenting what the daemon guarantees for proposals emitted from a `workspace_api` call:

- Proposals attach to the originating call's `tool_result` **regardless of the script's return value** — the MCP dispatch layer stamps a `tar-` nonce into the proposal resource item at binding time and registers the batch under `AtToolResult` before the result returns to the provider, whether the script returned the envelope, returned something else, or threw (`crates/intent-acp/src/mcp_server/dispatch.rs`, `collect_binding_attachments` / `register_pending_attachments`).
- The completed call claims the batch by nonce echo or, failing that, by the `workspace_api` FIFO fallback (`claim_at_tool_result`, gated on the recorded tool name containing `workspace_api`).
- Multiple proposals in one call register as one batch; the completed `agent:tool:call` event carries `registeredAttachments` + `proposalBlockIds`, and the transcript gets one standalone proposal block per proposal after the `tool_result` (§7.1).
- The recorded tool name is derived provider-independently: when the ACP title carries no tool identifier (auggie titles the call with the model-authored `summary`, no `name`, `kind: other`), an input holding exactly a non-empty string `code` plus a string `summary` (`_acpTitle` echo tolerated) identifies `workspace_api` before the `<name>: <description>` title split; explicitly namespaced MCP titles stay authoritative. Grounded in [intent-hq/intentd#1762](https://github.com/intent-hq/intentd/pull/1762) (`is_workspace_api_input`, `derive_tool_name_inner`).

Refs intent-hq/intent#4491.

## Daemon ordering / pin

intent-hq/intentd#1762 is **merged** on intentd `main` (`8912117d`, 2026-09-06T15:03Z), so the daemon side landed first. The monorepo `packages/intentd` pin (`f9b71028` at the time of writing) predates it; the `auto-bump-submodules` workflow advances the pin on its own — no manual bump PR. Until that bump lands, the pinned daemon records auggie-titled `workspace_api` calls under the prose title; the documented behavior is that of intentd `main`.

## Relation to #4500

#4500 rewrites the §7.1 derivation paragraph in `07-agent-streaming.md`. This PR only touches `workspace.md`; a review with a suggestion correcting the §7.1 text (rule order + crate path + FIFO-gate description) is posted on #4500 separately. The two do not conflict.

## Verification

Docs-only change; no code or tests affected. Every sentence cross-checked against the #1762 diff and the pinned `dispatch.rs` / `turn_attachments.rs` sources.
