### PR TITLE
chore(make): hide nextest and cargo progress bars in gate targets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -254,9 +254,12 @@ with no rollback.
   live under `$HOME/.cache/intent/gate-runs`, expire after seven days, and include
   `junit.xml` plus an incremental passed-test stream. Set `GATE_FORCE=1` to ignore
   a matching record and run the complete suite.
-- Run long gates as saved command-mode `ws.script` entries via `ws.script.start` plus a
-  self-checking `ws.hook.schedule` polling `ws.script.status` (dispatch on exit), then
-  `ws.script.output`. `ws.script.run` rejects `timeoutSeconds` above budget − 5s (25s default).
+- Run long gates as saved command-mode `ws.script` entries (`ws.script.start`, a
+  self-checking `ws.hook.schedule` on `ws.script.status`, then `ws.script.output`);
+  `ws.script.run` rejects `timeoutSeconds` above budget − 5s (25s default). Saved scripts
+  are PTY-backed, so use the `make` targets — they set `NEXTEST_SHOW_PROGRESS=none` and
+  `CARGO_TERM_PROGRESS_WHEN=never`; a raw `cargo nextest run` / `cargo build` must pass
+  the same or its progress-bar redraws flood the output buffer.
 
 ## Release Process
 

--- a/Makefile
+++ b/Makefile
@@ -140,6 +140,17 @@ SWEEP_DAYS ?= 3
 TEST_THREADS ?= -2
 BUILD_JOBS ?= -2
 
+# Progress rendering for the Rust gate targets. Agents run these as saved
+# command-mode ws.script entries, which are PTY-backed, so nextest and cargo
+# see an interactive stderr and redraw their progress bars into the captured
+# buffer (one full-suite run produced ~530 KB of cursor-control sequences
+# and overflowed an agent's context). Default to line-oriented output; a
+# human at a terminal can restore the bars with
+# `make test NEXTEST_SHOW_PROGRESS=bar CARGO_TERM_PROGRESS_WHEN=auto`.
+# CI already sets CI=true, under which both tools are non-interactive anyway.
+gate test test-intentd coverage-e2e coverage-all: export NEXTEST_SHOW_PROGRESS ?= none
+gate check clippy build-intentd test test-intentd coverage-e2e coverage-all: export CARGO_TERM_PROGRESS_WHEN ?= never
+
 # Resumable local test runs are opt-in. Records are keyed by the complete
 # monorepo + intentd worktree state and kept outside the checkout.
 RESUME ?= 0
@@ -328,7 +339,9 @@ test: test-intentd ## Run Rust tests; after interruption use RESUME=1 (GATE_FORC
 # none, so nothing is lost.
 # Capped to $(TEST_THREADS) test threads / $(BUILD_JOBS) build jobs (CPUs-2
 # by default) so a local run leaves CPU headroom; override for full speed,
-# e.g. `make test TEST_THREADS=num-cpus BUILD_JOBS=default`.
+# e.g. `make test TEST_THREADS=num-cpus BUILD_JOBS=default`. Progress bars
+# are off by default (see NEXTEST_SHOW_PROGRESS / CARGO_TERM_PROGRESS_WHEN
+# above); `make test NEXTEST_SHOW_PROGRESS=bar` restores nextest's.
 test-intentd: ensure-intentd-submodule
 	@cargo nextest --version >/dev/null 2>&1 || { \
 		echo "[test-intentd] ERROR: cargo-nextest is not installed — run 'cargo install cargo-nextest --locked'"; \


### PR DESCRIPTION
## Why

Agents run the Rust gates as saved command-mode `ws.script` entries, which are PTY-backed. nextest and cargo therefore see an interactive stderr and redraw their progress bars into the captured buffer. One full `intent-acp` + `intent-services` run produced ~530 KB of `ESC[10A / ESC[2K / ESC[1B` cursor-control sequences around a few useful lines; the hook wake built from that buffer overflowed an agent's context (413) and cost a re-delegation.

`make test-intentd` already pipes nextest's stdout through `scripts/resumable_nextest.py`, so the noise is entirely on stderr (nextest progress bar + cargo build progress) — environment variables fix both without touching the Python wrapper.

## What

- `Makefile`: target-specific `export NEXTEST_SHOW_PROGRESS ?= none` on `gate test test-intentd coverage-e2e coverage-all` and `export CARGO_TERM_PROGRESS_WHEN ?= never` on those plus `check clippy build-intentd`. `?=` keeps env / command-line overrides working (`make test NEXTEST_SHOW_PROGRESS=bar` restores the bar for a human at a terminal). `NEXTEST_HIDE_PROGRESS_BAR` is deprecated on the pinned nextest 0.9.143, hence `NEXTEST_SHOW_PROGRESS`.
- `AGENTS.md` (Resuming local Rust gates): compress the saved-script bullet to name the PTY hazard and the two flags, pointing at the `make` targets.

CI already sets `CI=true`, under which both tools are non-interactive; CI output is unchanged.

Companion docs PR on intentd: intent-hq/intentd — "docs(agents): lead the Gates section with make targets and the PTY progress-bar caveat" (link in the PR conversation once opened).

## Verification

- `make -n gate test coverage-all check` parse; `make -p` shows the target-specific bindings; `make -n test-intentd NEXTEST_SHOW_PROGRESS=bar` reports the command-line value winning.
- `make test-intentd` as a PTY-backed saved script: cursor-sequence count in `ws.script.output` is 0 (evidence in the workspace spec).
- `make docs-check` passes.
