### PR TITLE
fix: probe dev ports for live listeners and keep sandbox restarts on their pinned port

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -471,17 +471,20 @@ dev-ui: ensure-fe-submodule ## Run the fast browser-only frontend UI preview
 dev-sandbox-ui: ensure-fe-submodule ## UI preview sandbox on this worktree's derived DEV_PORT
 	@[ -d $(FE_DIR)/node_modules ] || (echo "[dev-sandbox-ui] installing FE deps (corepack pnpm install)" && cd $(FE_DIR) && corepack pnpm install --frozen-lockfile)
 	@DEV_PORT="$(DEV_PORT)" DEV_TCP_PORT="$(DEV_TCP_PORT)" SANDBOX_READY_TIMEOUT="$(SANDBOX_READY_TIMEOUT)" \
+		DEV_PORT_ORIGIN="$(origin DEV_PORT)" DEV_TCP_PORT_ORIGIN="$(origin DEV_TCP_PORT)" \
 		FE_DIR="$(CURDIR)/$(FE_DIR)" exec scripts/dev-sandbox.sh ui
 
 dev-sandbox-app: ensure-fe-submodule ## Web renderer sandbox connected to the installed intentd
 	@[ -d $(FE_DIR)/node_modules ] || (echo "[dev-sandbox-app] installing FE deps (corepack pnpm install)" && cd $(FE_DIR) && corepack pnpm install --frozen-lockfile)
 	@DEV_PORT="$(DEV_PORT)" DEV_TCP_PORT="$(DEV_TCP_PORT)" SANDBOX_READY_TIMEOUT="$(SANDBOX_READY_TIMEOUT)" \
+		DEV_PORT_ORIGIN="$(origin DEV_PORT)" DEV_TCP_PORT_ORIGIN="$(origin DEV_TCP_PORT)" \
 		SANDBOX_WARM_TIMEOUT="$(SANDBOX_WARM_TIMEOUT)" \
 		FE_DIR="$(CURDIR)/$(FE_DIR)" exec scripts/dev-sandbox.sh app
 
 dev-sandbox-stack: ensure-intentd-submodule ensure-fe-submodule ## Dev-profile intentd + renderer (INTENTD_PROFILE=release or INTENTD_BIN=/path)
 	@[ -d $(FE_DIR)/node_modules ] || (echo "[dev-sandbox-stack] installing FE deps (corepack pnpm install)" && cd $(FE_DIR) && corepack pnpm install --frozen-lockfile)
 	@DEV_PORT="$(DEV_PORT)" DEV_TCP_PORT="$(DEV_TCP_PORT)" DEV_DATA_DIR="$(DEV_DATA_DIR)" \
+		DEV_PORT_ORIGIN="$(origin DEV_PORT)" DEV_TCP_PORT_ORIGIN="$(origin DEV_TCP_PORT)" \
 		SANDBOX_TCP="$(SANDBOX_TCP)" SANDBOX_READY_TIMEOUT="$(SANDBOX_READY_TIMEOUT)" \
 		SANDBOX_WARM_TIMEOUT="$(SANDBOX_WARM_TIMEOUT)" BUILD_JOBS="$(BUILD_JOBS)" \
 		INTENTD_PROFILE="$(INTENTD_PROFILE)" INTENTD_BIN="$(INTENTD_BIN)" \

--- a/docs/fe/DEVELOPER_GUIDE.md
+++ b/docs/fe/DEVELOPER_GUIDE.md
@@ -99,6 +99,14 @@ sandbox of each mode; starting a second same-mode sandbox overwrites that mode's
 Run `make sandbox-status` first and coordinate with the recorded owner, or use a separate
 worktree.
 
