### PR TITLE
fix(ci): accept fe-owned sandbox knobs in docs-check

### DIFF
--- a/scripts/docs-check.sh
+++ b/scripts/docs-check.sh
@@ -47,8 +47,16 @@ sandbox_doc_lines() {
 }
 
 knob_sources=(Makefile scripts/dev-*.sh)
-[[ -f packages/cloudlands-fe/scripts/vite-plugin-intentd-bridge.mjs ]] &&
-  knob_sources+=(packages/cloudlands-fe/scripts/vite-plugin-intentd-bridge.mjs)
+fe_knob_sources=(
+  packages/cloudlands-fe/scripts/vite-plugin-intentd-bridge.mjs
+  packages/cloudlands-fe/scripts/sandbox/*.mjs
+  packages/cloudlands-fe/vite.config.mjs
+  packages/cloudlands-fe/package.json
+  packages/cloudlands-fe/src/lib/component-catalog/geometry-snapshot.ts
+)
+for source in "${fe_knob_sources[@]}"; do
+  [[ -f "$source" ]] && knob_sources+=("$source")
+done
 
 while IFS=: read -r file line text; do
   while IFS= read -r knob; do
@@ -56,7 +64,7 @@ while IFS=: read -r file line text; do
       DEVELOPER_GUIDE) continue ;;
     esac
     if ! grep -Fq "$knob" "${knob_sources[@]}"; then
-      fail "$file" "$line" "sandbox knob '$knob' is not present in the Makefile, dev scripts, or bridge plugin"
+      fail "$file" "$line" "sandbox knob '$knob' is not present in the Makefile, dev scripts, or cloudlands-fe sandbox sources"
     fi
   done < <(printf '%s\n' "$text" | tr -cs 'A-Z0-9_' '\n' | grep -E '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)+$' | sort -u || true)
 done < <(sandbox_doc_lines)

--- a/scripts/docs-check.test.sh
+++ b/scripts/docs-check.test.sh
@@ -45,4 +45,19 @@ fi
 grep -q 'legacy guidance is forbidden (browser-rewritten local port)' <<<"$fail_output" ||
   fail "client-local port failure did not retain its human-readable label"
 
+: >"$temp_dir/README.md"
+printf '%s\n' 'Set SANDBOX_ONLY_KNOB=1 for runner diagnostics.' >>"$temp_dir/packages/cloudlands-fe/AGENTS.md"
+if fail_output=$(cd "$temp_dir" && bash scripts/docs-check.sh 2>&1); then
+  fail "undeclared sandbox knob was accepted"
+fi
+grep -q "sandbox knob 'SANDBOX_ONLY_KNOB' is not present" <<<"$fail_output" ||
+  fail "undeclared sandbox knob failure did not name the knob: $fail_output"
+
+mkdir -p "$temp_dir/packages/cloudlands-fe/scripts/sandbox"
+printf '%s\n' 'const debug = process.env.SANDBOX_ONLY_KNOB === "1";' \
+  >"$temp_dir/packages/cloudlands-fe/scripts/sandbox/runner.mjs"
+if ! pass_output=$(cd "$temp_dir" && bash scripts/docs-check.sh 2>&1); then
+  fail "sandbox knob defined in an fe sandbox source was rejected: $pass_output"
+fi
+
 echo "docs-check tests passed"


### PR DESCRIPTION
Fixes intent-hq/intent#4558

## Cause

`scripts/docs-check.sh` validates every `UPPER_CASE` knob mentioned in the sandbox docs against `knob_sources`, which only covered the monorepo `Makefile`, `scripts/dev-*.sh`, and `packages/cloudlands-fe/scripts/vite-plugin-intentd-bridge.mjs`. cloudlands-fe#2196 documented four knobs in `packages/cloudlands-fe/AGENTS.md` (`INTENT_BUILD_TARGET`, `INTENT_UI_PREVIEW`, `SANDBOX_DEBUG`, `SANDBOX_GEOMETRY_UPDATE`) that are defined elsewhere in the fe tree, so once the fe pin advanced to 9cdbd2cc (intent#4554) the `docs-check` job failed on every monorepo PR regardless of its diff.

## Fix

Extend the knob sources with the fe files that actually define these knobs, verified against the pinned fe tree (9cdbd2cc):

| Knob | Defining fe source(s) |
|---|---|
| `INTENT_BUILD_TARGET` | `scripts/sandbox/runner.mjs`, `vite.config.mjs`, `package.json` |
| `INTENT_UI_PREVIEW` | `scripts/sandbox/runner.mjs`, `vite.config.mjs`, `package.json` |
| `SANDBOX_DEBUG` | `scripts/sandbox/runner.mjs` |
| `SANDBOX_GEOMETRY_UPDATE` | `src/lib/component-catalog/geometry-snapshot.ts`, `package.json` |

Each fe source is guarded with a file-exists check (the existing bridge-plugin pattern), so the check still passes when the submodule is not initialized. `scripts/sandbox/*.mjs` is a glob so future sandbox runner scripts are covered without another edit. No allowlist is used: every knob resolves to a real source file. The error message now names "cloudlands-fe sandbox sources" instead of "bridge plugin".

`scripts/docs-check.test.sh` gains two cases: an undeclared knob in the fe sandbox section is still rejected (and the message names the knob), and a knob defined only in `packages/cloudlands-fe/scripts/sandbox/runner.mjs` is accepted. The new test fails against the pre-fix script.

## Verification

With the pinned fe checked out (`git submodule update --init --depth=1 packages/cloudlands-fe`):

```
$ make docs-check
docs-check: checked 4 docs; all invariants passed

$ bash scripts/docs-check.test.sh
docs-check tests passed
```

Negative check (local-only edit to fe AGENTS.md line 145, reverted, not committed):

```
$ make docs-check
packages/cloudlands-fe/AGENTS.md:145: error: sandbox knob 'FOO_BAR_BAZ' is not present in the Makefile, dev scripts, or cloudlands-fe sandbox sources
docs-check: 1 error(s)
```

Submodule-not-initialized path (`git archive HEAD` into a temp dir):

```
skipped: packages/cloudlands-fe/AGENTS.md (submodule not initialized)
docs-check: checked 3 docs; all invariants passed
```

## Follow-up (out of scope)

The auto-bump PRs that carried the break merged because the monorepo ruleset has no required status checks. Making `docs-check` a required check on the monorepo ruleset (rung-2 enforcement per AGENTS.md) would stop a submodule bump from landing when it breaks the docs invariants. Tracked in intent#4558's "Longer term" note; not changed here.
