### PR TITLE
chore(doctor): require gh >= 2.94.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -341,19 +341,8 @@ for all components.
   not apply them (triage retires them — on the issue's open / edit / reopen, or as
   soon as the label is applied — after setting the matching Type; the `question`
   label stays a regular label). Set the Type when filing:
-  `gh issue create --repo intent-hq/intent --type Bug ...` (gh ≥ 2.94.0). On older
-  gh, create the issue first, then set the Type via
-  `gh api graphql` with the `updateIssue` mutation, passing an `issueTypeId`
-  resolved from the repository's `issueTypes` connection:
-
-  ```bash
-  gh api graphql -f query='query { repository(owner: "intent-hq", name: "intent") {
-    issueTypes(first: 10) { nodes { id name } } } }'
-  gh api graphql -f query='mutation($id: ID!, $type: ID!) {
-    updateIssue(input: { id: $id, issueTypeId: $type }) { issue { number } } }' \
-    -f id="$(gh issue view <N> --repo intent-hq/intent --json id -q .id)" -f type=<issueTypeId>
-  ```
-
+  `gh issue create --repo intent-hq/intent --type Bug ...`. `make doctor` enforces
+  gh >= 2.94.0; if `--type` is unrecognized, run `make bootstrap-dev-host` to upgrade.
 - **Labels**: apply the appropriate `component:*` label (`component:intentd`,
   `component:fe`, `component:ios`) plus `agent-filed`.
 - **Aggressive dedup**: search existing issues first

