### PR TITLE
feat: add shipped-in release lookup script and canonical tracking hook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,7 @@ jobs:
           bash scripts/dev-sandbox.test.sh
           bash scripts/dev-status.test.sh
           bash scripts/docs-check.test.sh
+          bash scripts/shipped-in.test.sh
 
   # Agent-facing documentation links and root hygiene are checked without
   # dependencies or initialized submodules, directly on GitHub hosting.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -276,14 +276,29 @@ guardrails) lives in [docs/RELEASING.md](./docs/RELEASING.md). The agent-facing 
 - **Track shipped work**: a workspace that changed intentd and/or cloudlands-fe is NOT
   done when the PRs merge — monitor until the work ships in a cloudlands-fe alpha,
   then update the final workspace status message with the carrying version (e.g.
-  "Shipped in cloudlands-fe vX.Y.Z (alpha)."). This applies to intentd-only changes
-  too: they ride the chained cloudlands-fe alpha, and the version to report is the
-  cloudlands-fe alpha — verify inclusion via `intentdVersion` in the published
-  release's `release-manifest.json` on the
-  [intent-hq/cloudlands-releases](https://github.com/intent-hq/cloudlands-releases)
-  distribution repo (same tag; cloudlands-fe source-repo releases carry no
-  assets). Use background monitoring (`ws.pr.monitor` / `ws.hook.*`) — never
-  block a turn polling.
+  "Shipped in cloudlands-fe vX.Y.Z (alpha)."). intentd-only changes ride the chained
+  cloudlands-fe alpha too, so the version to report is always the cloudlands-fe tag.
+  `scripts/shipped-in.sh <intentd|cloudlands-fe> <squash-commit-sha>` (or
+  `make shipped-in COMPONENT=... SHA=...`) is the canonical detector: it prints the
+  first [intent-hq/cloudlands-releases](https://github.com/intent-hq/cloudlands-releases)
+  tag carrying the commit (for intentd, via the `intentdVersion` pin in that tag's
+  `release-manifest.json`) and exits 3 while nothing carries it yet. Never block a
+  turn polling — schedule this hook after replacing the placeholders:
+
+  ```javascript
+  await ws.hook.schedule({
+    name: "Wait for shipped alpha",
+    delayMs: 600_000,
+    ttlMs: 21_600_000,
+    code: `const run = await ws.host.exec({
+    command: "scripts/shipped-in.sh", args: ["<COMPONENT>", "<SHA>"], timeoutMs: 120_000,
+  });
+  if (run.exitCode === 0) return { dispatch: true, message: "Shipped in cloudlands-fe " + run.stdout.trim() };
+  if (run.exitCode === 3) return { dispatch: false };
+  throw new Error("shipped-in failed (exit " + run.exitCode + "): " + run.stderr.trim());`,
+  });
+  ```
+
   Before the final status, complete the [ergonomics retrospective](#closing-a-workspace--ergonomics-retrospective).
 - Monorepo-only work (docs, Makefile, CI, scripts) ships nothing to the alpha channel,
   so it needs no release monitoring or shipped-version status message.

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ CDP_PORT ?= $(call dev_port_value,CDP_PORT)
 # An explicit INTENTD_SOCKET always takes precedence.
 BRIDGE_PLATFORM ?= $(shell uname -s)
 
-.PHONY: ports status docs-check
+.PHONY: ports status docs-check shipped-in
 ports: ## Print this worktree's resolved development ports
 	@set -- .dev/sandbox/*.json; if [ -e "$$1" ]; then \
 		echo "[ports] Note: these ports are for the next start; read running ports from 'make sandbox-status' or .dev/sandbox/<mode>.json." >&2; \
@@ -101,6 +101,14 @@ status: ## Show host, ports, sandboxes, and submodule/PR state (STATUS_JSON=1 fo
 
 docs-check: ## Check documented development targets, knobs, and remote-host guidance
 	@scripts/docs-check.sh
+
+# Release tracking: which cloudlands-releases alpha first carries a merged
+# commit. The script exits 3 for "not shipped yet" (make reports it as
+# `Error 3`); background hooks should invoke scripts/shipped-in.sh directly so
+# they can branch on that code. `LIMIT=N` widens the scan window past the
+# newest 10 releases.
+shipped-in: ## Print the first cloudlands-releases tag carrying COMPONENT=intentd|cloudlands-fe SHA=<commit> (script exit 3 = not yet)
+	@scripts/shipped-in.sh "$(COMPONENT)" "$(SHA)" $(if $(LIMIT),--limit "$(LIMIT)",)
 
 # Build-artifact GC (cargo-sweep). Rust target/ dirs grow without bound as
 # deps and toolchains churn; `sweep` prunes artifacts older than SWEEP_DAYS

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -174,5 +174,7 @@ cloudlands-fe stable promotion is followed by a website release notes PR on
   `release-manifest.json` on the
   [intent-hq/cloudlands-releases](https://github.com/intent-hq/cloudlands-releases)
   distribution repo (same tag) — cloudlands-fe source-repo releases carry no assets.
+  `scripts/shipped-in.sh intentd <sha>` (`make shipped-in`) performs this lookup and
+  prints the first cloudlands-releases tag whose pin carries the commit.
 - Commits merged after the release PR was cut ride the next release PR (e.g. intentd#517
   landed via follow-up release PR intentd#520).

--- a/scripts/shipped-in.sh
+++ b/scripts/shipped-in.sh
@@ -113,4 +113,5 @@ if [[ -z "$first_hit" ]]; then
   exit 3
 fi
 
-printf '%s intentdVersion=%s\n' "$first_hit" "$(manifest_version "$first_hit")"
+hit_version=$(manifest_version "$first_hit")
+printf '%s intentdVersion=%s\n' "$first_hit" "$hit_version"

--- a/scripts/shipped-in.sh
+++ b/scripts/shipped-in.sh
@@ -86,11 +86,14 @@ carries() {
   esac
 }
 
+# The distribution repo also carries rolling channel releases (alpha, beta,
+# stable) that can sit anywhere in the listing, so over-fetch and take the
+# newest $limit versioned tags after filtering.
 release_list=$(
-  gh release list --repo "$releases_repo" --limit "$limit" --exclude-drafts \
+  gh release list --repo "$releases_repo" --limit "$((limit + 10))" --exclude-drafts \
     --json tagName --jq '.[].tagName' 2>/dev/null
 ) || fail "gh release list on $releases_repo failed"
-mapfile -t tags < <(grep -E '^v[0-9]+\.[0-9]+\.[0-9]+' <<<"$release_list" || true)
+mapfile -t tags < <(grep -E '^v[0-9]+\.[0-9]+\.[0-9]+' <<<"$release_list" | head -n "$limit" || true)
 ((${#tags[@]} > 0)) || fail "gh release list on $releases_repo returned no vX.Y.Z tags"
 
 declare -A intentd_status=()

--- a/scripts/shipped-in.sh
+++ b/scripts/shipped-in.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# Print the first intent-hq/cloudlands-releases tag that carries a merged commit.
+#
+#   scripts/shipped-in.sh <intentd|cloudlands-fe> <commit-sha> [--limit N]
+#
+# cloudlands-fe: the tag carries the commit when the GitHub compare
+# `<sha>...<tag>` on intent-hq/cloudlands-fe reports `ahead` or `identical`.
+# intentd: each tag's release-manifest.json names the pinned `intentdVersion`;
+# the tag carries the commit when `<sha>...v<intentdVersion>` on
+# intent-hq/intentd reports `ahead` or `identical`. `behind` and `diverged`
+# never count. The newest N releases are scanned (default 10) and the oldest
+# carrying tag is printed as `<tag> intentdVersion=<version>`.
+#
+# Exit codes: 0 = printed a carrying tag; 3 = no scanned release carries the
+# commit yet (stdout empty); 2 = usage error; 1 = gh/API failure.
+
+set -euo pipefail
+
+releases_repo=intent-hq/cloudlands-releases
+fe_repo=intent-hq/cloudlands-fe
+intentd_repo=intent-hq/intentd
+
+usage() {
+  echo "Usage: $0 <intentd|cloudlands-fe> <commit-sha> [--limit N]" >&2
+  exit 2
+}
+
+component=${1:-}
+sha=${2:-}
+[[ -n "$component" && -n "$sha" ]] || usage
+shift 2
+limit=10
+while (($# > 0)); do
+  case "$1" in
+    --limit)
+      [[ $# -ge 2 && "$2" =~ ^[1-9][0-9]*$ ]] || usage
+      limit=$2
+      shift 2
+      ;;
+    --limit=*)
+      limit=${1#--limit=}
+      [[ "$limit" =~ ^[1-9][0-9]*$ ]] || usage
+      shift
+      ;;
+    *) usage ;;
+  esac
+done
+
+case "$component" in
+  intentd) compare_repo=$intentd_repo ;;
+  cloudlands-fe) compare_repo=$fe_repo ;;
+  *) usage ;;
+esac
+[[ "$sha" =~ ^[0-9a-fA-F]{7,40}$ ]] || usage
+
+fail() {
+  echo "shipped-in: $*" >&2
+  exit 1
+}
+
+compare_status() {
+  local head=$1 status
+  status=$(gh api "repos/$compare_repo/compare/$sha...$head" --jq .status 2>/dev/null) ||
+    fail "gh api compare $sha...$head on $compare_repo failed"
+  printf '%s\n' "$status"
+}
+
+declare -A manifest_versions=()
+manifest_version() {
+  local tag=$1 version
+  if [[ -z "${manifest_versions[$tag]+x}" ]]; then
+    version=$(gh release download "$tag" --repo "$releases_repo" \
+      --pattern release-manifest.json --output - 2>/dev/null |
+      python3 -c 'import json, sys; print(json.load(sys.stdin)["intentdVersion"])' 2>/dev/null) ||
+      fail "could not read intentdVersion from release-manifest.json for $tag on $releases_repo"
+    [[ -n "$version" ]] || fail "release-manifest.json for $tag has an empty intentdVersion"
+    manifest_versions[$tag]=$version
+  fi
+  printf '%s\n' "${manifest_versions[$tag]}"
+}
+
+carries() {
+  case "$1" in
+    ahead | identical) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+mapfile -t tags < <(
+  gh release list --repo "$releases_repo" --limit "$limit" --exclude-drafts \
+    --json tagName --jq '.[].tagName' 2>/dev/null |
+    grep -E '^v[0-9]+\.[0-9]+\.[0-9]+' || true
+)
+((${#tags[@]} > 0)) || fail "gh release list on $releases_repo failed or returned no vX.Y.Z tags"
+
+declare -A intentd_status=()
+first_hit=""
+for tag in "${tags[@]}"; do
+  if [[ "$component" == intentd ]]; then
+    version=$(manifest_version "$tag")
+    if [[ -z "${intentd_status[$version]+x}" ]]; then
+      intentd_status[$version]=$(compare_status "v$version")
+    fi
+    status=${intentd_status[$version]}
+  else
+    status=$(compare_status "$tag")
+  fi
+  carries "$status" && first_hit=$tag
+done
+
+if [[ -z "$first_hit" ]]; then
+  echo "shipped-in: $sha is not carried by the newest ${#tags[@]} release(s) on $releases_repo (newest ${tags[0]})" >&2
+  exit 3
+fi
+
+printf '%s intentdVersion=%s\n' "$first_hit" "$(manifest_version "$first_hit")"

--- a/scripts/shipped-in.sh
+++ b/scripts/shipped-in.sh
@@ -86,12 +86,12 @@ carries() {
   esac
 }
 
-mapfile -t tags < <(
+release_list=$(
   gh release list --repo "$releases_repo" --limit "$limit" --exclude-drafts \
-    --json tagName --jq '.[].tagName' 2>/dev/null |
-    grep -E '^v[0-9]+\.[0-9]+\.[0-9]+' || true
-)
-((${#tags[@]} > 0)) || fail "gh release list on $releases_repo failed or returned no vX.Y.Z tags"
+    --json tagName --jq '.[].tagName' 2>/dev/null
+) || fail "gh release list on $releases_repo failed"
+mapfile -t tags < <(grep -E '^v[0-9]+\.[0-9]+\.[0-9]+' <<<"$release_list" || true)
+((${#tags[@]} > 0)) || fail "gh release list on $releases_repo returned no vX.Y.Z tags"
 
 declare -A intentd_status=()
 first_hit=""

--- a/scripts/shipped-in.test.sh
+++ b/scripts/shipped-in.test.sh
@@ -15,7 +15,7 @@ fail() {
   exit 1
 }
 
-for command in bash cat grep python3; do
+for command in bash cat grep head python3; do
   ln -s "$(command -v "$command")" "$bin_dir/$command"
 done
 
@@ -78,7 +78,7 @@ echo behind >"$fe_compare/$sha...v2.1.0"
 run_script cloudlands-fe "$sha"
 [[ "$status" -eq 0 ]] || fail "newest-tag hit exited $status: $stderr"
 [[ "$stdout" == "v2.3.0 intentdVersion=0.9.0" ]] || fail "newest-tag hit printed '$stdout'"
-grep -q -- '^release list --repo intent-hq/cloudlands-releases --limit 10 ' "$temp_dir/gh.log" || fail "default limit was not 10"
+grep -q -- '^release list --repo intent-hq/cloudlands-releases --limit 20 ' "$temp_dir/gh.log" || fail "default limit 10 was not over-fetched as 20"
 
 reset_stub
 echo ahead >"$fe_compare/$sha...v2.3.0"
@@ -87,7 +87,18 @@ echo behind >"$fe_compare/$sha...v2.1.0"
 run_script cloudlands-fe "$sha" --limit 3
 [[ "$status" -eq 0 ]] || fail "older-tag hit exited $status: $stderr"
 [[ "$stdout" == "v2.2.0 intentdVersion=0.9.0" ]] || fail "expected the oldest carrying tag, printed '$stdout'"
-grep -q -- '^release list --repo intent-hq/cloudlands-releases --limit 3 ' "$temp_dir/gh.log" || fail "--limit was not forwarded"
+grep -q -- '^release list --repo intent-hq/cloudlands-releases --limit 13 ' "$temp_dir/gh.log" || fail "--limit 3 was not over-fetched as 13"
+
+reset_stub
+printf '%s\n' stable v2.3.0 alpha v2.2.0 beta v2.1.0 >"$stub_dir/releases"
+echo ahead >"$fe_compare/$sha...v2.3.0"
+echo behind >"$fe_compare/$sha...v2.2.0"
+echo identical >"$fe_compare/$sha...v2.1.0"
+run_script cloudlands-fe "$sha" --limit 2
+[[ "$status" -eq 0 ]] || fail "channel-interleaved hit exited $status: $stderr"
+[[ "$stdout" == "v2.3.0 intentdVersion=0.9.0" ]] || fail "channel-interleaved scan printed '$stdout' (v2.1.0 is outside --limit 2)"
+! grep -q 'v2.1.0' "$temp_dir/gh.log" || fail "channel-interleaved scan inspected v2.1.0 beyond --limit 2"
+! grep -qE 'compare/.*\.\.\.(stable|alpha|beta)$' "$temp_dir/gh.log" || fail "channel releases were compared"
 
 reset_stub
 echo behind >"$fe_compare/$sha...v2.3.0"

--- a/scripts/shipped-in.test.sh
+++ b/scripts/shipped-in.test.sh
@@ -29,7 +29,9 @@ printf '%s\n' "$*" >>"$GH_TEST_LOG"
 case "$1 $2" in
   "release list")
     [[ "$*" == *"--repo intent-hq/cloudlands-releases"* ]] || exit 1
-    cat "$GH_STUB_DIR/releases" ;;
+    cat "$GH_STUB_DIR/releases"
+    [[ -f "$GH_STUB_DIR/releases.fail" ]] && { echo "stub: release list truncated" >&2; exit 1; }
+    exit 0 ;;
   "api repos/"*)
     path=${2#repos/}; repo=${path%%/compare/*}; range=${path##*/compare/}
     file="$GH_STUB_DIR/compare/${repo/\//__}/$range"
@@ -112,6 +114,15 @@ run_script cloudlands-fe "$sha"
 reset_stub
 GH_STUB_FAIL=1 run_script cloudlands-fe "$sha"
 [[ "$status" -eq 1 ]] || fail "gh failure exited $status (expected 1, not 3)"
+
+reset_stub
+echo ahead >"$fe_compare/$sha...v2.3.0"
+echo behind >"$fe_compare/$sha...v2.2.0"
+echo behind >"$fe_compare/$sha...v2.1.0"
+: >"$stub_dir/releases.fail"
+run_script cloudlands-fe "$sha"
+[[ "$status" -eq 1 ]] || fail "release list that printed tags then failed exited $status (expected 1)"
+[[ -z "$stdout" ]] || fail "release list that printed tags then failed printed '$stdout'"
 
 reset_stub
 echo ahead >"$fe_compare/$sha...v2.3.0"

--- a/scripts/shipped-in.test.sh
+++ b/scripts/shipped-in.test.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)
+script="$repo_root/scripts/shipped-in.sh"
+temp_dir=$(mktemp -d)
+bin_dir="$temp_dir/bin"
+stub_dir="$temp_dir/stub"
+mkdir -p "$bin_dir" "$stub_dir"
+trap 'rm -rf "$temp_dir"' EXIT
+
+fail() {
+  echo "shipped-in test failed: $*" >&2
+  exit 1
+}
+
+for command in bash cat grep python3; do
+  ln -s "$(command -v "$command")" "$bin_dir/$command"
+done
+
+# Stub gh: releases from $GH_STUB_DIR/releases, compare statuses from
+# $GH_STUB_DIR/compare/<owner>__<repo>/<base>...<head>, manifests from
+# $GH_STUB_DIR/manifest/<tag>.json. Every invocation is appended to GH_TEST_LOG.
+cat >"$bin_dir/gh" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"$GH_TEST_LOG"
+[[ "${GH_STUB_FAIL:-0}" == 1 ]] && { echo "stub: gh unavailable" >&2; exit 1; }
+case "$1 $2" in
+  "release list")
+    [[ "$*" == *"--repo intent-hq/cloudlands-releases"* ]] || exit 1
+    cat "$GH_STUB_DIR/releases" ;;
+  "api repos/"*)
+    path=${2#repos/}; repo=${path%%/compare/*}; range=${path##*/compare/}
+    file="$GH_STUB_DIR/compare/${repo/\//__}/$range"
+    [[ -f "$file" ]] || { echo "stub: 404 $2" >&2; exit 1; }
+    cat "$file" ;;
+  "release download")
+    [[ "$*" == *"--repo intent-hq/cloudlands-releases"*"--pattern release-manifest.json"*"--output -"* ]] || exit 1
+    [[ -f "$GH_STUB_DIR/manifest/$3.json" ]] || { echo "stub: no manifest $3" >&2; exit 1; }
+    cat "$GH_STUB_DIR/manifest/$3.json" ;;
+  *) echo "stub: unexpected gh $*" >&2; exit 1 ;;
+esac
+SH
+chmod +x "$bin_dir/gh"
+
+sha=66e5cb92c4858dd3119b1d12d369493bec69dfb2
+fe_compare="$stub_dir/compare/intent-hq__cloudlands-fe"
+intentd_compare="$stub_dir/compare/intent-hq__intentd"
+manifest_dir="$stub_dir/manifest"
+
+reset_stub() {
+  rm -rf "$stub_dir"
+  mkdir -p "$fe_compare" "$intentd_compare" "$manifest_dir"
+  printf '%s\n' v2.3.0 v2.2.0 v2.1.0 >"$stub_dir/releases"
+  for tag in v2.3.0 v2.2.0 v2.1.0; do
+    printf '{"version":"%s","intentdVersion":"0.9.%s"}\n' "${tag#v}" "${tag##*.}" >"$manifest_dir/$tag.json"
+  done
+  : >"$temp_dir/gh.log"
+}
+
+run_script() {
+  set +e
+  PATH="$bin_dir" GH_STUB_DIR="$stub_dir" GH_TEST_LOG="$temp_dir/gh.log" \
+    bash "$script" "$@" >"$temp_dir/stdout" 2>"$temp_dir/stderr"
+  status=$?
+  set -e
+  stdout=$(<"$temp_dir/stdout")
+  stderr=$(<"$temp_dir/stderr")
+}
+
+reset_stub
+echo ahead >"$fe_compare/$sha...v2.3.0"
+echo behind >"$fe_compare/$sha...v2.2.0"
+echo behind >"$fe_compare/$sha...v2.1.0"
+run_script cloudlands-fe "$sha"
+[[ "$status" -eq 0 ]] || fail "newest-tag hit exited $status: $stderr"
+[[ "$stdout" == "v2.3.0 intentdVersion=0.9.0" ]] || fail "newest-tag hit printed '$stdout'"
+grep -q -- '^release list --repo intent-hq/cloudlands-releases --limit 10 ' "$temp_dir/gh.log" || fail "default limit was not 10"
+
+reset_stub
+echo ahead >"$fe_compare/$sha...v2.3.0"
+echo identical >"$fe_compare/$sha...v2.2.0"
+echo behind >"$fe_compare/$sha...v2.1.0"
+run_script cloudlands-fe "$sha" --limit 3
+[[ "$status" -eq 0 ]] || fail "older-tag hit exited $status: $stderr"
+[[ "$stdout" == "v2.2.0 intentdVersion=0.9.0" ]] || fail "expected the oldest carrying tag, printed '$stdout'"
+grep -q -- '^release list --repo intent-hq/cloudlands-releases --limit 3 ' "$temp_dir/gh.log" || fail "--limit was not forwarded"
+
+reset_stub
+echo behind >"$fe_compare/$sha...v2.3.0"
+echo behind >"$fe_compare/$sha...v2.2.0"
+echo behind >"$fe_compare/$sha...v2.1.0"
+run_script cloudlands-fe "$sha"
+[[ "$status" -eq 3 ]] || fail "no-hit exited $status (expected 3): $stderr"
+[[ -z "$stdout" ]] || fail "no-hit printed '$stdout'"
+! grep -q '^release download' "$temp_dir/gh.log" || fail "no-hit downloaded a manifest"
+
+reset_stub
+echo diverged >"$fe_compare/$sha...v2.3.0"
+echo behind >"$fe_compare/$sha...v2.2.0"
+echo diverged >"$fe_compare/$sha...v2.1.0"
+run_script cloudlands-fe "$sha"
+[[ "$status" -eq 3 ]] || fail "behind/diverged counted as a hit (exit $status, stdout '$stdout')"
+
+reset_stub
+echo ahead >"$fe_compare/$sha...v2.3.0"
+run_script cloudlands-fe "$sha"
+[[ "$status" -eq 1 ]] || fail "compare API failure exited $status (expected 1)"
+[[ -z "$stdout" ]] || fail "compare API failure printed '$stdout'"
+
+reset_stub
+GH_STUB_FAIL=1 run_script cloudlands-fe "$sha"
+[[ "$status" -eq 1 ]] || fail "gh failure exited $status (expected 1, not 3)"
+
+reset_stub
+printf '{"version":"2.3.0","intentdVersion":"0.9.5"}\n' >"$manifest_dir/v2.3.0.json"
+printf '{"version":"2.2.0","intentdVersion":"0.9.5"}\n' >"$manifest_dir/v2.2.0.json"
+printf '{"version":"2.1.0","intentdVersion":"0.9.4"}\n' >"$manifest_dir/v2.1.0.json"
+echo ahead >"$intentd_compare/$sha...v0.9.5"
+echo behind >"$intentd_compare/$sha...v0.9.4"
+run_script intentd "$sha"
+[[ "$status" -eq 0 ]] || fail "intentd hit exited $status: $stderr"
+[[ "$stdout" == "v2.2.0 intentdVersion=0.9.5" ]] || fail "intentd hit printed '$stdout'"
+[[ "$(grep -c "^api repos/intent-hq/intentd/compare/$sha...v0.9.5 " "$temp_dir/gh.log")" -eq 1 ]] || fail "intentd compare was not deduplicated per pinned version"
+! grep -q '^api repos/intent-hq/cloudlands-fe/' "$temp_dir/gh.log" || fail "intentd lookup compared against cloudlands-fe"
+
+reset_stub
+echo ahead >"$intentd_compare/$sha...v0.9.0"
+rm "$manifest_dir/v2.2.0.json"
+run_script intentd "$sha"
+[[ "$status" -eq 1 ]] || fail "missing manifest exited $status (expected 1)"
+
+reset_stub
+run_script ios "$sha"
+[[ "$status" -eq 2 ]] || fail "unknown component exited $status (expected 2)"
+run_script cloudlands-fe main
+[[ "$status" -eq 2 ]] || fail "non-sha ref exited $status (expected 2)"
+run_script cloudlands-fe "$sha" --limit 0
+[[ "$status" -eq 2 ]] || fail "--limit 0 exited $status (expected 2)"
+! grep -q '^release list' "$temp_dir/gh.log" || fail "usage errors reached gh"
+
+echo "shipped-in tests passed"