+Readiness also records `.dev/sandbox/<mode>.port` (`DEV_PORT=` and `DEV_TCP_PORT=` lines).
+Unlike the state file, it survives every exit, so a supervised restart that starts with the
+Makefile-derived ports reuses the recorded port when it is free and the tunnel URL stays
+valid; an explicit `DEV_PORT=` override always wins, and `make sandbox-stop` forgets the
+record. The port probe sets `SO_REUSEADDR` and treats only a live listener as busy —
+`TIME_WAIT`/`CLOSE_WAIT` leftovers from a just-stopped sandbox are free — and a busy
+explicit port is reported with the owning PID when it is visible.
+
 `make sandbox-status` verifies recorded PIDs, removes stale files, and exits nonzero when
 nothing is running; `SANDBOX_JSON=1 make sandbox-status` emits the live array. A clean exit
 removes the owned file. `make sandbox-stop MODE=<mode>` owns unmanaged process trees and

--- a/scripts/dev-ports.sh
+++ b/scripts/dev-ports.sh
@@ -11,14 +11,27 @@ canonical_path=$(pwd -P)
 path_hash=$(printf '%s' "$canonical_path" | cksum | awk '{print $1}')
 preferred_block=$((path_hash % BLOCK_COUNT))
 
+# Busy means a live listener: something accepts on loopback, or a SO_REUSEADDR
+# bind fails (EADDRINUSE from a LISTEN socket). Recently closed connections in
+# TIME_WAIT/CLOSE_WAIT do not block a SO_REUSEADDR bind, so they read as free —
+# the same answer the FE dev server (which also sets SO_REUSEADDR) would get.
 port_is_free() {
   python3 - "$1" <<'PY'
 import socket
 import sys
 
-sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+port = int(sys.argv[1])
+probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+probe.settimeout(0.25)
 try:
-    sock.bind(("127.0.0.1", int(sys.argv[1])))
+    if probe.connect_ex(("127.0.0.1", port)) == 0:
+        raise SystemExit(1)
+finally:
+    probe.close()
+sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+try:
+    sock.bind(("127.0.0.1", port))
 except OSError:
     raise SystemExit(1)
 finally:

--- a/scripts/dev-ports.test.sh
+++ b/scripts/dev-ports.test.sh
@@ -78,6 +78,36 @@ if (cd "$temp_dir" && DEV_PORT="$busy_port" bash "$script" >"$temp_dir/explicit.
 fi
 grep -q 'explicit DEV_PORT=.* is busy' "$temp_dir/explicit.stderr" || fail "busy explicit port error was unclear"
 
+# Regression for intent-hq/intent#4619: a connection accepted and closed by a
+# now-gone listener leaves TIME_WAIT state on the port, which is not a listener.
+timewait_port=$(python3 - <<'PY'
+import socket
+
+server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+server.bind(("127.0.0.1", 0))
+server.listen()
+port = server.getsockname()[1]
+client = socket.create_connection(("127.0.0.1", port))
+accepted, _ = server.accept()
+accepted.close()
+client.close()
+server.close()
+print(port)
+PY
+)
+python3 - "$timewait_port" <<'PY' || fail "TIME_WAIT probe port unexpectedly accepts connections"
+import socket
+import sys
+s = socket.socket()
+s.settimeout(0.2)
+assert s.connect_ex(("127.0.0.1", int(sys.argv[1]))) != 0
+s.close()
+PY
+timewait_output=$(cd "$temp_dir" && DEV_PORT="$timewait_port" bash "$script" 2>"$temp_dir/timewait.stderr") \
+  || fail "a closed connection's TIME_WAIT state was reported as a busy port: $(cat "$temp_dir/timewait.stderr")"
+[[ "$(value_of "$timewait_output" DEV_PORT)" == "$timewait_port" ]] || fail "TIME_WAIT port was not kept as the explicit DEV_PORT"
+
 default_output=$(cd "$repo_root" && "$make_bin" -n)
 grep -q 'cargo build --workspace' <<<"$default_output" || fail "plain make no longer selects the build target"
 [[ $(head -n 1 <<<"$default_output") != 'set -- .dev/sandbox/'* ]] || fail "plain make still selects the ports target"

--- a/scripts/dev-sandbox.sh
+++ b/scripts/dev-sandbox.sh
@@ -115,8 +115,11 @@ if [[ "$mode" == ui || "$mode" == app || "$mode" == stack ]]; then
   [[ "$dev_tcp_port" =~ ^[0-9]+$ ]] || { echo "[dev-sandbox-$mode] ERROR: DEV_TCP_PORT must be numeric." >&2; exit 2; }
   [[ "$ready_timeout" =~ ^[1-9][0-9]*$ ]] || { echo "[dev-sandbox-$mode] ERROR: SANDBOX_READY_TIMEOUT must be a positive integer." >&2; exit 2; }
   [[ "$warm_timeout" =~ ^[1-9][0-9]*$ ]] || { echo "[dev-sandbox-$mode] ERROR: SANDBOX_WARM_TIMEOUT must be a positive integer." >&2; exit 2; }
+  derived_dev_port=$dev_port
   if [[ "$dev_port_explicit" -eq 0 ]] && pinned_port=$(pinned_value DEV_PORT) && [[ "$pinned_port" != "$dev_port" ]]; then
-    if port_is_free "$pinned_port"; then
+    if [[ "$pinned_port" == "$dev_tcp_port" && "$dev_tcp_port_explicit" -eq 1 ]]; then
+      echo "[dev-sandbox-$mode] WARNING: recorded DEV_PORT=$pinned_port from $pin_file collides with explicit DEV_TCP_PORT=$dev_tcp_port; starting on derived DEV_PORT=$dev_port instead." >&2
+    elif port_is_free "$pinned_port"; then
       echo "[dev-sandbox-$mode] Reusing recorded DEV_PORT=$pinned_port from $pin_file (derived DEV_PORT=$dev_port not used); run 'make sandbox-stop MODE=$mode' to forget it."
       dev_port=$pinned_port
     else
@@ -129,6 +132,10 @@ if [[ "$mode" == ui || "$mode" == app || "$mode" == stack ]]; then
     if [[ "$mode" != stack || ${SANDBOX_TCP:-0} != 1 ]] || port_is_free "$pinned_tcp_port"; then
       dev_tcp_port=$pinned_tcp_port
     fi
+  fi
+  if [[ "$dev_port" != "$derived_dev_port" && "$dev_port" == "$dev_tcp_port" ]]; then
+    echo "[dev-sandbox-$mode] WARNING: recorded DEV_PORT=$dev_port from $pin_file collides with DEV_TCP_PORT=$dev_tcp_port; starting on derived DEV_PORT=$derived_dev_port instead." >&2
+    dev_port=$derived_dev_port
   fi
   export DEV_PORT="$dev_port" DEV_TCP_PORT="$dev_tcp_port"
   if [[ "$dev_port_explicit" -eq 1 ]] && ! port_is_free "$dev_port"; then

--- a/scripts/dev-sandbox.sh
+++ b/scripts/dev-sandbox.sh
@@ -13,10 +13,13 @@ esac
 repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)
 state_dir=${SANDBOX_STATE_DIR:-"$repo_root/.dev/sandbox"}
 fe_dir=${FE_DIR:-"$repo_root/packages/cloudlands-fe"}
+# The Makefile always passes DEV_PORT/DEV_TCP_PORT and reports where each came
+# from via $(origin): "file" means the worktree-derived default, anything else
+# (environment, command line) is an explicit pin that is never remapped.
 dev_port_explicit=0
 dev_tcp_port_explicit=0
-[[ ${DEV_PORT+x} == x ]] && dev_port_explicit=1
-[[ ${DEV_TCP_PORT+x} == x ]] && dev_tcp_port_explicit=1
+[[ ${DEV_PORT+x} == x && ${DEV_PORT_ORIGIN:-} != file ]] && dev_port_explicit=1
+[[ ${DEV_TCP_PORT+x} == x && ${DEV_TCP_PORT_ORIGIN:-} != file ]] && dev_tcp_port_explicit=1
 dev_port=${DEV_PORT:-5190}
 dev_tcp_port=${DEV_TCP_PORT:-5181}
 ready_timeout=${SANDBOX_READY_TIMEOUT:-60}
@@ -33,20 +36,34 @@ daemon_pid=""
 cleaning=0
 child_exit_status=0
 state_file="$state_dir/$mode.json"
+# The pin record outlives the state file (which is removed on every exit) so a
+# supervised restart of this mode comes back on the port its tunnel URL uses.
+pin_file="$state_dir/$mode.port"
 started_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 warm_ok=true
 warm_ms=0
 intentd_source=installed
 [[ "$mode" == ui ]] && intentd_source=none
 
+# Mirrors scripts/dev-ports.sh: busy means a live listener (loopback connect
+# accepted, or a SO_REUSEADDR bind fails); TIME_WAIT/CLOSE_WAIT leftovers are free.
 port_is_free() {
   python3 - "$1" <<'PY' >/dev/null 2>&1
 import socket
 import sys
 
-sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+port = int(sys.argv[1])
+probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+probe.settimeout(0.25)
 try:
-    sock.bind(("127.0.0.1", int(sys.argv[1])))
+    if probe.connect_ex(("127.0.0.1", port)) == 0:
+        raise SystemExit(1)
+finally:
+    probe.close()
+sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+try:
+    sock.bind(("127.0.0.1", port))
 except OSError:
     raise SystemExit(1)
 finally:
@@ -54,17 +71,74 @@ finally:
 PY
 }
 
+port_owner() {
+  local port=$1 pid="" comm=""
+  if command -v ss >/dev/null 2>&1; then
+    pid=$(ss -Hltnp "sport = :$port" 2>/dev/null | sed -n 's/.*pid=\([0-9]*\).*/\1/p' | head -n 1)
+  fi
+  if [[ -z "$pid" ]] && command -v lsof >/dev/null 2>&1; then
+    pid=$(lsof -nP -iTCP:"$port" -sTCP:LISTEN -t 2>/dev/null | head -n 1)
+  fi
+  [[ -n "$pid" ]] || return 1
+  comm=$(ps -o comm= -p "$pid" 2>/dev/null | tr -d ' ')
+  printf 'PID %s%s' "$pid" "${comm:+ ($comm)}"
+}
+
+describe_busy_port() {
+  local port=$1 owner
+  if owner=$(port_owner "$port"); then
+    echo "[dev-ports] 127.0.0.1:$port is held by $owner; stop it or choose another port." >&2
+  else
+    echo "[dev-ports] No listening PID is visible for 127.0.0.1:$port (another user's process, or connections still draining); retry shortly or choose another port." >&2
+  fi
+}
+
+pinned_value() {
+  local key=$1 line
+  [[ -f "$pin_file" ]] || return 1
+  while IFS= read -r line; do
+    if [[ "$line" == "$key="* && "${line#*=}" =~ ^[0-9]+$ ]]; then
+      printf '%s' "${line#*=}"
+      return 0
+    fi
+  done <"$pin_file"
+  return 1
+}
+
+write_pin_file() {
+  local temp_file="$pin_file.tmp.$$"
+  printf 'DEV_PORT=%s\nDEV_TCP_PORT=%s\n' "$dev_port" "$dev_tcp_port" >"$temp_file" && mv -f "$temp_file" "$pin_file"
+}
+
 if [[ "$mode" == ui || "$mode" == app || "$mode" == stack ]]; then
   [[ "$dev_port" =~ ^[0-9]+$ ]] || { echo "[dev-sandbox-$mode] ERROR: DEV_PORT must be numeric." >&2; exit 2; }
   [[ "$dev_tcp_port" =~ ^[0-9]+$ ]] || { echo "[dev-sandbox-$mode] ERROR: DEV_TCP_PORT must be numeric." >&2; exit 2; }
   [[ "$ready_timeout" =~ ^[1-9][0-9]*$ ]] || { echo "[dev-sandbox-$mode] ERROR: SANDBOX_READY_TIMEOUT must be a positive integer." >&2; exit 2; }
   [[ "$warm_timeout" =~ ^[1-9][0-9]*$ ]] || { echo "[dev-sandbox-$mode] ERROR: SANDBOX_WARM_TIMEOUT must be a positive integer." >&2; exit 2; }
+  if [[ "$dev_port_explicit" -eq 0 ]] && pinned_port=$(pinned_value DEV_PORT) && [[ "$pinned_port" != "$dev_port" ]]; then
+    if port_is_free "$pinned_port"; then
+      echo "[dev-sandbox-$mode] Reusing recorded DEV_PORT=$pinned_port from $pin_file (derived DEV_PORT=$dev_port not used); run 'make sandbox-stop MODE=$mode' to forget it."
+      dev_port=$pinned_port
+    else
+      echo "[dev-sandbox-$mode] WARNING: recorded DEV_PORT=$pinned_port from $pin_file is busy; starting on derived DEV_PORT=$dev_port instead." >&2
+      describe_busy_port "$pinned_port"
+    fi
+  fi
+  if [[ "$dev_tcp_port_explicit" -eq 0 ]] && pinned_tcp_port=$(pinned_value DEV_TCP_PORT) \
+    && [[ "$pinned_tcp_port" != "$dev_tcp_port" && "$pinned_tcp_port" != "$dev_port" ]]; then
+    if [[ "$mode" != stack || ${SANDBOX_TCP:-0} != 1 ]] || port_is_free "$pinned_tcp_port"; then
+      dev_tcp_port=$pinned_tcp_port
+    fi
+  fi
+  export DEV_PORT="$dev_port" DEV_TCP_PORT="$dev_tcp_port"
   if [[ "$dev_port_explicit" -eq 1 ]] && ! port_is_free "$dev_port"; then
     echo "[dev-ports] ERROR: explicit DEV_PORT=$dev_port is busy; explicit ports are never remapped." >&2
+    describe_busy_port "$dev_port"
     exit 1
   fi
   if [[ "$mode" == stack && ${SANDBOX_TCP:-0} == 1 && "$dev_tcp_port_explicit" -eq 1 ]] && ! port_is_free "$dev_tcp_port"; then
     echo "[dev-ports] ERROR: explicit DEV_TCP_PORT=$dev_tcp_port is busy; explicit ports are never remapped." >&2
+    describe_busy_port "$dev_tcp_port"
     exit 1
   fi
 fi
@@ -216,9 +290,11 @@ stop_sandboxes() {
   mkdir -p "$state_dir"
   if [[ -n "$requested_mode" ]]; then
     [[ -e "$state_dir/$requested_mode.json" ]] && paths+=("$state_dir/$requested_mode.json")
+    rm -f "$state_dir/$requested_mode.port"
   else
     shopt -s nullglob
     paths=("$state_dir"/*.json)
+    for path in "$state_dir"/*.port; do rm -f "$path"; done
     shopt -u nullglob
   fi
   if [[ ${#paths[@]} -eq 0 ]]; then
@@ -571,6 +647,7 @@ if ! write_state_file "$ready_at"; then
   echo "[dev-sandbox-$mode] ERROR: could not write sandbox state at $state_file" >&2
   exit 1
 fi
+write_pin_file || echo "[dev-sandbox-$mode] WARNING: could not record the pinned port at $pin_file" >&2
 echo "Sandbox ready: http://127.0.0.1:${dev_port}/  (open as http://daemon.localhost:${dev_port}/ from the client)"
 
 if [[ -z "$daemon_pid" ]]; then

--- a/scripts/dev-sandbox.test.sh
+++ b/scripts/dev-sandbox.test.sh
@@ -401,6 +401,23 @@ kill "$listener_pid"
 wait "$listener_pid" 2>/dev/null || true
 listener_pid=""
 
+# A recorded DEV_PORT that equals an explicit DEV_TCP_PORT is never reused: the
+# resolved pair must stay unique. The record now points at $derived_port.
+collide_port=$(free_port)
+PATH="$temp_dir/bin:$PATH" FE_DIR="$temp_dir/fe" DEV_PORT="$collide_port" DEV_PORT_ORIGIN=file \
+  DEV_TCP_PORT="$derived_port" DEV_TCP_PORT_ORIGIN="command line" \
+  SANDBOX_STATE_DIR="$state_dir" SANDBOX_READY_TIMEOUT=5 bash "$script" ui >"$temp_dir/pinned-collide.out" 2>&1 &
+sandbox_pid=$!
+wait_for_ready "$temp_dir/pinned-collide.out" || fail "sandbox with a colliding recorded port did not become ready"
+grep -q "recorded DEV_PORT=$derived_port from $state_dir/ui.port collides with explicit DEV_TCP_PORT=$derived_port; starting on derived DEV_PORT=$collide_port" "$temp_dir/pinned-collide.out" \
+  || fail "colliding recorded port was not reported"
+! grep -q 'Reusing recorded DEV_PORT' "$temp_dir/pinned-collide.out" || fail "recorded DEV_PORT was reused despite colliding with DEV_TCP_PORT"
+grep -q "^Sandbox ready: http://127.0.0.1:$collide_port/" "$temp_dir/pinned-collide.out" \
+  || fail "colliding recorded port was not replaced by the derived port"
+kill -TERM "$sandbox_pid"
+wait "$sandbox_pid" 2>/dev/null || true
+sandbox_pid=""
+
 # An explicit port always wins over the recorded one.
 explicit_port=$(free_port)
 PATH="$temp_dir/bin:$PATH" FE_DIR="$temp_dir/fe" DEV_PORT="$explicit_port" DEV_PORT_ORIGIN="command line" \

--- a/scripts/dev-sandbox.test.sh
+++ b/scripts/dev-sandbox.test.sh
@@ -161,6 +161,8 @@ if PATH="$temp_dir/bin:$PATH" FE_DIR="$temp_dir/fe" DEV_PORT="$busy_port" \
 fi
 grep -q "explicit DEV_PORT=$busy_port is busy; explicit ports are never remapped" "$temp_dir/busy-port.out" \
   || fail "busy explicit port error was not actionable"
+grep -q "127.0.0.1:$busy_port is held by PID $listener_pid" "$temp_dir/busy-port.out" \
+  || fail "busy explicit port error did not name the owning PID"
 kill "$listener_pid"
 wait "$listener_pid" 2>/dev/null || true
 listener_pid=""
@@ -335,6 +337,83 @@ set -e
 sandbox_pid=""
 [[ "$status" -ne 0 ]] || fail "frontend child failure was not propagated"
 [[ ! -e "$state_dir/ui.json" ]] || fail "state file remained after frontend child failure"
+[[ -f "$state_dir/ui.port" ]] || fail "pinned port record was not written on readiness"
+grep -qx "DEV_PORT=$port" "$state_dir/ui.port" || fail "pinned port record did not hold the ready DEV_PORT"
+
+# Regression for intent-hq/intent#4619: a supervised restart with a derived
+# (Makefile-default) port comes back on the recorded port, even when the derived
+# block moved, so the existing tunnel URL stays valid.
+pinned_port=$port
+derived_port=$(free_port)
+PATH="$temp_dir/bin:$PATH" FE_DIR="$temp_dir/fe" DEV_PORT="$derived_port" DEV_PORT_ORIGIN=file \
+  SANDBOX_STATE_DIR="$state_dir" SANDBOX_READY_TIMEOUT=5 bash "$script" ui >"$temp_dir/pinned-restart.out" 2>&1 &
+sandbox_pid=$!
+wait_for_ready "$temp_dir/pinned-restart.out" || fail "pinned restart sandbox did not become ready"
+grep -q "Reusing recorded DEV_PORT=$pinned_port from $state_dir/ui.port" "$temp_dir/pinned-restart.out" \
+  || fail "pinned restart did not report the reused port"
+grep -q "^Sandbox ready: http://127.0.0.1:$pinned_port/" "$temp_dir/pinned-restart.out" \
+  || fail "pinned restart did not come back on the recorded port"
+python3 - "$state_dir/ui.json" "$pinned_port" <<'PY' || fail "pinned restart state did not record the reused port"
+import json
+import sys
+assert json.load(open(sys.argv[1], encoding="utf-8"))["devPort"] == int(sys.argv[2])
+PY
+kill -TERM "$sandbox_pid"
+wait "$sandbox_pid" 2>/dev/null || true
+sandbox_pid=""
+[[ -f "$state_dir/ui.port" ]] || fail "pinned port record did not survive a TERM exit"
+
+# A busy recorded port falls back to the derived port and names the holder.
+python3 - "$pinned_port" "$busy_ready.pinned" <<'PY' &
+import pathlib
+import socket
+import sys
+import time
+
+sock = socket.socket()
+sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+sock.bind(("127.0.0.1", int(sys.argv[1])))
+sock.listen()
+pathlib.Path(sys.argv[2]).touch()
+time.sleep(30)
+PY
+listener_pid=$!
+for _ in {1..100}; do
+  [[ -e "$busy_ready.pinned" ]] && break
+  sleep 0.01
+done
+[[ -e "$busy_ready.pinned" ]] || fail "pinned-port listener did not start"
+PATH="$temp_dir/bin:$PATH" FE_DIR="$temp_dir/fe" DEV_PORT="$derived_port" DEV_PORT_ORIGIN=file \
+  SANDBOX_STATE_DIR="$state_dir" SANDBOX_READY_TIMEOUT=5 bash "$script" ui >"$temp_dir/pinned-busy.out" 2>&1 &
+sandbox_pid=$!
+wait_for_ready "$temp_dir/pinned-busy.out" || fail "sandbox with a busy recorded port did not become ready"
+grep -q "recorded DEV_PORT=$pinned_port from $state_dir/ui.port is busy; starting on derived DEV_PORT=$derived_port" "$temp_dir/pinned-busy.out" \
+  || fail "busy recorded port fallback was not reported"
+grep -q "127.0.0.1:$pinned_port is held by PID $listener_pid" "$temp_dir/pinned-busy.out" \
+  || fail "busy recorded port did not name the owning PID"
+grep -q "^Sandbox ready: http://127.0.0.1:$derived_port/" "$temp_dir/pinned-busy.out" \
+  || fail "busy recorded port did not fall back to the derived port"
+grep -qx "DEV_PORT=$derived_port" "$state_dir/ui.port" || fail "pinned port record was not re-pointed at the fallback port"
+kill -TERM "$sandbox_pid"
+wait "$sandbox_pid" 2>/dev/null || true
+sandbox_pid=""
+kill "$listener_pid"
+wait "$listener_pid" 2>/dev/null || true
+listener_pid=""
+
+# An explicit port always wins over the recorded one.
+explicit_port=$(free_port)
+PATH="$temp_dir/bin:$PATH" FE_DIR="$temp_dir/fe" DEV_PORT="$explicit_port" DEV_PORT_ORIGIN="command line" \
+  SANDBOX_STATE_DIR="$state_dir" SANDBOX_READY_TIMEOUT=5 bash "$script" ui >"$temp_dir/explicit-restart.out" 2>&1 &
+sandbox_pid=$!
+wait_for_ready "$temp_dir/explicit-restart.out" || fail "explicit-port sandbox did not become ready"
+grep -q "^Sandbox ready: http://127.0.0.1:$explicit_port/" "$temp_dir/explicit-restart.out" \
+  || fail "explicit DEV_PORT was overridden by the recorded port"
+! grep -q 'Reusing recorded DEV_PORT' "$temp_dir/explicit-restart.out" || fail "explicit DEV_PORT reported a recorded-port reuse"
+MODE=ui SANDBOX_STATE_DIR="$state_dir" bash "$script" stop >/dev/null
+wait "$sandbox_pid" 2>/dev/null || true
+sandbox_pid=""
+[[ ! -e "$state_dir/ui.port" ]] || fail "sandbox-stop did not forget the pinned port record"
 
 if PATH="$temp_dir/bin:$PATH" FE_DIR="$temp_dir/fe" DEV_PORT="$(free_port)" \
   SANDBOX_STATE_DIR="$state_dir" INTENTD_SOCKET="$temp_dir/missing.sock" bash "$script" app >"$temp_dir/app.out" 2>&1; then


### PR DESCRIPTION
Fixes intent-hq/intent#4619

## Problem

`port_is_free` in `scripts/dev-ports.sh` and `scripts/dev-sandbox.sh` bound a fresh loopback socket without `SO_REUSEADDR`. A connection that a now-gone listener accepted and closed leaves the port in `TIME_WAIT`, and a plain bind fails with `EADDRINUSE` in that state, so:

- an explicit `DEV_PORT=` restart right after a stop failed with "explicit DEV_PORT=N is busy" even though `ss -ltnp` showed no listener;
- a supervised `make dev-sandbox-app` restart derived the next free block instead of its previous one, moving the app (5508 -> 5512, 6520 -> 6524 in the issue) and invalidating the embedded-browser tunnel URL.

Reproduced deterministically: Node/libuv listeners set `SO_REUSEADDR`, so a `SO_REUSEADDR` bind succeeds against the `TIME_WAIT` they leave behind while the old probe fails.

## Changes

- **Probe** (`dev-ports.sh`, `dev-sandbox.sh`): busy means a live listener — a loopback connect is accepted, or a `SO_REUSEADDR` bind still fails. `TIME_WAIT`/`CLOSE_WAIT` leftovers read as free; an occupied listener is still rejected. A busy explicit port now also prints the owning PID (`ss`/`lsof`, when visible).
- **Pinned restart** (`dev-sandbox.sh`, `Makefile`): readiness records `.dev/sandbox/<mode>.port` (`DEV_PORT=`/`DEV_TCP_PORT=`). Unlike `<mode>.json`, it survives every exit (the state file is removed on crash/TERM by design, so it cannot carry the port across a restart). The three sandbox recipes pass `DEV_PORT_ORIGIN="$(origin DEV_PORT)"` / `DEV_TCP_PORT_ORIGIN`; when the port is the Makefile-derived default (`file`) and a record exists, the sandbox reuses the recorded port if free (logged), or falls back to the derived port naming the holder. Explicit env/command-line ports always win; `make sandbox-stop` forgets the record.
- **Docs**: `docs/fe/DEVELOPER_GUIDE.md` Remote Sandbox Internals describes the record and probe semantics.

## Tests

- `dev-ports.test.sh`: accept-and-close a loopback connection, assert the explicit port is kept (fails on the old probe, passes now); the existing bound-listener case still asserts busy.
- `dev-sandbox.test.sh`: busy explicit error names the listener PID; derived-origin restart after a child crash comes back on the recorded port; busy recorded port falls back to the derived port and names the holder; explicit port beats the record; `sandbox-stop` removes the record.

## Verification

- `bash scripts/dev-ports.test.sh && bash scripts/dev-sandbox.test.sh` pass; `dev-status.test.sh`, `docs-check.test.sh`, `make docs-check` pass.
- Manual: `dev-sandbox.sh app` against the installed daemon with explicit `DEV_PORT=5700`, TERM, immediate restart with the same `DEV_PORT` -> ready on 5700 with one `TIME-WAIT` present on the port.
- `make -n dev-sandbox-app` shows `DEV_PORT_ORIGIN="file"` by default, `environment`/`command line` when pinned.
