### PR TITLE
docs(protocol): state crossWorkspace sibling rule as GitHub identity OR path

### DIFF
--- a/docs/protocol/methods/misc-namespaces.md
+++ b/docs/protocol/methods/misc-namespaces.md
@@ -4,7 +4,7 @@
 
 | Method | Params | Result |
 | --- | --- | --- |
-| crossWorkspace.listSiblings | workspaceId (req) | sibling workspaces of the given workspace. Siblings are workspaces with the same GitHub `repositoryOwner`/`repositoryName` (case-insensitive), falling back to an identical source `repositoryPath` when a GitHub identity is unavailable; a caller with neither errors as not associated with a repository |
+| crossWorkspace.listSiblings | workspaceId (req) | sibling workspaces of the given workspace. Siblings are workspaces with the same non-empty GitHub `repositoryOwner`/`repositoryName` (case-insensitive, trailing `.git` tolerated) OR an identical non-empty source `repositoryPath`; a caller with neither errors as not associated with a repository |
 | crossWorkspace.readNote | targetWorkspaceId (req), noteId (req) | note from a sibling workspace (same sibling rule as `listSiblings`; a non-sibling target is denied) |
 | crossWorkspace.listNotes | targetWorkspaceId (req) | notes in a sibling workspace (same sibling rule as `listSiblings`; a non-sibling target is denied) |
 | primitive.addReference | noteId (req), semanticId (req), description (req), snapshot? | { ok, primitiveId, noteId } |

--- a/docs/protocol/methods/misc-namespaces.md
+++ b/docs/protocol/methods/misc-namespaces.md
@@ -4,9 +4,9 @@
 
 | Method | Params | Result |
 | --- | --- | --- |
-| crossWorkspace.listSiblings | workspaceId (req) | sibling workspaces sharing the same git repository (the workspace's own repo) |
-| crossWorkspace.readNote | targetWorkspaceId (req), noteId (req) | note from a sibling workspace |
-| crossWorkspace.listNotes | targetWorkspaceId (req) | notes in a sibling workspace |
+| crossWorkspace.listSiblings | workspaceId (req) | sibling workspaces of the given workspace. Siblings are workspaces with the same GitHub `repositoryOwner`/`repositoryName` (case-insensitive), falling back to an identical source `repositoryPath` when a GitHub identity is unavailable; a caller with neither errors as not associated with a repository |
+| crossWorkspace.readNote | targetWorkspaceId (req), noteId (req) | note from a sibling workspace (same sibling rule as `listSiblings`; a non-sibling target is denied) |
+| crossWorkspace.listNotes | targetWorkspaceId (req) | notes in a sibling workspace (same sibling rule as `listSiblings`; a non-sibling target is denied) |
 | primitive.addReference | noteId (req), semanticId (req), description (req), snapshot? | { ok, primitiveId, noteId } |
 | primitive.addCli | noteId (req), command (req), description (req), workingDirectory? | { ok, primitiveId, noteId } |
 | primitive.addPatch | noteId (req), filePath (req), diff (req), description (req) | { ok, primitiveId, noteId } |


### PR DESCRIPTION
## Summary

Documents the sibling rule used by the `crossWorkspace.*` methods in `docs/protocol/methods/misc-namespaces.md`.

Two workspaces are siblings when either holds:

- they share the same non-empty GitHub identity — equal `repositoryOwner` and `repositoryName`, compared case-insensitively, with a trailing `.git` tolerated; **or**
- they have an identical non-empty source `repositoryPath`.

A caller workspace with neither a GitHub identity nor a repository path errors as not associated with a repository. `crossWorkspace.readNote` and `crossWorkspace.listNotes` apply the same rule to the target workspace and deny non-sibling targets.

## Context

This is the docs counterpart to the daemon behavior shipped in [intent-hq/intentd#1774](https://github.com/intent-hq/intentd/pull/1774) (merged). Docs only; no protocol shape (params or result fields) changed.
