### PR TITLE
ci: reject manual submodule gitlink changes in monorepo PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,7 @@ jobs:
       - name: Check for manual submodule pin changes
         env:
           PR_HEAD_REF: ${{ github.head_ref }}
+          PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
           PR_LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
         run: node scripts/check-submodule-pins.mjs --base "origin/${{ github.base_ref }}"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,9 +150,7 @@ jobs:
         env:
           PR_HEAD_REF: ${{ github.head_ref }}
           PR_LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
-        run: |
-          git diff --raw --no-renames "origin/${{ github.base_ref }}...HEAD" > "$RUNNER_TEMP/gitlink-diff"
-          node scripts/check-submodule-pins.mjs "$RUNNER_TEMP/gitlink-diff"
+        run: node scripts/check-submodule-pins.mjs --base "origin/${{ github.base_ref }}"
 
   # The issue-triage body parser (.github/scripts/issue-triage/) is also
   # zero-dependency Node with a fixture-driven node:test suite.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,30 @@ jobs:
           git log --format=%B "origin/${{ github.base_ref }}..HEAD" > "$RUNNER_TEMP/branch-commit-messages"
           node scripts/check-breaking-token.mjs "$RUNNER_TEMP/branch-commit-messages"
 
+  # Submodule pins are advanced only by the auto-bump-submodules workflow
+  # (auto/submodule-bump). Reject gitlink changes in any other PR — a
+  # workspace branch that checked out a submodule feature branch can carry
+  # one unnoticed — unless the submodule-pin-intended label is applied.
+  submodule-pins:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          submodules: false
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+      - run: node --test scripts/check-submodule-pins.test.mjs
+      - name: Check for manual submodule pin changes
+        env:
+          PR_HEAD_REF: ${{ github.head_ref }}
+          PR_LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+        run: |
+          git diff --raw --no-renames "origin/${{ github.base_ref }}...HEAD" > "$RUNNER_TEMP/gitlink-diff"
+          node scripts/check-submodule-pins.mjs "$RUNNER_TEMP/gitlink-diff"
+
   # The issue-triage body parser (.github/scripts/issue-triage/) is also
   # zero-dependency Node with a fixture-driven node:test suite.
   triage-parser-test:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,8 @@ Always use `http://daemon.localhost:<port>` in the embedded browser.
 ### Situate
 
 Run `STATUS_JSON=1 make status` first. It reports host gaps, resolved ports, live sandboxes
-and health, both component branches, and branch PR checks when `gh` is authenticated.
+and health, both component branches (`repos.<name>.gitlinkDirty` flags a submodule moved
+off its pin), and branch PR checks when `gh` is authenticated.
 Use `make status` for the human-readable form. If `host.doctorOk` is false, run
 `make bootstrap-dev-host`, then `make doctor`; automation can set `BOOTSTRAP_YES=1`, but
 system packages may require privilege. Do not discover prerequisites during a build.
@@ -87,8 +88,9 @@ to the task note rather than relying on prose alone:
 
 ### Hand off
 
-Stop what you started, then rerun `STATUS_JSON=1 make status` to confirm no listener or
-state remains. Keep app and stack on loopback: their Vite origin exposes the full
+Stop what you started, then rerun `STATUS_JSON=1 make status` to confirm no listener,
+state, or `gitlinkDirty` submodule remains (`git submodule update --checkout <path>` resets
+one). Keep app and stack on loopback: their Vite origin exposes the full
 unauthenticated daemon API and is safe only through the client's authenticated tunnel.
 
 Remote browser sandboxes cannot exercise Electron main/preload, native dialogs, window
@@ -130,16 +132,14 @@ backstop; and manual `workflow_dispatch` is available for urgent bumps. The
 contents:write on `intent-hq/intent`), and are fail-soft: when the secret is absent
 the notify step logs a warning and skips, and the cron backstop still advances the pins.
 
