### PR TITLE
docs(fe): point the IPC allowlist step at the untracked generated preload

### DIFF
--- a/docs/fe/IPC_DEBUG_GUIDE.md
+++ b/docs/fe/IPC_DEBUG_GUIDE.md
@@ -131,7 +131,7 @@ setupMyFeatureIPC();
 
 ### Step 3: Regenerate the Preload Allowlist
 
-The preload channel allowlist (`ALLOWED_CHANNELS` in `src/preload/index.ts`) is generated — do not hand-edit it. After registering the channel, regenerate:
+The preload channel allowlist (`ALLOWED_CHANNELS`) lives in the untracked, generated `src/preload/index.ts`, so never edit it by hand. The generator builds the allowlist from `src/shared/ipc-registry.ts` — a new channel must be added there, or the preload keeps blocking it; `src/preload/index.template.ts` only supplies the surrounding bridge code. `dev` and `build` regenerate the file; after registering the channel, regenerate it directly with:
 
 ```bash
 pnpm run generate:ipc-channels


### PR DESCRIPTION
Follow-up to intent-hq/cloudlands-fe#2345, which stopped committing the generated cloudlands-fe src/preload/index.ts and generates it on demand (pnpm run generate:ipc-channels) from src/preload/index.template.ts and src/shared/ipc-registry.ts.

Updates the IPC debug guide step that pointed at the committed preload allowlist so it now describes the untracked generated file and directs edits to the template/registry.

Docs-only; no code or pin changes (the cloudlands-fe submodule pin advances via the auto-bump-submodules workflow).