--- a/scripts/shipped-in.test.sh
+++ b/scripts/shipped-in.test.sh
@@ -114,6 +114,24 @@ GH_STUB_FAIL=1 run_script cloudlands-fe "$sha"
 [[ "$status" -eq 1 ]] || fail "gh failure exited $status (expected 1, not 3)"
 
 reset_stub
+echo ahead >"$fe_compare/$sha...v2.3.0"
+echo behind >"$fe_compare/$sha...v2.2.0"
+echo behind >"$fe_compare/$sha...v2.1.0"
+rm "$manifest_dir/v2.3.0.json"
+run_script cloudlands-fe "$sha"
+[[ "$status" -eq 1 ]] || fail "fe hit with missing manifest exited $status (expected 1)"
+[[ -z "$stdout" ]] || fail "fe hit with missing manifest printed '$stdout'"
+
+reset_stub
+echo ahead >"$fe_compare/$sha...v2.3.0"
+echo behind >"$fe_compare/$sha...v2.2.0"
+echo behind >"$fe_compare/$sha...v2.1.0"
+printf '{"version":"2.3.0"}\n' >"$manifest_dir/v2.3.0.json"
+run_script cloudlands-fe "$sha"
+[[ "$status" -eq 1 ]] || fail "fe hit with malformed manifest exited $status (expected 1)"
+[[ -z "$stdout" ]] || fail "fe hit with malformed manifest printed '$stdout'"
+
+reset_stub
 printf '{"version":"2.3.0","intentdVersion":"0.9.5"}\n' >"$manifest_dir/v2.3.0.json"
 printf '{"version":"2.2.0","intentdVersion":"0.9.5"}\n' >"$manifest_dir/v2.2.0.json"
 printf '{"version":"2.1.0","intentdVersion":"0.9.4"}\n' >"$manifest_dir/v2.1.0.json"