-**Agents (and humans) must NOT file manual submodule bump PRs on the monorepo.** The
-workflow owns pin advancement. If an urgent bump is needed, dispatch the workflow
-manually instead of filing a PR:
+The workflow owns pin advancement: the `submodule-pins` CI job fails any monorepo PR
+whose diff moves a `packages/*` gitlink unless its head branch is `auto/submodule-bump`
+or it carries the `submodule-pin-intended` label. For an urgent bump, dispatch the
+workflow instead of filing a PR:
 
 ```bash
 gh workflow run auto-bump-submodules.yml
 ```
-
-Regular monorepo PRs for actual content changes (docs, Makefile, CI, scripts) are
-unaffected and still follow the normal PR flow.
 
 The workflow authenticates with the `SUBMODULE_BUMP_TOKEN` secret — a fine-grained PAT
 with contents:read on `intent-hq/intentd`, `intent-hq/cloudlands-fe`, and
@@ -269,9 +269,8 @@ guardrails) lives in [docs/RELEASING.md](./docs/RELEASING.md). The agent-facing 
 - The pipeline is fully automated and event-chained (intentd alpha publish →
   cloudlands-fe pin bump → chained fe alpha cut), with hourly crons as fail-soft
   backstops when an event link is missed.
-- **Never file manual monorepo submodule-bump PRs or routine pin-bump PRs** — the
-  workflows own pin advancement. For an urgent monorepo bump, dispatch the workflow
-  instead (`gh workflow run auto-bump-submodules.yml`). The one sanctioned exception
+- **Never file routine pin-bump PRs** — the workflows own pin advancement (the monorepo
+  `submodule-pins` check enforces this; see Phase 2 above). The one sanctioned exception
   is the cloudlands-fe `intentd.version` pin under the emergency-release procedure
   in [docs/RELEASING.md](./docs/RELEASING.md).
 - **Track shipped work**: a workspace that changed intentd and/or cloudlands-fe is NOT

--- a/docs/fe/DEVELOPER_GUIDE.md
+++ b/docs/fe/DEVELOPER_GUIDE.md
@@ -133,8 +133,9 @@ socket and HTTP readiness probes.
 
 `STATUS_JSON=1 make status` consumes these files and health responses into
 `{host, ports, sandboxes, repos, docs}`. It adds doctor gaps, submodule dirty and
-ahead/behind state, and optional PR/check summaries when GitHub authentication is
-available. The report is read-only, including stale sandbox state.
+ahead/behind state, the recorded gitlink `pin` with `gitlinkDirty` when the checked-out
+submodule HEAD has moved off it, and optional PR/check summaries when GitHub
+authentication is available. The report is read-only, including stale sandbox state.
 
 ## Fast UI Preview Workflow
 

--- a/scripts/check-submodule-pins.mjs
+++ b/scripts/check-submodule-pins.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import { execFileSync } from 'node:child_process';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import process from 'node:process';
@@ -10,6 +11,16 @@ export const EXEMPT_HEAD_REFS = ['auto/submodule-bump'];
 export const EXEMPTION_LABEL = 'submodule-pin-intended';
 
 const RAW_LINE = /^:(\d{6}) (\d{6}) \S+ \S+ \S+\t(.+)$/;
