### PR TITLE
fix(dev-sandbox): survive repeated or late signals during cleanup and deflake the TERM tests

### DIFF
--- a/scripts/dev-sandbox.sh
+++ b/scripts/dev-sandbox.sh
@@ -362,9 +362,10 @@ elif [[ "$mode" == stop ]]; then
   exit $?
 fi
 
-# Fork-free so it cannot fail under host load: write_state_file emits compact
-# JSON, so "pid":$$, is a stable own-pid token. Every non-removal of an
-# existing file is reported so a leftover state file is never silent.
+# The own-pid ownership check uses only bash builtins (no python helper), so a
+# missing or failed helper can no longer leave the state in place; write_state_file
+# emits compact JSON, so "pid":$$, is a stable own-pid token. rm remains external,
+# and every non-removal of an existing file is reported so it is never silent.
 remove_state_file() {
   local state_line="" pid_token=""
   [[ -e "$state_file" ]] || return 0

--- a/scripts/dev-sandbox.sh
+++ b/scripts/dev-sandbox.sh
@@ -373,10 +373,10 @@ remove_state_file() {
 }
 
 cleanup() {
-  local pid
   # bash runs pending signal traps between commands even inside the EXIT trap,
   # so a repeated HUP/INT/TERM would otherwise longjmp out mid-cleanup.
   trap '' HUP INT TERM
+  local pid
   [[ "$cleaning" -eq 0 ]] || return
   cleaning=1
   remove_state_file

--- a/scripts/dev-sandbox.sh
+++ b/scripts/dev-sandbox.sh
@@ -362,25 +362,21 @@ elif [[ "$mode" == stop ]]; then
   exit $?
 fi
 
+# Fork-free so it cannot fail under host load: write_state_file emits compact
+# JSON, so "pid":$$, is a stable own-pid token.
 remove_state_file() {
-  python3 - "$state_file" "$$" <<'PY'
-import json
-import os
-import sys
-
-path, expected_pid = sys.argv[1], int(sys.argv[2])
-try:
-    with open(path, encoding="utf-8") as handle:
-        state = json.load(handle)
-    if int(state.get("pid", -1)) == expected_pid:
-        os.unlink(path)
-except (FileNotFoundError, ValueError, TypeError, json.JSONDecodeError):
-    pass
-PY
+  local state_line=""
+  [[ -e "$state_file" ]] || return 0
+  IFS= read -r state_line 2>/dev/null <"$state_file" || true
+  [[ "$state_line" == *"\"pid\":$$,"* ]] || return 0
+  rm -f -- "$state_file" || echo "[dev-sandbox-$mode] WARNING: could not remove sandbox state at $state_file" >&2
 }
 
 cleanup() {
   local pid
+  # bash runs pending signal traps between commands even inside the EXIT trap,
+  # so a repeated HUP/INT/TERM would otherwise longjmp out mid-cleanup.
+  trap '' HUP INT TERM
   [[ "$cleaning" -eq 0 ]] || return
   cleaning=1
   remove_state_file

--- a/scripts/dev-sandbox.sh
+++ b/scripts/dev-sandbox.sh
@@ -363,12 +363,23 @@ elif [[ "$mode" == stop ]]; then
 fi
 
 # Fork-free so it cannot fail under host load: write_state_file emits compact
-# JSON, so "pid":$$, is a stable own-pid token.
+# JSON, so "pid":$$, is a stable own-pid token. Every non-removal of an
+# existing file is reported so a leftover state file is never silent.
 remove_state_file() {
-  local state_line=""
+  local state_line="" pid_token=""
   [[ -e "$state_file" ]] || return 0
-  IFS= read -r state_line 2>/dev/null <"$state_file" || true
-  [[ "$state_line" == *"\"pid\":$$,"* ]] || return 0
+  if ! IFS= read -r state_line 2>/dev/null <"$state_file" && [[ -z "$state_line" ]]; then
+    echo "[dev-sandbox-$mode] WARNING: could not read sandbox state at $state_file; leaving it in place" >&2
+    return 0
+  fi
+  if [[ "$state_line" != *"\"pid\":$$,"* ]]; then
+    if [[ "$state_line" == *'"pid":'* ]]; then
+      pid_token=${state_line#*\"pid\":}
+      pid_token=${pid_token%%,*}
+    fi
+    echo "[dev-sandbox-$mode] WARNING: sandbox state at $state_file records pid ${pid_token:-(none)}, not this process ($$); leaving it in place" >&2
+    return 0
+  fi
   rm -f -- "$state_file" || echo "[dev-sandbox-$mode] WARNING: could not remove sandbox state at $state_file" >&2
 }
 
@@ -401,9 +412,19 @@ cleanup() {
   done
 }
 
+# bash checks pending signal traps before the first command of the EXIT trap
+# string, so a signal landing between a normal `exit` and cleanup starting
+# would skip cleanup entirely if the signal trap were a bare `exit`. The
+# signal traps therefore run cleanup themselves (idempotent via `cleaning`).
+on_signal() {
+  trap '' HUP INT TERM
+  cleanup
+  exit "$1"
+}
+
 trap cleanup EXIT
-trap 'exit 130' INT
-trap 'exit 143' HUP TERM
+trap 'on_signal 130' INT
+trap 'on_signal 143' HUP TERM
 
 socket_accepts() {
   [[ -S "$socket_path" ]] || return 1

--- a/scripts/dev-sandbox.test.sh
+++ b/scripts/dev-sandbox.test.sh
@@ -318,6 +318,8 @@ dump_supervised_residue() {
   cat "$state_dir/ui.json" >&2 2>/dev/null || echo "(absent)" >&2
   echo "processes in group $supervised_pgid:" >&2
   ps -eo pid,ppid,pgid,stat,command | awk -v pg="$supervised_pgid" 'NR == 1 || $3 == pg' >&2
+  echo "supervised recipe output:" >&2
+  cat "$temp_dir/supervised.out" >&2
 }
 for _ in {1..500}; do
   kill -0 "$state_pid" 2>/dev/null || break

--- a/scripts/dev-sandbox.test.sh
+++ b/scripts/dev-sandbox.test.sh
@@ -301,6 +301,7 @@ wait_for_ready "$temp_dir/supervised.out" || fail "supervised recipe sandbox did
 state_pid=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["pid"])' "$state_dir/ui.json")
 state_ppid=$(ps -o ppid= -p "$state_pid" | tr -d ' ')
 [[ "$state_ppid" == "$sandbox_pid" ]] || fail "recipe shell did not exec the sandbox script"
+supervised_pgid=$sandbox_pid
 kill -TERM -- "-$sandbox_pid"
 set +e
 wait "$sandbox_pid"
@@ -308,11 +309,32 @@ status=$?
 set -e
 sandbox_pid=""
 [[ "$status" -ne 0 ]] || fail "supervised recipe unexpectedly exited successfully after TERM"
-for _ in {1..50}; do
+# GNU make blocks on its local child when TERMed, so once wait returns the
+# script's EXIT trap has already run: the script must be gone and the state
+# file removed. The deadlines are generous so timing only matters when
+# cleanup is genuinely broken.
+dump_supervised_residue() {
+  echo "residual $state_dir/ui.json:" >&2
+  cat "$state_dir/ui.json" >&2 2>/dev/null || echo "(absent)" >&2
+  echo "processes in group $supervised_pgid:" >&2
+  ps -eo pid,ppid,pgid,stat,command | awk -v pg="$supervised_pgid" 'NR == 1 || $3 == pg' >&2
+}
+for _ in {1..500}; do
+  kill -0 "$state_pid" 2>/dev/null || break
+  sleep 0.02
+done
+if kill -0 "$state_pid" 2>/dev/null; then
+  dump_supervised_residue
+  fail "sandbox script pid $state_pid still alive 10s after the supervised recipe exited"
+fi
+for _ in {1..500}; do
   [[ ! -e "$state_dir/ui.json" ]] && break
   sleep 0.02
 done
-[[ ! -e "$state_dir/ui.json" ]] || fail "state remained after external TERM of the recipe process tree"
+if [[ -e "$state_dir/ui.json" ]]; then
+  dump_supervised_residue
+  fail "state remained after external TERM of the recipe process tree"
+fi
 python3 - "$port" <<'PY' || fail "supervised recipe listener remained after TERM"
 import socket
 import sys

--- a/scripts/dev-sandbox.test.sh
+++ b/scripts/dev-sandbox.test.sh
@@ -32,6 +32,19 @@ fail() {
   exit 1
 }
 
+# errexit exits silently on a plain command failure, leaving an empty log with
+# status 1. Name the command before that happens. The trap stays quiet inside
+# the deliberate `set +e … wait … set -e` windows, and bash already skips it in
+# the same conditional contexts (&&, ||, if, while, !) in which errexit is
+# suppressed, so helpers that return non-zero on purpose do not report.
+report_unexpected_failure() {
+  local status=$1 line=$2 command=$3 pipestatus=$4
+  [[ $- == *e* ]] || return 0
+  echo "dev-sandbox test: unexpected failure (status $status, pipestatus [$pipestatus]) at line $line: $command" >&2
+}
+set -o errtrace
+trap 'report_unexpected_failure "$?" "$LINENO" "$BASH_COMMAND" "${PIPESTATUS[*]}"' ERR
+
 free_port() {
   python3 - <<'PY'
 import socket
@@ -79,6 +92,31 @@ wait_for_ready() {
     kill -0 "$sandbox_pid" 2>/dev/null || return 1
     sleep 0.05
   done
+  return 1
+}
+
+# Print the pid of the fake frontend (`python3 - <port>`) running under the
+# sandbox script. A no-match pgrep exits 1, so a bare `$(pgrep -P … | head -1)`
+# assignment tripped errexit/pipefail on a transient miss before the caller's
+# `fail` guard could run; the lookup is retried for up to 2s instead, matching
+# the command line so a transient sibling child is never chosen, and fails only
+# after the deadline (or once the sandbox has died) with the child listing and
+# the sandbox output dumped.
+find_frontend_pid() {
+  local parent=$1 port=$2 output=$3 matches
+  for _ in {1..100}; do
+    matches=$(pgrep -P "$parent" -f "python3 - $port" 2>/dev/null || true)
+    if [[ -n "$matches" ]]; then
+      echo "${matches%%$'\n'*}"
+      return 0
+    fi
+    kill -0 "$parent" 2>/dev/null || break
+    sleep 0.02
+  done
+  echo "children of sandbox pid $parent (alive: $(kill -0 "$parent" 2>/dev/null && echo yes || echo no)):" >&2
+  ps -eo pid,ppid,stat,command | awk -v pp="$parent" 'NR == 1 || $2 == pp' >&2
+  echo "sandbox output:" >&2
+  cat "$output" >&2 || true
   return 1
 }
 
@@ -255,8 +293,8 @@ PATH="$temp_dir/bin:$PATH" FE_DIR="$temp_dir/fe" DEV_PORT="$port" FE_IGNORE_TERM
   bash "$script" ui >"$temp_dir/double-term.out" 2>&1 &
 sandbox_pid=$!
 wait_for_ready "$temp_dir/double-term.out" || fail "double-TERM sandbox did not become ready"
-frontend_pid=$(pgrep -P "$sandbox_pid" | head -1)
-[[ -n "$frontend_pid" ]] || fail "could not find double-TERM frontend child"
+frontend_pid=$(find_frontend_pid "$sandbox_pid" "$port" "$temp_dir/double-term.out") \
+  || fail "could not find double-TERM frontend child"
 kill -TERM "$sandbox_pid"
 for _ in {1..100}; do
   [[ ! -e "$state_dir/ui.json" ]] && break
@@ -301,8 +339,8 @@ for iteration in $(seq 1 20); do
     bash "$script" ui >"$temp_dir/signal-window.out" 2>&1 &
   sandbox_pid=$!
   wait_for_ready "$temp_dir/signal-window.out" || fail "signal-window sandbox did not become ready (iteration $iteration)"
-  frontend_pid=$(pgrep -P "$sandbox_pid" | head -1)
-  [[ -n "$frontend_pid" ]] || fail "could not find signal-window frontend child (iteration $iteration)"
+  frontend_pid=$(find_frontend_pid "$sandbox_pid" "$port" "$temp_dir/signal-window.out") \
+    || fail "could not find signal-window frontend child (iteration $iteration)"
   kill -TERM "$sandbox_pid"
   kill -TERM "$sandbox_pid" 2>/dev/null || true
   set +e
@@ -433,8 +471,8 @@ PATH="$temp_dir/bin:$PATH" FE_DIR="$temp_dir/fe" DEV_PORT="$port" SANDBOX_STATE_
   SANDBOX_READY_TIMEOUT=5 bash "$script" ui >"$temp_dir/child-failure.out" 2>&1 &
 sandbox_pid=$!
 wait_for_ready "$temp_dir/child-failure.out" || fail "child-failure sandbox did not become ready"
-frontend_pid=$(pgrep -P "$sandbox_pid" | head -1)
-[[ -n "$frontend_pid" ]] || fail "could not find frontend child"
+frontend_pid=$(find_frontend_pid "$sandbox_pid" "$port" "$temp_dir/child-failure.out") \
+  || fail "could not find frontend child"
 kill -KILL "$frontend_pid"
 set +e
 wait "$sandbox_pid"

--- a/scripts/dev-sandbox.test.sh
+++ b/scripts/dev-sandbox.test.sh
@@ -89,7 +89,10 @@ exec python3 - "$DEV_PORT" <<'PY'
 import http.server
 import json
 import os
+import signal
 import sys
+if os.environ.get("FE_IGNORE_TERM") == "1":
+    signal.signal(signal.SIGTERM, signal.SIG_IGN)
 class Handler(http.server.SimpleHTTPRequestHandler):
     def do_HEAD(self):
         self.send_response(200)
@@ -234,6 +237,49 @@ if SANDBOX_STATE_DIR="$state_dir" bash "$script" status >"$temp_dir/stopped-stat
   fail "sandbox status succeeded after stop"
 fi
 python3 - "$port" <<'PY' || fail "UI listener remained after sandbox-stop"
+import socket
+import sys
+s = socket.socket()
+s.settimeout(0.2)
+assert s.connect_ex(("127.0.0.1", int(sys.argv[1]))) != 0
+s.close()
+PY
+
+# Regression: a second TERM landing while cleanup waits on a TERM-ignoring
+# frontend must not abort cleanup; the KILL escalation still has to run. The
+# state file disappearing proves cleanup has started, and the frontend holds
+# it in its 50x0.1s wait loop, so 0.2s later the second TERM lands mid-loop.
+port=$(free_port)
+PATH="$temp_dir/bin:$PATH" FE_DIR="$temp_dir/fe" DEV_PORT="$port" FE_IGNORE_TERM=1 \
+  SANDBOX_STATE_DIR="$state_dir" SANDBOX_READY_TIMEOUT=5 \
+  bash "$script" ui >"$temp_dir/double-term.out" 2>&1 &
+sandbox_pid=$!
+wait_for_ready "$temp_dir/double-term.out" || fail "double-TERM sandbox did not become ready"
+frontend_pid=$(pgrep -P "$sandbox_pid" | head -1)
+[[ -n "$frontend_pid" ]] || fail "could not find double-TERM frontend child"
+kill -TERM "$sandbox_pid"
+for _ in {1..100}; do
+  [[ ! -e "$state_dir/ui.json" ]] && break
+  sleep 0.02
+done
+if [[ -e "$state_dir/ui.json" ]]; then
+  kill -KILL "$frontend_pid" 2>/dev/null || true
+  fail "double-TERM cleanup did not remove the state file within 2s"
+fi
+sleep 0.2
+kill -TERM "$sandbox_pid"
+set +e
+wait "$sandbox_pid"
+status=$?
+set -e
+sandbox_pid=""
+frontend_alive=0
+kill -0 "$frontend_pid" 2>/dev/null && frontend_alive=1
+kill -KILL "$frontend_pid" 2>/dev/null || true
+[[ "$status" -eq 143 ]] || fail "double TERM returned $status instead of 143"
+[[ "$frontend_alive" -eq 0 ]] || fail "second TERM during cleanup aborted the KILL escalation; frontend $frontend_pid survived"
+[[ ! -e "$state_dir/ui.json" ]] || fail "UI state file remained after double TERM"
+python3 - "$port" <<'PY' || fail "double-TERM listener remained after the sandbox exited"
 import socket
 import sys
 s = socket.socket()

--- a/scripts/dev-sandbox.test.sh
+++ b/scripts/dev-sandbox.test.sh
@@ -288,6 +288,42 @@ assert s.connect_ex(("127.0.0.1", int(sys.argv[1]))) != 0
 s.close()
 PY
 
+# Regression: bash checks pending signal traps before the first command of the
+# EXIT trap string, so a second TERM that is already pending when the first
+# TERM's `exit` starts the EXIT trap used to longjmp out before cleanup ran,
+# leaving the state file and the frontend behind (pre-fix ~65% of iterations).
+# The signal traps now run cleanup themselves. Two back-to-back TERMs to the
+# script pid hit that window; the loop makes a regression practically certain.
+for iteration in $(seq 1 20); do
+  port=$(free_port)
+  PATH="$temp_dir/bin:$PATH" FE_DIR="$temp_dir/fe" DEV_PORT="$port" \
+    SANDBOX_STATE_DIR="$state_dir" SANDBOX_READY_TIMEOUT=5 \
+    bash "$script" ui >"$temp_dir/signal-window.out" 2>&1 &
+  sandbox_pid=$!
+  wait_for_ready "$temp_dir/signal-window.out" || fail "signal-window sandbox did not become ready (iteration $iteration)"
+  frontend_pid=$(pgrep -P "$sandbox_pid" | head -1)
+  [[ -n "$frontend_pid" ]] || fail "could not find signal-window frontend child (iteration $iteration)"
+  kill -TERM "$sandbox_pid"
+  kill -TERM "$sandbox_pid" 2>/dev/null || true
+  set +e
+  wait "$sandbox_pid"
+  status=$?
+  set -e
+  sandbox_pid=""
+  frontend_alive=0
+  kill -0 "$frontend_pid" 2>/dev/null && frontend_alive=1
+  kill -KILL "$frontend_pid" 2>/dev/null || true
+  if [[ -e "$state_dir/ui.json" || "$frontend_alive" -ne 0 ]]; then
+    echo "residual $state_dir/ui.json (iteration $iteration, script exit $status):" >&2
+    cat "$state_dir/ui.json" >&2 2>/dev/null || echo "(absent)" >&2
+    echo "signal-window sandbox output:" >&2
+    cat "$temp_dir/signal-window.out" >&2 || true
+    rm -f "$state_dir/ui.json"
+    fail "second TERM in the exit path skipped cleanup (iteration $iteration; frontend alive: $frontend_alive)"
+  fi
+  [[ "$status" -eq 143 ]] || fail "signal-window TERM returned $status instead of 143 (iteration $iteration)"
+done
+
 cat >"$temp_dir/supervised.mk" <<'MAKE'
 supervised-ui:
 	@exec bash "$(SCRIPT)" ui
@@ -319,7 +355,7 @@ dump_supervised_residue() {
   echo "processes in group $supervised_pgid:" >&2
   ps -eo pid,ppid,pgid,stat,command | awk -v pg="$supervised_pgid" 'NR == 1 || $3 == pg' >&2
   echo "supervised recipe output:" >&2
-  cat "$temp_dir/supervised.out" >&2
+  cat "$temp_dir/supervised.out" >&2 || true
 }
 for _ in {1..500}; do
   kill -0 "$state_pid" 2>/dev/null || break


### PR DESCRIPTION
## Summary

Root-causes and fixes the flaky supervised-recipe external-TERM assertion in scripts/dev-sandbox.test.sh (state file 'ui.json' occasionally left behind). The flake was not a slow poll: GNU make blocks until its local child exits when TERMed, so by the time the test's wait returns the script's EXIT trap has already run. Residual state meant cleanup was aborted or skipped. Two signal-handling defects in scripts/dev-sandbox.sh are fixed and each is covered by a committed regression test that fails against the pre-fix script; a third robustness gap in state removal is fixed and was verified with ad-hoc probes.

### scripts/dev-sandbox.sh
- A second HUP/INT/TERM arriving during cleanup used to longjmp out of the EXIT trap and skip the child KILL escalation. cleanup() now masks HUP/INT/TERM as its very first statement. Committed test: the double-TERM block.
- bash checks pending signal traps before the first command of the EXIT trap string, so a TERM landing between a normal exit and cleanup starting skipped cleanup entirely (the residual own-pid ui.json case). The signal traps now run cleanup themselves via on_signal() and then exit 130/143; the EXIT trap remains the normal path and cleanup stays idempotent. Committed test: the 20-iteration signal-window block.
- remove_state_file no longer depends on a python3 helper to read the state file's pid: if that helper failed to start under host load, the own-pid check silently did not match and the state stayed in place. The check is now a bash string match on the own-pid token, and every non-removal of an existing file emits a WARNING (unreadable file, pid-token mismatch with the token seen, failed rm). Verified with ad-hoc probes (python unavailable, rm failure), not a committed test.

### scripts/dev-sandbox.test.sh
- New double-TERM regression block (fake frontend ignores TERM; second TERM sent mid-cleanup) and a 20-iteration exit-path signal-window block (two back-to-back TERMs to the script pid). Against the respective pre-fix scripts they fail (78/120 residual in an ad-hoc harness for the exit-path case); with the fixes they pass. Combined added suite time about 11 s.
- The supervised-recipe assertion waits deterministically (script pid gone, then state file, 10 s deadlines) and dumps the residual JSON, the process group and the script output before failing.
- The 'pgrep -P | head -1' frontend lookup could exit the suite silently under the test's set -euo pipefail on a transient no-match; replaced at all three sites by a bounded, command-matched find_frontend_pid helper, and an errexit-gated ERR trap now names the line and command of any plain-command failure.

## Verification
- bash -n on both scripts; suite passes standalone (about 38 s).
- Loaded stability at final head: 10/10 (implementor) + 8/8 (independent verifier) full-suite runs with dev-ports/dev-status test loops running concurrently, zero failures and zero ERR diagnostics; 20/20 at the commit that finalized dev-sandbox.sh.
- Negative controls: with only dev-sandbox.sh reverted to its parent, the double-TERM block fails; reverted to the pre-exit-path-fix version, the signal-window block fails.
- INT/HUP/TERM still exit 130/143/143 with state removed and the listener closed.

Monorepo-only change (scripts); no release monitoring needed.