### PR DESCRIPTION
## Summary

AGENTS.md § Release Process requires every intentd/cloudlands-fe workspace to monitor until the change ships in a cloudlands-fe alpha and report the carrying version, but offered no supported *how* — each agent hand-wrote its own polling hook (which repo to list, how to decide "tag contains my commit", where the manifest lives, the intentd pin-bump case). This adds one tested script plus the canonical hook that calls it, and shrinks the prose to "run this".

Retrospective rung 3 (make the right path discoverable via a script). Rung 1/2 are infeasible: shipping is an external asynchronous event that nothing in-repo can type-check or CI-gate.

## Changes

- `scripts/shipped-in.sh <intentd|cloudlands-fe> <sha> [--limit N]`
  - Lists the newest N (default 10) `vX.Y.Z` releases on `intent-hq/cloudlands-releases`.
  - cloudlands-fe: `gh api repos/intent-hq/cloudlands-fe/compare/<sha>...<tag>`; a hit is `ahead|identical` only (`behind`/`diverged` never count).
  - intentd: reads `intentdVersion` from each tag's `release-manifest.json` and compares `<sha>...v<version>` on `intent-hq/intentd` (deduplicated per pinned version).
  - Prints the oldest carrying tag as `<tag> intentdVersion=<v>` and exits 0; exits 3 (empty stdout) while nothing carries the commit yet; 2 on usage errors; 1 on `gh`/API failure.