--- a/scripts/bootstrap-dev-host.sh
+++ b/scripts/bootstrap-dev-host.sh
@@ -139,7 +139,7 @@ gh_version() {
   command -v gh >/dev/null 2>&1 || return 1
   local line
   line=$(gh --version 2>/dev/null | head -n 1)
-  [[ "$line" =~ ^gh\ version\ ([0-9]+\.[0-9]+\.[0-9]+) ]] || return 1
+  [[ "$line" =~ ^gh\ version\ ([0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?) ]] || return 1
   printf '%s\n' "${BASH_REMATCH[1]}"
 }
 
@@ -157,9 +157,12 @@ version_ge() {
 }
 
 gh_ready() {
-  local version
+  local version base
   version=$(gh_version) || return 1
-  version_ge "$version" "$GH_MIN_VERSION"
+  base=${version%%-*}
+  version_ge "$base" "$GH_MIN_VERSION" || return 1
+  # A prerelease sorts below its stable release: 2.94.0-rc.1 is still short of 2.94.0.
+  [[ "$version" == "$base" || "$base" != "$GH_MIN_VERSION" ]]
 }
 
 installable_gap_exists() {
@@ -482,7 +485,11 @@ install_gh() {
         TEMP_FILE=$(mktemp "${TMPDIR:-/tmp}/gh-cli.repo.XXXXXX") || exit 1
         curl -fsSL https://cli.github.com/packages/rpm/gh-cli.repo -o "$TEMP_FILE" || exit 1
         as_root install -D -m 0644 "$TEMP_FILE" /etc/yum.repos.d/gh-cli.repo || exit 1
-        as_root dnf install -y gh --repo gh-cli || exit 1
+        if rpm -q gh >/dev/null 2>&1; then
+          as_root dnf update -y gh --repo gh-cli || exit 1
+        else
+          as_root dnf install -y gh --repo gh-cli || exit 1
+        fi
       else
         echo "ERROR: unsupported Linux package manager; install gh >= $GH_MIN_VERSION from $GH_INSTALL_URL and re-run" >&2
         exit 1

--- a/scripts/bootstrap-dev-host.sh
+++ b/scripts/bootstrap-dev-host.sh
@@ -465,7 +465,8 @@ install_gh() {
   case "$(uname -s)" in
     Darwin)
       command -v brew >/dev/null 2>&1 || { echo "ERROR: Homebrew is required to install the GitHub CLI on macOS; see $GH_INSTALL_URL" >&2; exit 1; }
-      if command -v gh >/dev/null 2>&1; then
+      # A gh on PATH may come from Nix, MacPorts, or a manual install; only the formula can be upgraded.
+      if brew list --versions gh >/dev/null 2>&1; then
         brew upgrade gh || exit 1
       else
         brew install gh || exit 1
@@ -496,11 +497,18 @@ install_gh() {
       fi
       rm -f -- "$TEMP_FILE"
       TEMP_FILE=""
-      hash -r
       ;;
     *) echo "ERROR: only Linux and macOS are supported; install gh >= $GH_MIN_VERSION from $GH_INSTALL_URL" >&2; exit 1 ;;
   esac
-  gh_ready || { echo "ERROR: gh $(gh_version || echo unknown) is still below $GH_MIN_VERSION after install; see $GH_INSTALL_URL" >&2; exit 1; }
+  hash -r
+  gh_ready && return
+
+  local gh_path gh_found
+  gh_path=$(command -v gh || echo "no gh on PATH")
+  gh_found=$(gh_version || echo unknown)
+  echo "ERROR: gh $gh_found ($gh_path) is still below $GH_MIN_VERSION after install." >&2
+  echo "       A gh not installed by the package manager sits earlier on PATH and shadows the new one; remove it or move the package-manager gh ahead of it on PATH, then re-run. See $GH_INSTALL_URL" >&2
+  exit 1
 }
 
 install_frontend() {

--- a/scripts/bootstrap-dev-host.sh
+++ b/scripts/bootstrap-dev-host.sh
@@ -12,6 +12,11 @@ CARGO_HOME=${CARGO_HOME:-"$HOME/.cargo"}
 PATH="$CARGO_HOME/bin:$PATH"
 export CARGO_HOME PATH
 
+# Minimum GitHub CLI: `gh issue create --type` and a `gh pr edit` that survives
+# the projectCards API deprecation both need this release or newer.
+GH_MIN_VERSION="2.94.0"
+GH_INSTALL_URL="https://github.com/cli/cli#installation"
+
 MODE=install
 ASSUME_YES=${BOOTSTRAP_YES:-0}
 FAILURES=0
@@ -130,6 +135,33 @@ openssl_dev_ready() {
   command -v pkg-config >/dev/null 2>&1 && pkg-config --exists openssl
 }
 
+gh_version() {
+  command -v gh >/dev/null 2>&1 || return 1
+  local line
+  line=$(gh --version 2>/dev/null | head -n 1)
+  [[ "$line" =~ ^gh\ version\ ([0-9]+\.[0-9]+\.[0-9]+) ]] || return 1
+  printf '%s\n' "${BASH_REMATCH[1]}"
+}
+
+version_ge() {
+  local IFS=.
+  local -a have want
+  read -r -a have <<<"$1"
+  read -r -a want <<<"$2"
+  local i
+  for i in 0 1 2; do
+    if (( 10#${have[i]:-0} > 10#${want[i]:-0} )); then return 0; fi
+    if (( 10#${have[i]:-0} < 10#${want[i]:-0} )); then return 1; fi
+  done
+  return 0
+}
+
+gh_ready() {
+  local version
+  version=$(gh_version) || return 1
+  version_ge "$version" "$GH_MIN_VERSION"
+}
+
 installable_gap_exists() {
   required_submodules_ready || return 0
   load_versions
@@ -144,6 +176,7 @@ installable_gap_exists() {
   command -v corepack >/dev/null 2>&1 || return 0
   pnpm_ready || return 0
   [[ -d "$FE_DIR/node_modules" ]] || return 0
+  gh_ready || return 0
   return 1
 }
 
@@ -235,14 +268,20 @@ check_all() {
     missing "frontend dependencies: run corepack pnpm install --frozen-lockfile"
   fi
 
-  if command -v gh >/dev/null 2>&1; then
-    if gh auth status >/dev/null 2>&1; then
-      ok "GitHub CLI: present and authenticated"
-    else
-      optional "GitHub CLI: present but not authenticated; PR reporting is disabled until gh auth login"
-    fi
+  local gh_found
+  if ! command -v gh >/dev/null 2>&1; then
+    missing "GitHub CLI: gh >= $GH_MIN_VERSION is required (gh pr edit, gh issue create --type); run make bootstrap-dev-host"
+  elif ! gh_ready; then
+    gh_found=$(gh_version || echo unknown)
+    missing "GitHub CLI: gh $gh_found is below the required $GH_MIN_VERSION; run make bootstrap-dev-host (apt via https://cli.github.com/packages, dnf via gh-cli repo, or brew upgrade gh)"
   else
-    optional "GitHub CLI: not installed (PR reporting only; bootstrap does not install it)"
+    gh_found=$(gh_version)
+    if gh auth status >/dev/null 2>&1; then
+      ok "GitHub CLI: gh $gh_found (>= $GH_MIN_VERSION), authenticated"
+    else
+      ok "GitHub CLI: gh $gh_found (>= $GH_MIN_VERSION)"
+      optional "GitHub CLI: not authenticated; PR reporting is disabled until gh auth login"
+    fi
   fi
 
   if command -v sccache >/dev/null 2>&1; then
@@ -413,6 +452,50 @@ install_node() {
   esac
 }
 
+install_gh() {
+  if gh_ready; then
+    echo "[skip] GitHub CLI $(gh_version) satisfies >= $GH_MIN_VERSION"
+    return
+  fi
+
+  echo "[install] GitHub CLI >= $GH_MIN_VERSION"
+  case "$(uname -s)" in
+    Darwin)
+      command -v brew >/dev/null 2>&1 || { echo "ERROR: Homebrew is required to install the GitHub CLI on macOS; see $GH_INSTALL_URL" >&2; exit 1; }
+      if command -v gh >/dev/null 2>&1; then
+        brew upgrade gh || exit 1
+      else
+        brew install gh || exit 1
+      fi
+      ;;
+    Linux)
+      command -v curl >/dev/null 2>&1 || { echo "ERROR: curl is required to install the GitHub CLI" >&2; exit 1; }
+      if command -v apt-get >/dev/null 2>&1; then
+        TEMP_FILE=$(mktemp "${TMPDIR:-/tmp}/githubcli-archive-keyring.XXXXXX") || exit 1
+        curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg -o "$TEMP_FILE" || exit 1
+        as_root install -D -m 0644 "$TEMP_FILE" /usr/share/keyrings/githubcli-archive-keyring.gpg || exit 1
+        printf 'deb [arch=%s signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main\n' \
+          "$(dpkg --print-architecture)" | as_root tee /etc/apt/sources.list.d/github-cli.list >/dev/null || exit 1
+        as_root apt-get update || exit 1
+        as_root apt-get install -y gh || exit 1
+      elif command -v dnf >/dev/null 2>&1; then
+        TEMP_FILE=$(mktemp "${TMPDIR:-/tmp}/gh-cli.repo.XXXXXX") || exit 1
+        curl -fsSL https://cli.github.com/packages/rpm/gh-cli.repo -o "$TEMP_FILE" || exit 1
+        as_root install -D -m 0644 "$TEMP_FILE" /etc/yum.repos.d/gh-cli.repo || exit 1
+        as_root dnf install -y gh --repo gh-cli || exit 1
+      else
+        echo "ERROR: unsupported Linux package manager; install gh >= $GH_MIN_VERSION from $GH_INSTALL_URL and re-run" >&2
+        exit 1
+      fi
+      rm -f -- "$TEMP_FILE"
+      TEMP_FILE=""
+      hash -r
+      ;;
+    *) echo "ERROR: only Linux and macOS are supported; install gh >= $GH_MIN_VERSION from $GH_INSTALL_URL" >&2; exit 1 ;;
+  esac
+  gh_ready || { echo "ERROR: gh $(gh_version || echo unknown) is still below $GH_MIN_VERSION after install; see $GH_INSTALL_URL" >&2; exit 1; }
+}
+
 install_frontend() {
   if ! command -v corepack >/dev/null 2>&1; then
     command -v npm >/dev/null 2>&1 || { echo "ERROR: npm is required to install Corepack" >&2; exit 1; }
@@ -471,6 +554,7 @@ install_native_build_dependencies
 install_rust
 install_node
 install_frontend
+install_gh
 
 echo
 check_all

--- a/scripts/dev-sandbox.test.sh
+++ b/scripts/dev-sandbox.test.sh
@@ -500,4 +500,28 @@ grep -q '^\[ok\]       GitHub CLI: gh 2\.100\.0 (>= 2\.94\.0), authenticated' "$
 ! grep -q '^\[missing\]  GitHub CLI' "$temp_dir/bootstrap-check-gh-ok.out" \
   || fail "gh 2.100.0 was reported as a missing gap"
 
+write_gh_stub 2.94.0 0
+set +e
+COREPACK_HOME="$corepack_cache" PATH="$bootstrap_bin:$PATH" \
+  bash "$bootstrap_root/scripts/bootstrap-dev-host.sh" --check >"$temp_dir/bootstrap-check-gh-min.out" 2>&1
+set -e
+grep -q '^\[ok\]       GitHub CLI: gh 2\.94\.0 (>= 2\.94\.0), authenticated' "$temp_dir/bootstrap-check-gh-min.out" \
+  || fail "gh 2.94.0 (exact minimum) was not accepted as satisfying >= 2.94.0"
+
+write_gh_stub 2.94.0-rc.1 0
+set +e
+COREPACK_HOME="$corepack_cache" PATH="$bootstrap_bin:$PATH" \
+  bash "$bootstrap_root/scripts/bootstrap-dev-host.sh" --check >"$temp_dir/bootstrap-check-gh-rc.out" 2>&1
+set -e
+grep -q '^\[missing\]  GitHub CLI: gh 2\.94\.0-rc\.1 is below the required 2\.94\.0' "$temp_dir/bootstrap-check-gh-rc.out" \
+  || fail "prerelease gh 2.94.0-rc.1 was not reported as a missing gap below 2.94.0"
+
+write_gh_stub 2.95.0-rc.1 0
+set +e
+COREPACK_HOME="$corepack_cache" PATH="$bootstrap_bin:$PATH" \
+  bash "$bootstrap_root/scripts/bootstrap-dev-host.sh" --check >"$temp_dir/bootstrap-check-gh-next-rc.out" 2>&1
+set -e
+grep -q '^\[ok\]       GitHub CLI: gh 2\.95\.0-rc\.1 (>= 2\.94\.0), authenticated' "$temp_dir/bootstrap-check-gh-next-rc.out" \
+  || fail "prerelease gh 2.95.0-rc.1 of a newer release was not accepted as satisfying >= 2.94.0"
+
 echo "dev-sandbox tests passed (daemon, cargo, and pnpm behavior stubbed)"

--- a/scripts/dev-sandbox.test.sh
+++ b/scripts/dev-sandbox.test.sh
@@ -524,4 +524,66 @@ set -e
 grep -q '^\[ok\]       GitHub CLI: gh 2\.95\.0-rc\.1 (>= 2\.94\.0), authenticated' "$temp_dir/bootstrap-check-gh-next-rc.out" \
   || fail "prerelease gh 2.95.0-rc.1 of a newer release was not accepted as satisfying >= 2.94.0"
 
+# install_gh on macOS: exercise the function alone with a stubbed uname/brew/gh.
+bootstrap_funcs="$temp_dir/bootstrap-funcs.sh"
+sed '/^if \[\[ "\$MODE" == check \]\]; then$/,$d' "$bootstrap_root/scripts/bootstrap-dev-host.sh" >"$bootstrap_funcs"
+grep -q '^install_gh() {' "$bootstrap_funcs" || fail "could not extract bootstrap functions for the install_gh fixture"
+! grep -q '^install_gh$' "$bootstrap_funcs" || fail "bootstrap function extraction kept the main install flow"
+brew_bin="$temp_dir/brew-bin"
+mkdir -p "$brew_bin"
+printf '#!/usr/bin/env bash\nprintf "Darwin\\n"\n' >"$brew_bin/uname"
+cat >"$brew_bin/brew" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"$BREW_LOG"
+case "$*" in
+  "list --versions gh") [[ "$BREW_OWNS_GH" == 1 ]] ;;
+  "install gh"|"upgrade gh") [[ -n "${BREW_GH_RESULT:-}" ]] && "$BREW_WRITE_GH_STUB" "$BREW_GH_RESULT" 0; exit 0 ;;
+  *) exit 2 ;;
+esac
+SH
+cat >"$brew_bin/write-gh-stub" <<SH
+#!/usr/bin/env bash
+bootstrap_bin="$bootstrap_bin"
+$(declare -f write_gh_stub)
+write_gh_stub "\$@"
+SH
+chmod +x "$brew_bin/uname" "$brew_bin/brew" "$brew_bin/write-gh-stub"
+run_install_gh() {
+  BREW_LOG="$temp_dir/brew.log" BREW_OWNS_GH="$1" BREW_GH_RESULT="${2:-}" BREW_WRITE_GH_STUB="$brew_bin/write-gh-stub" \
+    PATH="$brew_bin:$bootstrap_bin:$PATH" \
+    bash -c 'funcs=$1; set --; source "$funcs"; install_gh' bash "$bootstrap_funcs" >"$temp_dir/install-gh.out" 2>&1
+}
+
+write_gh_stub 2.45.0 0
+: >"$temp_dir/brew.log"
+set +e
+run_install_gh 0 2.100.0
+status=$?
+set -e
+[[ "$status" -eq 0 ]] || fail "install_gh failed ($status) when brew install produced a current gh: $(cat "$temp_dir/install-gh.out")"
+grep -qx 'install gh' "$temp_dir/brew.log" || fail "a gh not owned by Homebrew did not trigger brew install gh"
+! grep -qx 'upgrade gh' "$temp_dir/brew.log" || fail "brew upgrade gh ran for a gh the gh formula does not own"
+
+write_gh_stub 2.45.0 0
+: >"$temp_dir/brew.log"
+set +e
+run_install_gh 1 2.100.0
+status=$?
+set -e
+[[ "$status" -eq 0 ]] || fail "install_gh failed ($status) when brew upgrade produced a current gh: $(cat "$temp_dir/install-gh.out")"
+grep -qx 'upgrade gh' "$temp_dir/brew.log" || fail "a Homebrew-owned gh did not trigger brew upgrade gh"
+! grep -qx 'install gh' "$temp_dir/brew.log" || fail "brew install gh ran for a gh the gh formula already owns"
+
+write_gh_stub 2.45.0 0
+: >"$temp_dir/brew.log"
+set +e
+run_install_gh 0
+status=$?
+set -e
+[[ "$status" -eq 1 ]] || fail "install_gh returned $status instead of 1 when a stale gh kept shadowing the installed one"
+grep -q "^ERROR: gh 2\.45\.0 ($bootstrap_bin/gh) is still below 2\.94\.0 after install\." "$temp_dir/install-gh.out" \
+  || fail "shadowed gh error did not name the stale binary and version: $(cat "$temp_dir/install-gh.out")"
+grep -q 'shadows the new one.*https://github.com/cli/cli#installation' "$temp_dir/install-gh.out" \
+  || fail "shadowed gh error did not explain PATH shadowing with the install URL"
+
 echo "dev-sandbox tests passed (daemon, cargo, and pnpm behavior stubbed)"

--- a/scripts/dev-sandbox.test.sh
+++ b/scripts/dev-sandbox.test.sh
@@ -466,6 +466,18 @@ mkdir -p "$COREPACK_HOME/v1/pnpm/10.30.3"
 touch "$COREPACK_HOME/v1/pnpm/10.30.3/downloaded"
 printf '10.30.3\n'
 SH
+write_gh_stub() {
+  cat >"$bootstrap_bin/gh" <<SH
+#!/usr/bin/env bash
+case "\$1 \${2:-}" in
+  "--version ") printf 'gh version $1 (2025-01-01)\nhttps://github.com/cli/cli/releases/tag/v$1\n' ;;
+  "auth status") exit $2 ;;
+  *) exit 2 ;;
+esac
+SH
+  chmod +x "$bootstrap_bin/gh"
+}
+write_gh_stub 2.45.0 1
 chmod +x "$bootstrap_bin/corepack" "$bootstrap_bin/pnpm"
 set +e
 COREPACK_HOME="$corepack_cache" PATH="$bootstrap_bin:$PATH" \
@@ -475,5 +487,17 @@ set -e
 [[ "$status" -eq 1 ]] || fail "fixture doctor returned $status instead of reporting its expected gaps"
 [[ -z $(find "$corepack_cache" -mindepth 1 -print -quit) ]] \
   || fail "check-only pnpm probe invoked the Corepack shim and populated its cache"
+grep -q '^\[missing\]  GitHub CLI: gh 2\.45\.0 is below the required 2\.94\.0' "$temp_dir/bootstrap-check.out" \
+  || fail "outdated gh 2.45.0 was not reported as a missing gap naming 2.94.0"
+
+write_gh_stub 2.100.0 0
+set +e
+COREPACK_HOME="$corepack_cache" PATH="$bootstrap_bin:$PATH" \
+  bash "$bootstrap_root/scripts/bootstrap-dev-host.sh" --check >"$temp_dir/bootstrap-check-gh-ok.out" 2>&1
+set -e
+grep -q '^\[ok\]       GitHub CLI: gh 2\.100\.0 (>= 2\.94\.0), authenticated' "$temp_dir/bootstrap-check-gh-ok.out" \
+  || fail "gh 2.100.0 was not accepted as satisfying >= 2.94.0"
+! grep -q '^\[missing\]  GitHub CLI' "$temp_dir/bootstrap-check-gh-ok.out" \
+  || fail "gh 2.100.0 was reported as a missing gap"
 
 echo "dev-sandbox tests passed (daemon, cargo, and pnpm behavior stubbed)"


### PR DESCRIPTION
## Summary

make doctor only checked that gh exists and is authenticated, so agents on hosts with an outdated GitHub CLI (this dev host runs gh 2.45.0) hit deprecated-API failures mid-workflow: gh pr edit fails on the removed projectCards field, and gh issue create --type is unrecognized (needs gh >= 2.94.0, which AGENTS.md already cited with a GraphQL workaround).

## Changes

- scripts/bootstrap-dev-host.sh: add GH_MIN_VERSION=2.94.0 with a numeric per-component version compare. The GitHub CLI is now a required prerequisite: absent or below-minimum gh is reported as a [missing] gap naming the installed version, the minimum, and the upgrade path, so make doctor exits non-zero and STATUS_JSON=1 make status reports host.doctorOk false. Authentication remains an [optional] note. installable_gap_exists covers the gh gap, and a new install_gh step installs/upgrades gh from the official GitHub CLI apt repository (keyring under /usr/share/keyrings), the official dnf gh-cli repo, or brew; other platforms get an actionable error.
- scripts/dev-sandbox.test.sh: the existing doctor fixture now stubs gh at 2.45.0 (asserts the [missing] line names 2.94.0) and at 2.100.0 with auth (asserts [ok], no [missing] gh line), which also guards against lexical version comparison.
- AGENTS.md Filing Issues: the GraphQL --type fallback paragraph and fenced block are replaced by a one-line pointer at make doctor / make bootstrap-dev-host (+2/-13).

## Verification

- bash scripts/dev-sandbox.test.sh, dev-status.test.sh, dev-ports.test.sh, docs-check.test.sh; node scripts/check-doc-links.mjs, check-root-hygiene.mjs — all pass.
- On this host (gh 2.45.0): make doctor prints the [missing] GitHub CLI line with minimum 2.94.0 and upgrade command; STATUS_JSON=1 make status shows host.doctorOk false with the gh gap.
- Independent verifier exercised absent, 2.9.0, 2.45.0, 2.93.9, 2.94.0, 2.94.1, 2.100.0, 3.0.0 and malformed gh versions against the check.
- Not executed: BOOTSTRAP_YES=1 make bootstrap-dev-host (requires sudo on the shared host; the install branch was statically reviewed). shellcheck is not installed on the host.

Monorepo-only change; no release monitoring needed.