### PR TITLE
docs(fe): document Mod+Alt new-agent/note/terminal/browser bindings

### DIFF
--- a/docs/fe/KEYBINDINGS.md
+++ b/docs/fe/KEYBINDINGS.md
@@ -10,11 +10,15 @@
 | ---------------- | ----------------------------- | -------------------------------- |
 | `Mod+K`          | Open Command Palette          | Anywhere (not in terminal)       |
 | `Mod+T`          | Open Blank Working Panel      | In workspace                     |
+| `Mod+Alt+A`      | New Agent                     | In workspace                     |
+| `Mod+Alt+N`      | New Note                      | In workspace                     |
+| `Mod+Alt+T`      | New Terminal                  | In workspace                     |
+| `Mod+Alt+B`      | New Browser                   | In workspace with browser panels |
 | `Mod+P`          | Quick Open (file picker)      | Anywhere (not in terminal)       |
 | `Mod+Shift+P`    | Open Command Palette          | Anywhere (not in terminal)       |
 | `Mod+,`          | Open Settings                 | Anywhere                         |
 | `Mod+O`          | Toggle All Spaces             | Anywhere                         |
-| `Mod+N`          | New Agent                     | Anywhere (not in inputs)         |
+| `Mod+N`          | New Workspace                 | Anywhere (not in inputs)         |
 | `Mod+?`          | Toggle Keyboard Shortcuts     | Anywhere                         |
 | `Mod+F`          | Search                        | Focused searchable panel         |
 | `Ctrl+Tab`       | Next Space                    | Anywhere in workspace            |


### PR DESCRIPTION
Documents the new workspace.new-agent / new-note / new-terminal / new-browser shortcut bindings (Mod+Alt+A / N / T / B) in docs/fe/KEYBINDINGS.md. Cmd+T remains New Panel.

Companion to intent-hq/cloudlands-fe#2234 (collapse column on last-pane close, right-neighbor tab routing, Swiss empty pane). Docs-only; no submodule pin change in this PR.