### PR TITLE
fix(scripts): exit 4 from shipped-in.sh on transient GitHub failures

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -283,8 +283,10 @@ guardrails) lives in [docs/RELEASING.md](./docs/RELEASING.md). The agent-facing 
   `make shipped-in COMPONENT=... SHA=...`) is the canonical detector: it prints the
   first [intent-hq/cloudlands-releases](https://github.com/intent-hq/cloudlands-releases)
   tag carrying the commit (for intentd, via the `intentdVersion` pin in that tag's
-  `release-manifest.json`) and exits 3 while nothing carries it yet. Never block a
-  turn polling — schedule this hook after replacing the placeholders:
+  `release-manifest.json`), exits 3 while nothing carries it yet, and exits 4 on a
+  transient GitHub failure (rate limit, 5xx, network) that the next poll should
+  simply retry. Never block a turn polling — schedule this hook after replacing
+  the placeholders:
 
   ```javascript
   await ws.hook.schedule({
@@ -295,7 +297,7 @@ guardrails) lives in [docs/RELEASING.md](./docs/RELEASING.md). The agent-facing 
     command: "scripts/shipped-in.sh", args: ["<COMPONENT>", "<SHA>"], timeoutMs: 120_000,
   });
   if (run.exitCode === 0) return { dispatch: true, message: "Shipped in cloudlands-fe " + run.stdout.trim() };
-  if (run.exitCode === 3) return { dispatch: false };
+  if (run.exitCode === 3 || run.exitCode === 4) return { dispatch: false };
   throw new Error("shipped-in failed (exit " + run.exitCode + "): " + run.stderr.trim());`,
   });
   ```

--- a/Makefile
+++ b/Makefile
@@ -110,11 +110,12 @@ docs-check: ## Check documented development targets, knobs, and remote-host guid
 	@scripts/docs-check.sh
 
 # Release tracking: which cloudlands-releases alpha first carries a merged
-# commit. The script exits 3 for "not shipped yet" (make reports it as
-# `Error 3`); background hooks should invoke scripts/shipped-in.sh directly so
-# they can branch on that code. `LIMIT=N` widens the scan window past the
-# newest 10 releases.
-shipped-in: ## Print the first cloudlands-releases tag carrying COMPONENT=intentd|cloudlands-fe SHA=<commit> (script exit 3 = not yet)
+# commit. The script exits 3 for "not shipped yet" and 4 for a transient
+# GitHub failure (rate limit, 5xx, network) worth retrying (make reports them
+# as `Error 3` / `Error 4`); background hooks should invoke
+# scripts/shipped-in.sh directly so they can branch on those codes. `LIMIT=N`
+# widens the scan window past the newest 10 releases.
+shipped-in: ## Print the first cloudlands-releases tag carrying COMPONENT=intentd|cloudlands-fe SHA=<commit> (script exit 3 = not yet, 4 = transient gh failure)
 	@scripts/shipped-in.sh "$(COMPONENT)" "$(SHA)" $(if $(LIMIT),--limit "$(LIMIT)",)
 
 # Build-artifact GC (cargo-sweep). Rust target/ dirs grow without bound as

--- a/scripts/shipped-in.sh
+++ b/scripts/shipped-in.sh
@@ -12,7 +12,9 @@
 # carrying tag is printed as `<tag> intentdVersion=<version>`.
 #
 # Exit codes: 0 = printed a carrying tag; 3 = no scanned release carries the
-# commit yet (stdout empty); 2 = usage error; 1 = gh/API failure.
+# commit yet (stdout empty); 4 = transient GitHub failure (rate limit, 5xx,
+# network) -- retry later; 2 = usage error; 1 = any other gh/API or manifest
+# failure. gh's own error text is appended to the message on 1 and 4.
 
 set -euo pipefail
 
@@ -58,10 +60,28 @@ fail() {
   exit 1
 }
 
+# gh stderr is captured here so failures can be classified and surfaced.
+gh_err=$(mktemp)
+trap 'rm -f "$gh_err"' EXIT
+
+transient_pattern='rate limit|HTTP 429|HTTP 5[0-9]{2}|error connecting|connection (reset|refused)|timeout|no such host|network is unreachable|temporary failure|unexpected EOF'
+
+# Report a failed gh call: exit 4 when its stderr looks transient, else 1.
+gh_fail() {
+  local detail
+  detail=$(<"$gh_err")
+  detail=${detail//$'\n'/ }
+  echo "shipped-in: $*${detail:+: $detail}" >&2
+  if grep -qiE "$transient_pattern" "$gh_err"; then
+    exit 4
+  fi
+  exit 1
+}
+
 compare_status() {
   local head=$1 status
-  status=$(gh api "repos/$compare_repo/compare/$sha...$head" --jq .status 2>/dev/null) ||
-    fail "gh api compare $sha...$head on $compare_repo failed"
+  status=$(gh api "repos/$compare_repo/compare/$sha...$head" --jq .status 2>"$gh_err") ||
+    gh_fail "gh api compare $sha...$head on $compare_repo failed"
   printf '%s\n' "$status"
 }
 
@@ -80,10 +100,12 @@ cache_get() {
 
 manifest_versions=""
 manifest_version() {
-  local tag=$1 version
+  local tag=$1 manifest version
   if ! version=$(cache_get "$manifest_versions" "$tag"); then
-    version=$(gh release download "$tag" --repo "$releases_repo" \
-      --pattern release-manifest.json --output - 2>/dev/null |
+    manifest=$(gh release download "$tag" --repo "$releases_repo" \
+      --pattern release-manifest.json --output - 2>"$gh_err") ||
+      gh_fail "gh release download release-manifest.json for $tag on $releases_repo failed"
+    version=$(printf '%s\n' "$manifest" |
       python3 -c 'import json, sys; print(json.load(sys.stdin)["intentdVersion"])' 2>/dev/null) ||
       fail "could not read intentdVersion from release-manifest.json for $tag on $releases_repo"
     [[ -n "$version" ]] || fail "release-manifest.json for $tag has an empty intentdVersion"
@@ -104,8 +126,8 @@ carries() {
 # newest $limit versioned tags after filtering.
 release_list=$(
   gh release list --repo "$releases_repo" --limit "$((limit + 10))" --exclude-drafts \
-    --json tagName --jq '.[].tagName' 2>/dev/null
-) || fail "gh release list on $releases_repo failed"
+    --json tagName --jq '.[].tagName' 2>"$gh_err"
+) || gh_fail "gh release list on $releases_repo failed"
 tags=()
 while IFS= read -r tag; do
   tags+=("$tag")

--- a/scripts/shipped-in.test.sh
+++ b/scripts/shipped-in.test.sh
@@ -19,17 +19,32 @@ fail() {
   exit 1
 }
 
-for command in bash cat grep head python3; do
+for command in bash cat grep head mktemp python3 rm; do
   ln -s "$(command -v "$command")" "$bin_dir/$command"
 done
 
 # Stub gh: releases from $GH_STUB_DIR/releases, compare statuses from
 # $GH_STUB_DIR/compare/<owner>__<repo>/<base>...<head>, manifests from
 # $GH_STUB_DIR/manifest/<tag>.json. Every invocation is appended to GH_TEST_LOG.
+# GH_STUB_FAIL selects a failure mode (1 = generic, or one of the gh error
+# texts below); GH_STUB_FAIL_ON narrows it to one subcommand ("release list",
+# "api", "release download"), default every call.
 cat >"$bin_dir/gh" <<'SH'
 #!/usr/bin/env bash
 printf '%s\n' "$*" >>"$GH_TEST_LOG"
-[[ "${GH_STUB_FAIL:-0}" == 1 ]] && { echo "stub: gh unavailable" >&2; exit 1; }
+fail_on=${GH_STUB_FAIL_ON:-}
+if [[ -n "${GH_STUB_FAIL:-}" && ( -z "$fail_on" || "$fail_on" == "$1" || "$fail_on" == "$1 $2" ) ]]; then
+  case "$GH_STUB_FAIL" in
+    1) echo "stub: gh unavailable" >&2 ;;
+    ratelimit) echo "gh: API rate limit exceeded for user ID 526899. If you reach out to GitHub Support for help, please include the request ID 1234:ABCD. (HTTP 403)" >&2 ;;
+    ratelimit-rest) echo "HTTP 403: API rate limit exceeded for user ID 526899. (https://api.github.com/repos/intent-hq/cloudlands-releases/releases/tags/v2.3.0)" >&2 ;;
+    5xx) echo "gh: Server Error (HTTP 502)" >&2 ;;
+    network) echo "error connecting to api.github.com" >&2; echo "check your internet connection or https://githubstatus.com" >&2 ;;
+    forbidden) echo "gh: Resource not accessible by personal access token (HTTP 403)" >&2 ;;
+    *) echo "stub: unknown GH_STUB_FAIL $GH_STUB_FAIL" >&2 ;;
+  esac
+  exit 1
+fi
 case "$1 $2" in
   "release list")
     [[ "$*" == *"--repo intent-hq/cloudlands-releases"* ]] || exit 1
@@ -125,10 +140,51 @@ echo ahead >"$fe_compare/$sha...v2.3.0"
 run_script cloudlands-fe "$sha"
 [[ "$status" -eq 1 ]] || fail "compare API failure exited $status (expected 1)"
 [[ -z "$stdout" ]] || fail "compare API failure printed '$stdout'"
+[[ "$stderr" == *"stub: 404 repos/intent-hq/cloudlands-fe/compare/$sha...v2.2.0"* ]] || fail "compare API failure hid gh stderr: $stderr"
 
 reset_stub
 GH_STUB_FAIL=1 run_script cloudlands-fe "$sha"
 [[ "$status" -eq 1 ]] || fail "gh failure exited $status (expected 1, not 3)"
+[[ "$stderr" == *"stub: gh unavailable"* ]] || fail "gh failure hid gh stderr: $stderr"
+
+# Transient GitHub failures exit 4 and surface gh's text so a polling hook can
+# retry instead of evicting itself (intent-hq/intent rate-limit incident).
+for mode in ratelimit ratelimit-rest 5xx network; do
+  reset_stub
+  GH_STUB_FAIL=$mode run_script cloudlands-fe "$sha"
+  [[ "$status" -eq 4 ]] || fail "$mode on release list exited $status (expected 4): $stderr"
+  [[ -z "$stdout" ]] || fail "$mode on release list printed '$stdout'"
+  [[ "$stderr" == "shipped-in: gh release list on intent-hq/cloudlands-releases failed: "* ]] || fail "$mode on release list message: $stderr"
+done
+[[ "$stderr" == *"error connecting to api.github.com check your internet connection"* ]] || fail "multi-line gh stderr was not surfaced on one line: $stderr"
+
+reset_stub
+echo ahead >"$fe_compare/$sha...v2.3.0"
+GH_STUB_FAIL=ratelimit GH_STUB_FAIL_ON=api run_script cloudlands-fe "$sha"
+[[ "$status" -eq 4 ]] || fail "rate-limited compare exited $status (expected 4): $stderr"
+[[ "$stderr" == *"compare $sha...v2.3.0 on intent-hq/cloudlands-fe failed: gh: API rate limit exceeded for user ID 526899."* ]] || fail "rate-limited compare message: $stderr"
+[[ "$stderr" == *"(HTTP 403)"* ]] || fail "rate-limited compare dropped the gh status: $stderr"
+
+reset_stub
+echo ahead >"$fe_compare/$sha...v2.3.0"
+echo behind >"$fe_compare/$sha...v2.2.0"
+echo behind >"$fe_compare/$sha...v2.1.0"
+GH_STUB_FAIL=ratelimit-rest GH_STUB_FAIL_ON="release download" run_script cloudlands-fe "$sha"
+[[ "$status" -eq 4 ]] || fail "rate-limited fe manifest download exited $status (expected 4): $stderr"
+[[ -z "$stdout" ]] || fail "rate-limited fe manifest download printed '$stdout'"
+[[ "$stderr" == *"release download release-manifest.json for v2.3.0 on intent-hq/cloudlands-releases failed: HTTP 403: API rate limit exceeded"* ]] || fail "rate-limited fe manifest message: $stderr"
+[[ "$stderr" != *"could not read intentdVersion"* ]] || fail "rate-limited download was reported as a manifest parse failure: $stderr"
+
+reset_stub
+GH_STUB_FAIL=ratelimit GH_STUB_FAIL_ON="release download" run_script intentd "$sha"
+[[ "$status" -eq 4 ]] || fail "rate-limited intentd manifest download exited $status (expected 4): $stderr"
+[[ "$stderr" == *"release download release-manifest.json for v2.3.0 on intent-hq/cloudlands-releases failed: gh: API rate limit exceeded"* ]] || fail "rate-limited intentd manifest message: $stderr"
+! grep -q '^api ' "$temp_dir/gh.log" || fail "rate-limited intentd manifest download went on to compare"
+
+reset_stub
+GH_STUB_FAIL=forbidden run_script cloudlands-fe "$sha"
+[[ "$status" -eq 1 ]] || fail "plain HTTP 403 exited $status (expected 1, not transient)"
+[[ "$stderr" == *"Resource not accessible by personal access token (HTTP 403)"* ]] || fail "plain HTTP 403 hid gh stderr: $stderr"
 
 reset_stub
 echo ahead >"$fe_compare/$sha...v2.3.0"
@@ -156,6 +212,7 @@ printf '{"version":"2.3.0"}\n' >"$manifest_dir/v2.3.0.json"
 run_script cloudlands-fe "$sha"
 [[ "$status" -eq 1 ]] || fail "fe hit with malformed manifest exited $status (expected 1)"
 [[ -z "$stdout" ]] || fail "fe hit with malformed manifest printed '$stdout'"
+[[ "$stderr" == "shipped-in: could not read intentdVersion from release-manifest.json for v2.3.0 on intent-hq/cloudlands-releases" ]] || fail "malformed manifest message: $stderr"
 
 reset_stub
 printf '{"version":"2.3.0","intentdVersion":"0.9.5"}\n' >"$manifest_dir/v2.3.0.json"
@@ -174,6 +231,7 @@ echo ahead >"$intentd_compare/$sha...v0.9.0"
 rm "$manifest_dir/v2.2.0.json"
 run_script intentd "$sha"
 [[ "$status" -eq 1 ]] || fail "missing manifest exited $status (expected 1)"
+[[ "$stderr" == *"release download release-manifest.json for v2.2.0 on intent-hq/cloudlands-releases failed: stub: no manifest v2.2.0" ]] || fail "missing manifest hid gh stderr: $stderr"
 
 reset_stub
 run_script ios "$sha"


### PR DESCRIPTION
## Problem

`scripts/shipped-in.sh` is the canonical shipped-version detector that AGENTS.md tells every workspace to poll from a background hook (exit 0 = shipped, exit 3 = not yet, anything else → the hook throws and is evicted). Its `gh` calls discarded stderr (`2>/dev/null`) and mapped every failure to exit 1, so a transient GitHub API rate limit (HTTP 403) was reported as `could not read intentdVersion from release-manifest.json for v2.146.0` — which reads like a broken release manifest — and the canonical hook evicted itself on the first rate-limited poll (incident 2026-09-11 ~10:23Z, workspace lively-snail). A workspace whose coordinator is not woken then never reports the shipped version.

## Change

- **`scripts/shipped-in.sh`** — capture `gh` stderr to a trap-cleaned temp file; a `gh_fail` helper appends the gh text to the message and exits **4** when it matches a transient pattern (`rate limit`, `HTTP 429`, `HTTP 5xx`, connection/timeout/DNS wording), else **1**. Applied to `release list`, `api compare` and `release download`. The manifest download failure is now separated from the JSON-parse failure, so `could not read intentdVersion …` only appears when the manifest really lacks the field. A bare `HTTP 403` without rate-limit wording stays exit 1 (auth/permission is not transient). Header documents the exit codes.
- **`scripts/shipped-in.test.sh`** — stub `gh` gains failure modes (`ratelimit`, `ratelimit-rest`, `5xx`, `network`, `forbidden`) and a `GH_STUB_FAIL_ON` call-site selector; new assertions cover exit 4 on each call site, exit 1 for a plain 403, and the surfaced gh stderr on existing exit-1 cases.
- **`AGENTS.md`** — "Track shipped work" prose mentions exit 4; the hook template now reads `if (run.exitCode === 3 || run.exitCode === 4) return { dispatch: false };`.
- **`Makefile`** — `shipped-in` target comment / help text mention exit 4.

## Verification

- `bash scripts/shipped-in.test.sh` passes (incl. the Bash 4+ construct gate); neutralising `exit 4` → `exit 1` in the script makes the new assertions fail.
- `make docs-check` passes.
- Live, real auth: shipped SHA (`ddf236e1…`, intentd v0.9.41) → exit 0 `v2.146.0 intentdVersion=0.9.41`; not-yet-carried SHA → exit 3; unknown ref → `gh: Not Found (HTTP 404)`, exit 1.
- Live, fake `gh` on PATH printing the incident's 403 rate-limit line → exit 4 with the gh text; fake 502 on compare only → exit 4; plain 403 → exit 1.
- Live hook: the updated AGENTS.md template scheduled against the simulated 403 stays `scheduled` (dispatch:false) instead of being evicted.

Monorepo-only change (scripts/docs); nothing ships to the alpha channel.