+
+// --ignore-submodules=none overrides any `ignore = all` a branch could add to
+// .gitmodules, which would otherwise hide the moved gitlink from the diff.
+export function rawDiffArgs(baseRef, headRef = 'HEAD') {
+  return ['diff', '--raw', '--no-renames', '--ignore-submodules=none', `${baseRef}...${headRef}`];
+}
+
+export function rawDiff(baseRef, options = {}) {
+  return execFileSync('git', rawDiffArgs(baseRef), { encoding: 'utf8', ...options });
+}
 
 export function findMovedGitlinks(rawDiff) {
   const paths = [];
@@ -36,19 +47,23 @@ function labelsFromEnvironment() {
   return labels;
 }
 
-async function main() {
-  const rawDiffPath = process.argv[2];
-  if (!rawDiffPath) throw new Error('usage: check-submodule-pins.mjs <raw-diff-file>');
+async function rawDiffFromArguments(argv) {
+  if (argv[0] === '--base' && argv[1]) return { diff: rawDiff(argv[1]), baseRef: argv[1] };
+  if (argv[0] && argv[0] !== '--base') return { diff: await fs.readFile(argv[0], 'utf8'), baseRef: '<base>' };
+  throw new Error('usage: check-submodule-pins.mjs (--base <ref> | <raw-diff-file>)');
+}
 
-  const rawDiff = await fs.readFile(rawDiffPath, 'utf8');
-  const offending = findOffendingGitlinks(rawDiff, process.env.PR_HEAD_REF, labelsFromEnvironment());
+async function main() {
+  const { diff, baseRef } = await rawDiffFromArguments(process.argv.slice(2));
+  const offending = findOffendingGitlinks(diff, process.env.PR_HEAD_REF, labelsFromEnvironment());
   if (offending.length === 0) {
     console.log('No manual submodule pin changes found.');
     return;
   }
   for (const pathspec of offending) console.error(`Submodule gitlink changed in this pull request: ${pathspec}`);
   console.error('Submodule pins are advanced only by the auto-bump-submodules workflow (auto/submodule-bump).');
-  console.error('Drop the gitlink change from this branch (git submodule update --checkout <path>) and, if a bump is urgent, run: gh workflow run auto-bump-submodules.yml');
+  console.error(`Restore the base pin and commit: git checkout ${baseRef} -- <path> && git submodule update --checkout <path>`);
+  console.error('If a bump is urgent, dispatch the workflow instead: gh workflow run auto-bump-submodules.yml');
   console.error(`Apply the ${EXEMPTION_LABEL} label only when a manual pin change is intentional.`);
   process.exitCode = 1;
 }

--- a/scripts/check-submodule-pins.mjs
+++ b/scripts/check-submodule-pins.mjs
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+export const GITLINK_MODE = '160000';
+export const EXEMPT_HEAD_REFS = ['auto/submodule-bump'];
+export const EXEMPTION_LABEL = 'submodule-pin-intended';
+
+const RAW_LINE = /^:(\d{6}) (\d{6}) \S+ \S+ \S+\t(.+)$/;
+
+export function findMovedGitlinks(rawDiff) {
+  const paths = [];
+  for (const line of String(rawDiff ?? '').split('\n')) {
+    const match = RAW_LINE.exec(line);
+    if (!match) continue;
+    const [, srcMode, dstMode, pathspec] = match;
+    if (srcMode === GITLINK_MODE || dstMode === GITLINK_MODE) paths.push(pathspec);
+  }
+  return paths;
+}
+
+export function findOffendingGitlinks(rawDiff, headRef, labels) {
+  if (EXEMPT_HEAD_REFS.includes(headRef ?? '')) return [];
+  if ((labels ?? []).includes(EXEMPTION_LABEL)) return [];
+  return findMovedGitlinks(rawDiff);
+}
+
+function labelsFromEnvironment() {
+  const labels = JSON.parse(process.env.PR_LABELS || '[]');
+  if (!Array.isArray(labels) || labels.some((label) => typeof label !== 'string')) {
+    throw new TypeError('PR_LABELS must be a JSON array of strings');
+  }
+  return labels;
+}
+
+async function main() {
+  const rawDiffPath = process.argv[2];
+  if (!rawDiffPath) throw new Error('usage: check-submodule-pins.mjs <raw-diff-file>');
+
+  const rawDiff = await fs.readFile(rawDiffPath, 'utf8');
+  const offending = findOffendingGitlinks(rawDiff, process.env.PR_HEAD_REF, labelsFromEnvironment());
+  if (offending.length === 0) {
+    console.log('No manual submodule pin changes found.');
+    return;
+  }
+  for (const pathspec of offending) console.error(`Submodule gitlink changed in this pull request: ${pathspec}`);
+  console.error('Submodule pins are advanced only by the auto-bump-submodules workflow (auto/submodule-bump).');
+  console.error('Drop the gitlink change from this branch (git submodule update --checkout <path>) and, if a bump is urgent, run: gh workflow run auto-bump-submodules.yml');
+  console.error(`Apply the ${EXEMPTION_LABEL} label only when a manual pin change is intentional.`);
+  process.exitCode = 1;
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) await main();

--- a/scripts/check-submodule-pins.mjs
+++ b/scripts/check-submodule-pins.mjs
@@ -33,10 +33,17 @@ export function findMovedGitlinks(rawDiff) {
   return paths;
 }
 
-export function findOffendingGitlinks(rawDiff, headRef, labels) {
-  if (EXEMPT_HEAD_REFS.includes(headRef ?? '')) return [];
+// The head-ref exemption is name-based, so it only counts for branches in this
+// repository: a fork can name its branch anything.
+export function findOffendingGitlinks(rawDiff, headRef, labels, { fromFork = false } = {}) {
+  if (!fromFork && EXEMPT_HEAD_REFS.includes(headRef ?? '')) return [];
   if ((labels ?? []).includes(EXEMPTION_LABEL)) return [];
   return findMovedGitlinks(rawDiff);
+}
+
+function fromForkFromEnvironment() {
+  const { PR_HEAD_REPO: headRepo, GITHUB_REPOSITORY: baseRepo } = process.env;
+  return Boolean(headRepo && baseRepo && headRepo !== baseRepo);
 }
 
 function labelsFromEnvironment() {
@@ -55,7 +62,9 @@ async function rawDiffFromArguments(argv) {
 
 async function main() {
   const { diff, baseRef } = await rawDiffFromArguments(process.argv.slice(2));
-  const offending = findOffendingGitlinks(diff, process.env.PR_HEAD_REF, labelsFromEnvironment());
+  const offending = findOffendingGitlinks(diff, process.env.PR_HEAD_REF, labelsFromEnvironment(), {
+    fromFork: fromForkFromEnvironment(),
+  });
   if (offending.length === 0) {
     console.log('No manual submodule pin changes found.');
     return;

--- a/scripts/check-submodule-pins.test.mjs
+++ b/scripts/check-submodule-pins.test.mjs
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  EXEMPTION_LABEL,
+  EXEMPT_HEAD_REFS,
+  findMovedGitlinks,
+  findOffendingGitlinks,
+} from './check-submodule-pins.mjs';
+
+const movedIntentd = ':160000 160000 3d37461 1c3dfbc M\tpackages/intentd';
+const addedSubmodule = ':000000 160000 0000000 9f8e7d6 A\tpackages/new-module';
+const removedSubmodule = ':160000 000000 9f8e7d6 0000000 D\tpackages/ios';
+const docsChange = ':100644 100644 0a1b2c3 4d5e6f7 M\tAGENTS.md';
+const addedFile = ':000000 100644 0000000 1234567 A\tscripts/check-submodule-pins.mjs';
+
+test('accepts a diff without gitlink changes', () => {
+  assert.deepEqual(findMovedGitlinks(`${docsChange}\n${addedFile}\n`), []);
+  assert.deepEqual(findOffendingGitlinks(`${docsChange}\n`, 'feature/docs', []), []);
+});
+
+test('accepts an empty diff', () => {
+  assert.deepEqual(findMovedGitlinks(''), []);
+  assert.deepEqual(findMovedGitlinks(undefined), []);
+});
+
+test('reports a moved gitlink', () => {
+  assert.deepEqual(findMovedGitlinks(`${movedIntentd}\n`), ['packages/intentd']);
+});
+
+test('reports added and removed gitlinks', () => {
+  assert.deepEqual(findMovedGitlinks(`${addedSubmodule}\n${removedSubmodule}\n`), [
+    'packages/new-module',
+    'packages/ios',
+  ]);
+});
+
+test('returns only gitlink paths from a mixed diff', () => {
+  const diff = [docsChange, movedIntentd, addedFile].join('\n');
+  assert.deepEqual(findOffendingGitlinks(diff, 'cycle-review', ['other-label']), ['packages/intentd']);
+});
+
+test('exempts the automation head branch', () => {
+  for (const headRef of EXEMPT_HEAD_REFS) {
+    assert.deepEqual(findOffendingGitlinks(movedIntentd, headRef, []), []);
+  }
+  assert.deepEqual(findOffendingGitlinks(movedIntentd, 'auto/submodule-bump-2', []), ['packages/intentd']);
+});
+
+test('exempts pull requests carrying the exemption label', () => {
+  assert.deepEqual(findOffendingGitlinks(movedIntentd, 'feature/new-submodule', ['x', EXEMPTION_LABEL]), []);
+});

--- a/scripts/check-submodule-pins.test.mjs
+++ b/scripts/check-submodule-pins.test.mjs
@@ -53,6 +53,13 @@ test('exempts the automation head branch', () => {
   assert.deepEqual(findOffendingGitlinks(movedIntentd, 'auto/submodule-bump-2', []), ['packages/intentd']);
 });
 
+test('does not exempt the automation branch name when it comes from a fork', () => {
+  assert.deepEqual(findOffendingGitlinks(movedIntentd, EXEMPT_HEAD_REFS[0], [], { fromFork: true }), [
+    'packages/intentd',
+  ]);
+  assert.deepEqual(findOffendingGitlinks(movedIntentd, EXEMPT_HEAD_REFS[0], [], { fromFork: false }), []);
+});
+
 test('exempts pull requests carrying the exemption label', () => {
   assert.deepEqual(findOffendingGitlinks(movedIntentd, 'feature/new-submodule', ['x', EXEMPTION_LABEL]), []);
 });

--- a/scripts/check-submodule-pins.test.mjs
+++ b/scripts/check-submodule-pins.test.mjs
@@ -1,4 +1,8 @@
 import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import test from 'node:test';
 
 import {
@@ -6,6 +10,8 @@ import {
   EXEMPT_HEAD_REFS,
   findMovedGitlinks,
   findOffendingGitlinks,
+  rawDiff,
+  rawDiffArgs,
 } from './check-submodule-pins.mjs';
 
 const movedIntentd = ':160000 160000 3d37461 1c3dfbc M\tpackages/intentd';
@@ -49,4 +55,45 @@ test('exempts the automation head branch', () => {
 
 test('exempts pull requests carrying the exemption label', () => {
   assert.deepEqual(findOffendingGitlinks(movedIntentd, 'feature/new-submodule', ['x', EXEMPTION_LABEL]), []);
+});
+
+test('diff arguments compare the merge base and never ignore submodules', () => {
+  assert.deepEqual(rawDiffArgs('origin/main'), [
+    'diff',
+    '--raw',
+    '--no-renames',
+    '--ignore-submodules=none',
+    'origin/main...HEAD',
+  ]);
+});
+
+test('detects a moved gitlink even when the branch sets ignore = all in .gitmodules', (t) => {
+  const repo = fs.mkdtempSync(path.join(os.tmpdir(), 'check-submodule-pins-'));
+  t.after(() => fs.rmSync(repo, { recursive: true, force: true }));
+  const git = (...args) =>
+    execFileSync('git', args, {
+      cwd: repo,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        GIT_AUTHOR_NAME: 'test',
+        GIT_AUTHOR_EMAIL: 'test@example.invalid',
+        GIT_COMMITTER_NAME: 'test',
+        GIT_COMMITTER_EMAIL: 'test@example.invalid',
+      },
+    });
+  git('init', '-q', '-b', 'main');
+  git('update-index', '--add', '--cacheinfo', `160000,${'1'.repeat(40)},packages/foo`);
+  git('commit', '-q', '-m', 'base');
+  fs.writeFileSync(
+    path.join(repo, '.gitmodules'),
+    '[submodule "foo"]\n\tpath = packages/foo\n\turl = https://example.invalid/foo\n\tignore = all\n',
+  );
+  git('add', '.gitmodules');
+  git('update-index', '--add', '--cacheinfo', `160000,${'2'.repeat(40)},packages/foo`);
+  git('commit', '-q', '-m', 'bump');
+
+  const defaultDiff = git('diff', '--raw', '--no-renames', 'HEAD~1...HEAD');
+  assert.deepEqual(findMovedGitlinks(defaultDiff), [], 'fixture must reproduce the ignore = all bypass');
+  assert.deepEqual(findMovedGitlinks(rawDiff('HEAD~1', { cwd: repo })), ['packages/foo']);
 });

--- a/scripts/dev-status.sh
+++ b/scripts/dev-status.sh
@@ -2,7 +2,8 @@
 # JSON schema:
 # {"host":{"doctorOk":bool,"gaps":[string]},"ports":{},"sandboxes":[],
 #  "repos":{"name":{"branch":string|null,"dirty":bool,"ahead":int|null,
-#  "behind":int|null,"pr?":{"number":int,"url":string,"state":string,
+#  "behind":int|null,"pin":string|null,"gitlinkDirty":bool,
+#  "pr?":{"number":int,"url":string,"state":string,
 #  "checks":{"total":int,"passing":int,"failing":int,"pending":int}}}},
 #  "docs":{"remoteHost":"AGENTS.md#developing-on-a-remote-host"}}
 
@@ -151,21 +152,44 @@ def branch_pr(path, branch):
     }
 
 
+def recorded_pin(relative_path):
+    entry = git_output(root, "ls-tree", "HEAD", "--", relative_path)
+    if not entry:
+        return None
+    fields = entry.split(None, 3)
+    if len(fields) < 3 or fields[0] != "160000":
+        return None
+    return fields[2]
+
+
 def repo_status(relative_path, gh_ready):
     path = os.path.join(root, relative_path)
+    pin = recorded_pin(relative_path)
+    short_pin = pin[:7] if pin else None
     git_marker = os.path.join(path, ".git")
     inside = git_output(path, "rev-parse", "--is-inside-work-tree") if os.path.exists(git_marker) else None
     if inside != "true":
-        return {"initialized": False, "branch": None, "dirty": False, "ahead": None, "behind": None}
+        return {
+            "initialized": False,
+            "branch": None,
+            "dirty": False,
+            "ahead": None,
+            "behind": None,
+            "pin": short_pin,
+            "gitlinkDirty": False,
+        }
 
     branch = git_output(path, "branch", "--show-current") or None
     porcelain = git_output(path, "status", "--short", "--untracked-files=normal")
+    head = git_output(path, "rev-parse", "HEAD")
     repo = {
         "initialized": True,
         "branch": branch,
         "dirty": bool(porcelain),
         "ahead": None,
         "behind": None,
+        "pin": short_pin,
+        "gitlinkDirty": bool(pin and head and head != pin),
     }
     if branch is None:
         repo["head"] = git_output(path, "rev-parse", "--short", "HEAD")
@@ -231,6 +255,7 @@ for name, repo in report["repos"].items():
     branch = repo["branch"] or f"detached@{repo.get('head') or '?'}"
     tracking = "-/-" if repo["ahead"] is None else f"+{repo['ahead']}/-{repo['behind']}"
     dirty = "dirty" if repo["dirty"] else "clean"
+    gitlink_text = f" gitlink=moved(pin {repo['pin'] or '?'})" if repo["gitlinkDirty"] else ""
     pr = repo.get("pr")
     pr_text = ""
     if pr:
@@ -239,6 +264,6 @@ for name, repo in report["repos"].items():
             f" PR #{pr['number']} checks={checks['passing']} pass/"
             f"{checks['pending']} pending/{checks['failing']} fail"
         )
-    print(f"Repo       {name}: {branch} {dirty} ahead/behind={tracking}{pr_text}")
+    print(f"Repo       {name}: {branch} {dirty} ahead/behind={tracking}{gitlink_text}{pr_text}")
 print(f"Docs       {report['docs']['remoteHost']}")
 PY

--- a/scripts/dev-status.test.sh
+++ b/scripts/dev-status.test.sh
@@ -111,4 +111,53 @@ PATH="$bin_dir:$PATH" SANDBOX_STATE_DIR="$state_dir" STATUS_JSON=1 \
 grep -q '^auth status$' "$GH_TEST_LOG" || fail "gh authentication was not checked"
 ! grep -q '^pr ' "$GH_TEST_LOG" || fail "PR lookup ran without authenticated gh"
 
+# Gitlink fixture: a throwaway monorepo with real submodule checkouts, so the
+# pin / gitlinkDirty fields are asserted for in-sync, moved, and uninitialized.
+fixture="$temp_dir/fixture"
+git_fixture() { git -c protocol.file.allow=always -C "$fixture" "$@"; }
+export GIT_AUTHOR_NAME=test GIT_AUTHOR_EMAIL=test@example.invalid
+export GIT_COMMITTER_NAME=test GIT_COMMITTER_EMAIL=test@example.invalid
+mkdir -p "$fixture/scripts"
+cp "$script" "$fixture/scripts/dev-status.sh"
+git init -q -b main "$fixture"
+for name in intentd cloudlands-fe; do
+  git init -q -b main "$temp_dir/src-$name"
+  git -C "$temp_dir/src-$name" commit -q --allow-empty -m "$name base"
+  git_fixture submodule add -q "$temp_dir/src-$name" "packages/$name"
+done
+git_fixture commit -q -m "fixture base"
+intentd_pin=$(git_fixture rev-parse --short=7 HEAD:packages/intentd)
+
+fixture_status() {
+  PATH="$bin_dir:$PATH" SANDBOX_STATE_DIR="$state_dir" STATUS_JSON=1 \
+    bash "$fixture/scripts/dev-status.sh" | python3 -c '
+import json, sys
+repos = json.load(sys.stdin)["repos"]
+print(json.dumps({k: [v["initialized"], v["pin"], v["gitlinkDirty"]] for k, v in repos.items()}, sort_keys=True))'
+}
+
+in_sync=$(fixture_status)
+[[ "$in_sync" == "{\"cloudlands-fe\": [true, \"$(git_fixture rev-parse --short=7 HEAD:packages/cloudlands-fe)\", false], \"intentd\": [true, \"$intentd_pin\", false]}" ]] \
+  || fail "in-sync fixture reported $in_sync"
+
+git -C "$fixture/packages/intentd" commit -q --allow-empty -m "moved off the pin"
+moved=$(fixture_status)
+python3 - "$moved" "$intentd_pin" <<'PY' || fail "moved gitlink fixture reported $moved"
+import json, sys
+repos, pin = json.loads(sys.argv[1]), sys.argv[2]
+assert repos["intentd"] == [True, pin, True], repos
+assert repos["cloudlands-fe"][2] is False, repos
+PY
+grep -q "^Repo *intentd: .* gitlink=moved(pin $intentd_pin)" <(PATH="$bin_dir:$PATH" SANDBOX_STATE_DIR="$state_dir" bash "$fixture/scripts/dev-status.sh") \
+  || fail "human status did not flag the moved gitlink"
+
+git_fixture submodule deinit -q -f packages/cloudlands-fe
+deinit=$(fixture_status)
+python3 - "$deinit" <<'PY' || fail "uninitialized fixture reported $deinit"
+import json, sys
+repos = json.loads(sys.argv[1])
+assert repos["cloudlands-fe"][0] is False and repos["cloudlands-fe"][2] is False, repos
+assert isinstance(repos["cloudlands-fe"][1], str), repos
+PY
+
 echo "dev-status tests passed (no-gh ${elapsed_ms}ms)"

--- a/scripts/dev-status.test.sh
+++ b/scripts/dev-status.test.sh
@@ -72,7 +72,9 @@ assert {"DEV_PORT", "DEV_TCP_PORT", "BRIDGE_PORT", "CDP_PORT"} <= set(report["po
 assert report["sandboxes"] == []
 assert set(report["repos"]) == {"intentd", "cloudlands-fe"}
 for repo in report["repos"].values():
-    assert {"branch", "dirty", "ahead", "behind"} <= set(repo)
+    assert {"branch", "dirty", "ahead", "behind", "pin", "gitlinkDirty"} <= set(repo)
+    assert repo["pin"] is None or isinstance(repo["pin"], str)
+    assert isinstance(repo["gitlinkDirty"], bool)
     assert "pr" not in repo
 assert report["docs"]["remoteHost"] == "AGENTS.md#developing-on-a-remote-host"
 PY


### PR DESCRIPTION
## Summary

Submodule pin advancement belongs to the auto-bump-submodules workflow, but until now that rule lived only in AGENTS.md prose. A workspace branch that checks out a feature branch inside `packages/intentd` carries a moved gitlink, auto-commit records it, and a monorepo PR cut from that branch silently becomes a manual pin bump (near-miss in the workspace that produced #4720).

This PR makes the rule mechanical:

- **`submodule-pins` CI job** (`.github/workflows/ci.yml`) backed by `scripts/check-submodule-pins.mjs --base origin/<base>`: runs `git diff --raw --no-renames --ignore-submodules=none <base>...HEAD` and fails when any gitlink (mode 160000) changed, unless the head branch is `auto/submodule-bump` or the PR carries the `submodule-pin-intended` label. `--ignore-submodules=none` defeats an `ignore = all` entry a branch could add to `.gitmodules`, which would otherwise hide the moved gitlink from the diff. Failure output names the path, gives the recovery command (`git checkout <base> -- <path> && git submodule update --checkout <path>`), and points at `gh workflow run auto-bump-submodules.yml`.
- **`make status` companion**: each `repos.<name>` entry now carries `pin` (recorded gitlink) and `gitlinkDirty` (submodule HEAD moved off it); the human form appends `gitlink=moved(pin <sha>)`.
- **AGENTS.md** compressed to point at the check instead of restating the rule (net -1 line); `docs/fe/DEVELOPER_GUIDE.md` schema paragraph updated.

## Verification

- `node --test scripts/check-submodule-pins.test.mjs` — 9 pass, including a real-git fixture that reproduces the `ignore = all` bypass with the default diff and confirms the check's own invocation still reports the gitlink.
- `--base` mode rejects real bump commit `00a5e30` (exit 1, names `packages/intentd`) in a detached worktree and passes this branch against `origin/main`.
- `bash scripts/dev-status.test.sh` passes; detaching `packages/intentd` flips `gitlinkDirty` to `true`, `git submodule update --checkout` restores it.
- `make docs-check`, `node scripts/check-doc-links.mjs`, `node scripts/check-root-hygiene.mjs`, and all node:test and shell suites listed in ci.yml pass locally.

## Follow-up (human, repo settings)

The monorepo ruleset has no required status checks, so this job shows red but does not block the merge queue until `submodule-pins` is added as a required check. That ruleset change must be paired with a `merge_group` trigger on this workflow (the job can pass trivially on `merge_group`; the `pull_request` run already gated the content) — otherwise the required check stays pending for every merge group and queued PRs are ejected.