- `scripts/shipped-in.test.sh` — hermetic, stubbed `gh` on PATH (same convention as `dev-status.test.sh`); wired into the `shell-tests` CI job.
- `make shipped-in COMPONENT=... SHA=... [LIMIT=N]` (listed in `make help`).
- AGENTS.md "Track shipped work" bullet rewritten around the script with a canonical `ws.hook.schedule` snippet (dispatch on exit 0, keep waiting on exit 3, throw otherwise), mirroring the sandbox health-wait snippet.
- One-line pointer in `docs/RELEASING.md` § Gotchas.

## Verification

| Claim | Command | Result |
|---|---|---|
| Unit tests | `bash scripts/shipped-in.test.sh` | pass (hit-first, hit-later/oldest wins, no hit → 3, behind/diverged miss, compare 404 → 1, gh failure → 1 not 3, intentd manifest path + dedup, missing manifest → 1, usage → 2, `--limit` forwarding) |
| Doc gates | `make docs-check`, `node scripts/check-doc-links.mjs`, `node scripts/check-root-hygiene.mjs`, `bash scripts/docs-check.test.sh` | all pass |
| Not yet shipped | `scripts/shipped-in.sh cloudlands-fe 66e5cb92c4858dd3119b1d12d369493bec69dfb2` (cloudlands-fe#2260) | exit 3, empty stdout |
| fe hit | `scripts/shipped-in.sh cloudlands-fe 5b466957241fe6e6e3533294e6a86bf61083557c` (v2.144.0 `feSha`) | `v2.144.0 intentdVersion=0.9.38`, exit 0 |
| intentd hit | `scripts/shipped-in.sh intentd <v0.9.37 commit> --limit 6` | `v2.143.0 intentdVersion=0.9.38`, exit 0, ~7 s |
| Hook path | `ws.host.exec({ command: "scripts/shipped-in.sh", ... })` | same exit codes as above |

Note: `make shipped-in` surfaces the script's exit 3 as make `Error 3`, so hooks invoke the script directly (documented in the Makefile comment and AGENTS.md snippet).
