### PR TITLE
fix(gate): hide the nextest progress bar in scripted runs and document the hook dispatch bound

### DIFF
--- a/docs/protocol/methods/hooks.md
+++ b/docs/protocol/methods/hooks.md
@@ -100,7 +100,12 @@ state**: it is injected into the next run as the `hookState` global (`null` when
 an omitted `state` keeps the previous value, `state: null` clears it, and a value whose
 JSON serialization exceeds ~16 KiB is dropped (the previous state is kept and a warning
 line is appended to that run's `lastLogs`). The schedule-time validation run persists
-its returned state too. `hook:*` event payloads (§6.5) stay light
+its returned state too. The dispatch `message` a run returns — and the error text an
+eviction wake carries — is bounded at 32 Ki chars before the wake is framed and queued:
+longer text keeps its head and gains a trailing `[hook message truncated: …]` marker, so
+a hook wake is always bounded in size (the cap bounds the wake itself; it does not
+guarantee the provider has context room for it; `lastError` itself is persisted
+verbatim). `hook:*` event payloads (§6.5) stay light
 and do **not** carry `lastLogs` or `lastState` (they do carry `perpetual`/`dispatchCount`);
 clients read the heavy fields via `hook.list`.
 

--- a/scripts/resumable_nextest.py
+++ b/scripts/resumable_nextest.py
@@ -178,6 +178,15 @@ def write_tool_config(
     temporary.replace(path)
 
 
+def nextest_env() -> dict[str, str]:
+    env = os.environ.copy()
+    env["NEXTEST_EXPERIMENTAL_LIBTEST_JSON"] = "1"
+    # nextest draws its progress bar on stderr whenever stderr is a TTY; under a
+    # PTY-backed script runner that fills the captured output with redraws.
+    env.setdefault("NEXTEST_HIDE_PROGRESS_BAR", "1")
+    return env
+
+
 def run_nextest(args: argparse.Namespace) -> int:
     repo_root = Path(args.repo_root).resolve()
     intentd_dir = (repo_root / args.intentd_dir).resolve()
@@ -195,8 +204,7 @@ def run_nextest(args: argparse.Namespace) -> int:
         print(f"resumed: skipped {len(resumed)} tests already passed for this tree", flush=True)
         return 0
 
-    env = os.environ.copy()
-    env["NEXTEST_EXPERIMENTAL_LIBTEST_JSON"] = "1"
+    env = nextest_env()
     list_output = run(
         [
             "cargo", "nextest", "list", "--workspace",

--- a/scripts/test_resumable_nextest.py
+++ b/scripts/test_resumable_nextest.py
@@ -121,6 +121,15 @@ class ResumableNextestTests(unittest.TestCase):
                 {name: value for name, value in values.items() if name != "UNRELATED"},
             )
 
+    def test_nextest_env_hides_progress_bar_unless_caller_overrides(self):
+        with mock.patch.dict(os.environ, {"PATH": "/bin"}, clear=True):
+            env = gate.nextest_env()
+            self.assertEqual(env["NEXTEST_HIDE_PROGRESS_BAR"], "1")
+            self.assertEqual(env["NEXTEST_EXPERIMENTAL_LIBTEST_JSON"], "1")
+            self.assertEqual(env["PATH"], "/bin")
+        with mock.patch.dict(os.environ, {"NEXTEST_HIDE_PROGRESS_BAR": "0"}, clear=True):
+            self.assertEqual(gate.nextest_env()["NEXTEST_HIDE_PROGRESS_BAR"], "0")
+
     def test_prune_removes_only_old_key_directories(self):
         with tempfile.TemporaryDirectory() as temporary:
             cache = Path(temporary)


### PR DESCRIPTION
Monorepo half of the fix for intent-hq/intent#4703 (oversized hook dispatch messages wedging the owning agent). The daemon-side fix is intent-hq/intentd#1792.

- **docs(protocol)**: document the 32 Ki char bound on hook dispatch/eviction messages, the truncation marker, and that `lastError` stays verbatim (`docs/protocol/methods/hooks.md`).
- **fix(gate)**: `scripts/resumable_nextest.py` sets `NEXTEST_HIDE_PROGRESS_BAR=1` for the nextest child (via `setdefault`, so a caller override is respected). Scripted `make test` runs previously captured thousands of progress-bar redraws (verified under a PTY: 0 redraws / ~9 KB by default vs 6094 redraws / ~822 KB with the bar on), which is one of the ways an agent-run gate produced an oversized wake payload.

No submodule pin changes — pins are advanced by `auto-bump-submodules`.

Verification: `python3 scripts/test_resumable_nextest.py` (10/10); independent verifier PTY reproduction with `script -q -e` on a narrowed nextest filter, default and `NEXTEST_HIDE_PROGRESS_BAR=0`.