### PR TITLE
docs: point long gates at ws.script.start plus a completion hook

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -254,8 +254,9 @@ with no rollback.
   live under `$HOME/.cache/intent/gate-runs`, expire after seven days, and include
   `junit.xml` plus an incremental passed-test stream. Set `GATE_FORCE=1` to ignore
   a matching record and run the complete suite.
-- Run long gates as saved command-mode `ws.script` entries and give `ws.script.run`
-  an explicit `timeoutSeconds`; its default timeout is only 30 seconds.
+- Run long gates as saved command-mode `ws.script` entries via `ws.script.start` plus a
+  self-checking `ws.hook.schedule` polling `ws.script.status` (dispatch on exit), then
+  `ws.script.output`. `ws.script.run` (~30s call budget) rejects longer `timeoutSeconds`.
 
 ## Release Process
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -256,7 +256,7 @@ with no rollback.
   a matching record and run the complete suite.
 - Run long gates as saved command-mode `ws.script` entries via `ws.script.start` plus a
   self-checking `ws.hook.schedule` polling `ws.script.status` (dispatch on exit), then
-  `ws.script.output`. `ws.script.run` (~30s call budget) rejects longer `timeoutSeconds`.
+  `ws.script.output`. `ws.script.run` rejects `timeoutSeconds` above budget − 5s (25s default).
 
 ## Release Process
 


### PR DESCRIPTION
## Summary

AGENTS.md § Resuming local Rust gates told agents to give `ws.script.run` a long
`timeoutSeconds` for long gates. That cannot work: `ws.script.run` is bounded by the
`workspace_api` eval budget (30s by default), so a 600s wait hits the transport timeout
while the process keeps running (observed in workspace https-review-2 / cloudlands-fe #2320).

This replaces the bullet, in the same three-line budget, with the supported pattern:

- save a command-mode `ws.script` entry and `ws.script.start` it;
- wait with a self-checking `ws.hook.schedule` that polls `ws.script.status`
  (dispatch on exit), then read `ws.script.output`;
- `ws.script.run` rejects any `timeoutSeconds` above its ceiling of
  eval budget − 5s — 25s on the default 30s budget (so 26..30 are rejected too).
  The ceiling and rejection are implemented by companion intent-hq/intentd#1787.

Refs intent-hq/intent#4703

## Landing order

The bullet describes the daemon behavior introduced by intent-hq/intentd#1787. Land
that PR first; the `auto-bump-submodules` workflow then advances the `packages/intentd`
pin automatically (no manual bump PR), and this docs PR lands after the bump so
`AGENTS.md` never describes behavior the pinned daemon lacks.

## Verification

- `git diff origin/main..HEAD` touches only the one bullet (2 lines → 3); `git diff --check` clean.
