### PR TITLE
fix: make scripts/shipped-in.sh run on stock macOS Bash 3.2

### DIFF
--- a/scripts/shipped-in.sh
+++ b/scripts/shipped-in.sh
@@ -65,18 +65,31 @@ compare_status() {
   printf '%s\n' "$status"
 }
 
-declare -A manifest_versions=()
+# Stock macOS ships Bash 3.2, which has no associative arrays: caches are
+# newline-separated "<key> <value>" records in plain strings.
+cache_get() {
+  local record
+  while IFS= read -r record; do
+    if [[ "${record%% *}" == "$2" ]]; then
+      printf '%s\n' "${record#* }"
+      return 0
+    fi
+  done <<<"$1"
+  return 1
+}
+
+manifest_versions=""
 manifest_version() {
   local tag=$1 version
-  if [[ -z "${manifest_versions[$tag]+x}" ]]; then
+  if ! version=$(cache_get "$manifest_versions" "$tag"); then
     version=$(gh release download "$tag" --repo "$releases_repo" \
       --pattern release-manifest.json --output - 2>/dev/null |
       python3 -c 'import json, sys; print(json.load(sys.stdin)["intentdVersion"])' 2>/dev/null) ||
       fail "could not read intentdVersion from release-manifest.json for $tag on $releases_repo"
     [[ -n "$version" ]] || fail "release-manifest.json for $tag has an empty intentdVersion"
-    manifest_versions[$tag]=$version
+    manifest_versions+="$tag $version"$'\n'
   fi
-  printf '%s\n' "${manifest_versions[$tag]}"
+  printf '%s\n' "$version"
 }
 
 carries() {
@@ -93,18 +106,21 @@ release_list=$(
   gh release list --repo "$releases_repo" --limit "$((limit + 10))" --exclude-drafts \
     --json tagName --jq '.[].tagName' 2>/dev/null
 ) || fail "gh release list on $releases_repo failed"
-mapfile -t tags < <(grep -E '^v[0-9]+\.[0-9]+\.[0-9]+' <<<"$release_list" | head -n "$limit" || true)
+tags=()
+while IFS= read -r tag; do
+  tags+=("$tag")
+done < <(grep -E '^v[0-9]+\.[0-9]+\.[0-9]+' <<<"$release_list" | head -n "$limit" || true)
 ((${#tags[@]} > 0)) || fail "gh release list on $releases_repo returned no vX.Y.Z tags"
 
-declare -A intentd_status=()
+intentd_status=""
 first_hit=""
 for tag in "${tags[@]}"; do
   if [[ "$component" == intentd ]]; then
     version=$(manifest_version "$tag")
-    if [[ -z "${intentd_status[$version]+x}" ]]; then
-      intentd_status[$version]=$(compare_status "v$version")
+    if ! status=$(cache_get "$intentd_status" "$version"); then
+      status=$(compare_status "v$version")
+      intentd_status+="$version $status"$'\n'
     fi
-    status=${intentd_status[$version]}
   else
     status=$(compare_status "$tag")
   fi

--- a/scripts/shipped-in.test.sh
+++ b/scripts/shipped-in.test.sh
@@ -190,11 +190,59 @@ echo "shipped-in tests passed under $("$script_bash" -c 'echo "bash $BASH_VERSIO
 # Stock macOS /bin/bash is 3.2 (intent-hq/intent#4706). `bash -n` alone
 # accepts Bash 4+ builtins and expansions, so reject them by pattern too,
 # then rerun the fixtures under a real Bash 3 when one can be found:
-# BASH3_BIN, a bash3 on PATH, Homebrew bash@3, or a 3.x /bin/bash.
+# BASH3_BIN, a bash3 on PATH, Homebrew bash@3, or a 3.x /bin/bash. The
+# pattern gate is a best-effort guard for hosts without a Bash 3; the real
+# Bash 3 fixture run is the authoritative check.
 bash -n "$script" || fail "shipped-in.sh does not parse"
 bash -n "${BASH_SOURCE[0]}" || fail "shipped-in.test.sh does not parse"
-bash4_constructs='(declare|local|typeset) +-[A-Za-z]*[An]|mapfile|readarray|\$\{[A-Za-z_][A-Za-z_0-9]*(\[[^]]*\])?(\^\^?|,,?)[^}]*\}|&>>|\|&|;;?&|coproc'
-gate_hits=$(grep -nE "$bash4_constructs" "$script" "${BASH_SOURCE[0]}" | grep -v -F 'bash4_constructs' || true)
+bash4_constructs='(^|[^A-Za-z0-9_])(declare|local|typeset)([[:blank:]]+-[A-Za-z]+)*[[:blank:]]+-[A-Za-z]*[An]([^A-Za-z]|$)|(^|[^A-Za-z0-9_])(mapfile|readarray|coproc)([^A-Za-z0-9_]|$)|\$\{([A-Za-z_][A-Za-z_0-9]*|[0-9]+|[@*#?!$-])(\[[^]]*\])?(\^\^?|,,?)[^}]*\}|&>>|\|&|;;?&'
+# Full-line comments, the pattern itself and the gate_sample table below are
+# not scanned.
+gate_matches() {
+  grep -nE "$bash4_constructs" "$@" | grep -vE '^([^:]*:)?[0-9]+:[[:blank:]]*#' |
+    grep -v -F -e 'bash4_constructs' -e 'gate_sample' || true
+}
+gate_sample() {
+  local expected=$1 sample=$2 hit
+  hit=$(printf '%s\n' "$sample" | gate_matches)
+  case "$expected:${hit:+hit}" in
+    hit:hit | miss:) ;;
+    *) fail "gate regex $expected sample misclassified: $sample" ;;
+  esac
+}
+gate_sample hit 'declare -A m=()'
+gate_sample hit 'local -gA x'
+gate_sample hit 'declare -r -A cache=()'
+gate_sample hit $'declare\t-A m'
+gate_sample hit 'typeset -n ref=x'
+gate_sample hit 'mapfile -t a'
+gate_sample hit 'readarray a <f'
+gate_sample hit 'coproc x'
+gate_sample hit 'echo ${var,,}'
+gate_sample hit 'echo ${var^^}'
+gate_sample hit 'echo ${var^}'
+gate_sample hit 'echo ${1^^}'
+gate_sample hit 'echo ${@,,}'
+gate_sample hit 'echo ${arr[1],,[a-z]}'
+gate_sample hit 'cmd &>> log'
+gate_sample hit 'cmd |& tee'
+gate_sample hit 'x) y ;;&'
+gate_sample hit 'x) y ;&'
+gate_sample miss 'local head=$1 status'
+gate_sample miss 'declare -a arr'
+gate_sample miss 'local -r x=1'
+gate_sample miss 'echo ${record%% *}'
+gate_sample miss 'echo ${1#--limit=}'
+gate_sample miss 'echo ${tags[0]}'
+gate_sample miss 'echo ${repo/\//__}'
+gate_sample miss 'a || b'
+gate_sample miss 'x) y ;;'
+gate_sample miss 'echo ${tag##*.}'
+gate_sample miss 'cmd 2>&1 >>log'
+gate_sample miss '# mapfile is unavailable on Bash 3'
+gate_sample miss 'readarray_count=0'
+gate_sample miss 'my_coproc=1'
+gate_hits=$(gate_matches "$script" "${BASH_SOURCE[0]}")
 [[ -z "$gate_hits" ]] || fail "Bash 4+ constructs found (stock macOS bash is 3.2):"$'\n'"$gate_hits"
 
 find_bash3() {

--- a/scripts/shipped-in.test.sh
+++ b/scripts/shipped-in.test.sh
@@ -195,7 +195,7 @@ echo "shipped-in tests passed under $("$script_bash" -c 'echo "bash $BASH_VERSIO
 # Bash 3 fixture run is the authoritative check.
 bash -n "$script" || fail "shipped-in.sh does not parse"
 bash -n "${BASH_SOURCE[0]}" || fail "shipped-in.test.sh does not parse"
-bash4_constructs='(^|[^A-Za-z0-9_])(declare|local|typeset)([[:blank:]]+-[A-Za-z]+)*[[:blank:]]+-[A-Za-z]*[An]([^A-Za-z]|$)|(^|[^A-Za-z0-9_])(mapfile|readarray|coproc)([^A-Za-z0-9_]|$)|\$\{([A-Za-z_][A-Za-z_0-9]*|[0-9]+|[@*#?!$-])(\[[^]]*\])?(\^\^?|,,?)[^}]*\}|&>>|\|&|;;?&'
+bash4_constructs='(^|[^A-Za-z0-9_])(declare|local|typeset)([[:blank:]]+-[A-Za-z]+)*[[:blank:]]+-[A-Za-z]*[An][A-Za-z]*([^A-Za-z]|$)|(^|[^A-Za-z0-9_])(mapfile|readarray|coproc)([^A-Za-z0-9_]|$)|\$\{([A-Za-z_][A-Za-z_0-9]*|[0-9]+|[@*#?!$-])(\[[^]]*\])?(\^\^?|,,?)[^}]*\}|&>>|\|&|;;?&'
 # Full-line comments, the pattern itself and the gate_sample table below are
 # not scanned.
 gate_matches() {
@@ -213,8 +213,13 @@ gate_sample() {
 gate_sample hit 'declare -A m=()'
 gate_sample hit 'local -gA x'
 gate_sample hit 'declare -r -A cache=()'
+gate_sample hit 'declare -Ar cache=()'
+gate_sample hit 'declare -Ax cache=()'
+gate_sample hit 'declare -r -Ax cache=()'
 gate_sample hit $'declare\t-A m'
 gate_sample hit 'typeset -n ref=x'
+gate_sample hit 'local -nr ref=x'
+gate_sample hit 'typeset -Anr ref=x'
 gate_sample hit 'mapfile -t a'
 gate_sample hit 'readarray a <f'
 gate_sample hit 'coproc x'

--- a/scripts/shipped-in.test.sh
+++ b/scripts/shipped-in.test.sh
@@ -4,6 +4,10 @@ set -euo pipefail
 
 repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)
 script="$repo_root/scripts/shipped-in.sh"
+# The interpreter that runs the script under test defaults to the one running
+# this suite; the Bash 3.2 compatibility pass at the end re-executes the suite
+# with it set to a real Bash 3.
+script_bash=${SHIPPED_IN_TEST_BASH:-$BASH}
 temp_dir=$(mktemp -d)
 bin_dir="$temp_dir/bin"
 stub_dir="$temp_dir/stub"
@@ -64,7 +68,7 @@ reset_stub() {
 run_script() {
   set +e
   PATH="$bin_dir" GH_STUB_DIR="$stub_dir" GH_TEST_LOG="$temp_dir/gh.log" \
-    bash "$script" "$@" >"$temp_dir/stdout" 2>"$temp_dir/stderr"
+    "$script_bash" "$script" "$@" >"$temp_dir/stdout" 2>"$temp_dir/stderr"
   status=$?
   set -e
   stdout=$(<"$temp_dir/stdout")
@@ -180,4 +184,38 @@ run_script cloudlands-fe "$sha" --limit 0
 [[ "$status" -eq 2 ]] || fail "--limit 0 exited $status (expected 2)"
 ! grep -q '^release list' "$temp_dir/gh.log" || fail "usage errors reached gh"
 
-echo "shipped-in tests passed"
+echo "shipped-in tests passed under $("$script_bash" -c 'echo "bash $BASH_VERSION"')"
+[[ -z "${SHIPPED_IN_TEST_BASH:-}" ]] || exit 0
+
+# Stock macOS /bin/bash is 3.2 (intent-hq/intent#4706). `bash -n` alone
+# accepts Bash 4+ builtins and expansions, so reject them by pattern too,
+# then rerun the fixtures under a real Bash 3 when one can be found:
+# BASH3_BIN, a bash3 on PATH, Homebrew bash@3, or a 3.x /bin/bash.
+bash -n "$script" || fail "shipped-in.sh does not parse"
+bash -n "${BASH_SOURCE[0]}" || fail "shipped-in.test.sh does not parse"
+bash4_constructs='(declare|local|typeset) +-[A-Za-z]*[An]|mapfile|readarray|\$\{[A-Za-z_][A-Za-z_0-9]*(\[[^]]*\])?(\^\^?|,,?)[^}]*\}|&>>|\|&|;;?&|coproc'
+gate_hits=$(grep -nE "$bash4_constructs" "$script" "${BASH_SOURCE[0]}" | grep -v -F 'bash4_constructs' || true)
+[[ -z "$gate_hits" ]] || fail "Bash 4+ constructs found (stock macOS bash is 3.2):"$'\n'"$gate_hits"
+
+find_bash3() {
+  local candidate resolved brew_prefix
+  brew_prefix=$(brew --prefix bash@3 2>/dev/null) || brew_prefix=""
+  for candidate in "${BASH3_BIN:-}" bash3 "${brew_prefix:+$brew_prefix/bin/bash}" \
+    /opt/homebrew/opt/bash@3/bin/bash /usr/local/opt/bash@3/bin/bash /bin/bash; do
+    [[ -n "$candidate" ]] || continue
+    resolved=$(command -v "$candidate" 2>/dev/null) || continue
+    [[ -x "$resolved" ]] || continue
+    "$resolved" -c '[[ "${BASH_VERSINFO[0]}" -eq 3 ]]' 2>/dev/null || continue
+    printf '%s\n' "$resolved"
+    return 0
+  done
+  return 1
+}
+
+if [[ "${BASH_VERSINFO[0]}" -eq 3 ]]; then
+  : # the fixtures above already ran under Bash 3
+elif bash3=$(find_bash3); then
+  SHIPPED_IN_TEST_BASH="$bash3" "$bash3" "${BASH_SOURCE[0]}"
+else
+  echo "shipped-in tests: no Bash 3 interpreter found (set BASH3_BIN); real 3.2 run skipped, static gate only"
+fi


### PR DESCRIPTION
Fixes intent-hq/intent#4706

## Problem

`scripts/shipped-in.sh` used `declare -A` and `mapfile`, so on stock macOS `/bin/bash` 3.2.57 it exited 2 at line 68 (`declare: -A: invalid option`) and agents on Mac could not run the documented shipped-in check. `bash -n` accepts the broken script, so a syntax check alone does not catch this.

## Change

**`scripts/shipped-in.sh`** — Bash 3.2-compatible, same `#!/usr/bin/env bash` entrypoint:
- The two associative-array caches (manifest `intentdVersion` per tag, compare status per pinned intentd version) become newline-separated `<key> <value>` string records with a small `cache_get` helper.
- `mapfile -t tags < <(...)` becomes a `while read` loop into an indexed array.
- Tag scan, containment semantics (`ahead`/`identical` carry; `behind`/`diverged` never), manifest handling and exit codes (0 hit / 3 no-hit / 2 usage / 1 gh failure) are unchanged.

**`scripts/shipped-in.test.sh`** — Bash 3.2 compatibility pass appended after the existing fixtures:
- The interpreter running the script under test defaults to the one running the suite (`$BASH`), so `/bin/bash scripts/shipped-in.test.sh` on macOS exercises 3.2 directly.
- Static gate on both files: `bash -n` plus a grep rejecting Bash 4+ constructs (associative-array declarations, `mapfile`/`readarray`, case-modification expansions, `&>>`, `|&`, case fall-through, `coproc`, namerefs).
- When a Bash 3 interpreter is found — `BASH3_BIN`, `bash3` on PATH, Homebrew `bash@3`, or a 3.x `/bin/bash` — the whole fixture suite is re-executed under it; otherwise it prints that the real 3.2 run was skipped (this is what CI on ubuntu does).

## Verification

Bash 3.2.57 was built from the GNU tarball locally to run the suite for real:

| Run | Result |
|---|---|
| `bash scripts/shipped-in.test.sh` (no Bash 3 present) | passes under 5.2; prints "real 3.2 run skipped, static gate only" |
| `BASH3_BIN=<bash-3.2.57> bash scripts/shipped-in.test.sh` | passes under 5.2, then all fixtures pass again under 3.2.57(4)-release |
| `<bash-3.2.57> scripts/shipped-in.test.sh` | all fixtures pass under 3.2.57 as the top-level interpreter |
| new test against `origin/main`'s script | fails: gate reports lines 68, 96, 99 (`declare -A`, `mapfile`, `declare -A`) |
| gate regex sample check | 14/14 positive samples match; 0/10 legitimate expansions (`${x%% *}`, `${1#--limit=}`, `${a[0]}`, `${r/\//__}`, `;;`, `2>&1 >>log`, …) match |

Not covered: a Docker-based Bash 3 runner. The fixtures symlink host `bash`/`python3`/`grep` into a stub `PATH`, so a container cannot execute them as-is; `BASH3_BIN` accepts any native Bash 3 executable instead.
