### PR TITLE
fix(scripts): make docs-check.sh portable to Bash 3.2

### DIFF
--- a/scripts/docs-check.sh
+++ b/scripts/docs-check.sh
@@ -86,7 +86,12 @@ hydration_docs=(AGENTS.md docs/fe/DEVELOPER_GUIDE.md)
 [[ -f "$fe_agents" ]] && hydration_docs+=("$fe_agents")
 canonical_range=
 for file in "${hydration_docs[@]}"; do
-  mapfile -t anchors < <(grep -ni 'first tunneled' "$file" || true)
+  # Read lines into the array with a loop: stock macOS ships Bash 3.2, which
+  # lacks the Bash 4 array-fill builtin (intent-hq/intent#4759).
+  anchors=()
+  while IFS= read -r anchor; do
+    anchors+=("$anchor")
+  done < <(grep -ni 'first tunneled' "$file" || true)
   if ((${#anchors[@]} != 1)); then
     fail "$file" 1 "expected exactly one first-tunneled hydration expectation; found ${#anchors[@]}"
     continue

--- a/scripts/docs-check.test.sh
+++ b/scripts/docs-check.test.sh
@@ -3,16 +3,31 @@
 set -euo pipefail
 
 repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)
+script=$repo_root/scripts/docs-check.sh
 temp_dir=$(mktemp -d)
 trap 'rm -rf "$temp_dir"' EXIT
+
+# The fixtures below run docs-check.sh under $script_bash and append every
+# exit code + output to $transcript, so a rerun under another interpreter
+# (see the Bash 3 section at the end) can be compared byte for byte.
+script_bash=${DOCS_CHECK_TEST_BASH:-$BASH}
+transcript=${DOCS_CHECK_TEST_TRANSCRIPT:-$temp_dir/transcript}
+: >"$transcript"
 
 fail() {
   echo "docs-check test failed: $*" >&2
   exit 1
 }
 
+run_check() {
+  local status=0
+  check_output=$(cd "$temp_dir" && "$script_bash" scripts/docs-check.sh 2>&1) || status=$?
+  printf 'exit %s\n%s\n' "$status" "$check_output" >>"$transcript"
+  return "$status"
+}
+
 mkdir -p "$temp_dir/scripts" "$temp_dir/docs/fe" "$temp_dir/packages/cloudlands-fe"
-cp "$repo_root/scripts/docs-check.sh" "$temp_dir/scripts/docs-check.sh"
+cp "$script" "$temp_dir/scripts/docs-check.sh"
 touch "$temp_dir/Makefile" "$temp_dir/README.md"
 
 cat >"$temp_dir/AGENTS.md" <<'EOF'
@@ -34,30 +49,106 @@ Do not link a client-local capture.
 ### Next
 EOF
 
-if ! pass_output=$(cd "$temp_dir" && bash scripts/docs-check.sh 2>&1); then
-  fail "client-local capture guidance was rejected: $pass_output"
+if ! run_check; then
+  fail "client-local capture guidance was rejected: $check_output"
 fi
 
 printf '%s\n' 'Use the client-local port.' >>"$temp_dir/README.md"
-if fail_output=$(cd "$temp_dir" && bash scripts/docs-check.sh 2>&1); then
+if run_check; then
   fail "client-local port guidance was accepted"
 fi
-grep -q 'legacy guidance is forbidden (browser-rewritten local port)' <<<"$fail_output" ||
+grep -q 'legacy guidance is forbidden (browser-rewritten local port)' <<<"$check_output" ||
   fail "client-local port failure did not retain its human-readable label"
 
 : >"$temp_dir/README.md"
 printf '%s\n' 'Set SANDBOX_ONLY_KNOB=1 for runner diagnostics.' >>"$temp_dir/packages/cloudlands-fe/AGENTS.md"
-if fail_output=$(cd "$temp_dir" && bash scripts/docs-check.sh 2>&1); then
+if run_check; then
   fail "undeclared sandbox knob was accepted"
 fi
-grep -q "sandbox knob 'SANDBOX_ONLY_KNOB' is not present" <<<"$fail_output" ||
-  fail "undeclared sandbox knob failure did not name the knob: $fail_output"
+grep -q "sandbox knob 'SANDBOX_ONLY_KNOB' is not present" <<<"$check_output" ||
+  fail "undeclared sandbox knob failure did not name the knob: $check_output"
 
 mkdir -p "$temp_dir/packages/cloudlands-fe/scripts/sandbox"
 printf '%s\n' 'const debug = process.env.SANDBOX_ONLY_KNOB === "1";' \
   >"$temp_dir/packages/cloudlands-fe/scripts/sandbox/runner.mjs"
-if ! pass_output=$(cd "$temp_dir" && bash scripts/docs-check.sh 2>&1); then
-  fail "sandbox knob defined in an fe sandbox source was rejected: $pass_output"
+if ! run_check; then
+  fail "sandbox knob defined in an fe sandbox source was rejected: $check_output"
 fi
 
-echo "docs-check tests passed"
+printf '%s\n' 'The first tunneled open is slow.' >>"$temp_dir/AGENTS.md"
+if run_check; then
+  fail "duplicate first-tunneled hydration expectation was accepted"
+fi
+grep -q 'expected exactly one first-tunneled hydration expectation; found 2' <<<"$check_output" ||
+  fail "duplicate hydration expectation failure did not report the anchor count: $check_output"
+
+cat >"$temp_dir/AGENTS.md" <<'EOF'
+## Developing on a remote host
+A first tunneled open takes one to three minutes.
+## Next
+EOF
+if ! run_check; then
+  fail "restored hydration expectation was rejected: $check_output"
+fi
+
+echo "docs-check tests passed under $("$script_bash" -c 'echo "bash $BASH_VERSION"')"
+[[ -z "${DOCS_CHECK_TEST_BASH:-}" ]] || exit 0
+
+# Stock macOS /bin/bash is 3.2 (intent-hq/intent#4759). `bash -n` alone
+# accepts Bash 4+ builtins and expansions, so reject them by pattern too,
+# then rerun the fixtures under a real Bash 3 when one can be found (same
+# lookup as shipped-in.test.sh) and require a byte-identical transcript.
+bash -n "$script" || fail "docs-check.sh does not parse"
+bash -n "${BASH_SOURCE[0]}" || fail "docs-check.test.sh does not parse"
+bash4_constructs='(^|[^A-Za-z0-9_])(declare|local|typeset)([[:blank:]]+-[A-Za-z]+)*[[:blank:]]+-[A-Za-z]*[An][A-Za-z]*([^A-Za-z]|$)|(^|[^A-Za-z0-9_])(mapfile|readarray|coproc)([^A-Za-z0-9_]|$)|\$\{([A-Za-z_][A-Za-z_0-9]*|[0-9]+|[@*#?!$-])(\[[^]]*\])?(\^\^?|,,?)[^}]*\}|&>>|\|&|;;?&'
+# Full-line comments, the pattern itself and the gate_sample calls below are
+# not scanned.
+gate_matches() {
+  grep -nE "$bash4_constructs" "$@" | grep -vE '^([^:]*:)?[0-9]+:[[:blank:]]*#' |
+    grep -v -F -e 'bash4_constructs' -e 'gate_sample' || true
+}
+gate_sample() {
+  local expected=$1 sample=$2 hit
+  hit=$(printf '%s\n' "$sample" | gate_matches)
+  case "$expected:${hit:+hit}" in
+    hit:hit | miss:) ;;
+    *) fail "gate regex $expected sample misclassified: $sample" ;;
+  esac
+}
+gate_sample hit 'mapfile -t anchors < <(grep -ni x "$file" || true)'
+gate_sample hit 'readarray a <f'
+gate_sample hit 'declare -A m=()'
+gate_sample hit 'echo ${var,,}'
+gate_sample miss 'line=${anchors[0]%%:*}'
+gate_sample miss 'local file=$1 line=$2 message=$3'
+gate_sample miss '# mapfile is unavailable on Bash 3'
+gate_hits=$(gate_matches "$script" "${BASH_SOURCE[0]}")
+[[ -z "$gate_hits" ]] || fail "Bash 4+ constructs found (stock macOS bash is 3.2):"$'\n'"$gate_hits"
+
+find_bash3() {
+  local candidate resolved brew_prefix
+  brew_prefix=$(brew --prefix bash@3 2>/dev/null) || brew_prefix=""
+  for candidate in "${BASH3_BIN:-}" bash3 "${brew_prefix:+$brew_prefix/bin/bash}" \
+    /opt/homebrew/opt/bash@3/bin/bash /usr/local/opt/bash@3/bin/bash /bin/bash; do
+    [[ -n "$candidate" ]] || continue
+    resolved=$(command -v "$candidate" 2>/dev/null) || continue
+    [[ -x "$resolved" ]] || continue
+    "$resolved" -c '[[ "${BASH_VERSINFO[0]}" -eq 3 ]]' 2>/dev/null || continue
+    printf '%s\n' "$resolved"
+    return 0
+  done
+  return 1
+}
+
+if [[ "${BASH_VERSINFO[0]}" -eq 3 ]]; then
+  : # the fixtures above already ran under Bash 3
+elif bash3=$(find_bash3); then
+  bash3_transcript=$temp_dir/bash3-transcript
+  DOCS_CHECK_TEST_BASH="$bash3" DOCS_CHECK_TEST_TRANSCRIPT="$bash3_transcript" \
+    "$bash3" "${BASH_SOURCE[0]}"
+  cmp -s "$transcript" "$bash3_transcript" ||
+    fail "docs-check.sh output differs between bash $BASH_VERSION and $bash3:"$'\n'"$(diff "$transcript" "$bash3_transcript" || true)"
+  echo "docs-check.sh output is identical under bash $BASH_VERSION and $bash3"
+else
+  echo "docs-check tests: no Bash 3 interpreter found (set BASH3_BIN); real 3.2 run skipped, static gate only"
+fi


### PR DESCRIPTION
Fixes intent-hq/intent#4759

`make docs-check` exits on stock macOS because `scripts/docs-check.sh` used `mapfile`, a Bash 4 builtin absent from `/bin/bash` 3.2. Same approach as the #4706 fix in `scripts/shipped-in.sh`.

## Changes

- `scripts/docs-check.sh`: replace `mapfile -t anchors < <(...)` with a `while IFS= read -r` loop. No behaviour change to the checks.
- `scripts/docs-check.test.sh`:
  - fixtures now run under `DOCS_CHECK_TEST_BASH` (default: the running bash) and record every exit code + output to a transcript;
  - a static gate rejects Bash 4+ constructs (`mapfile`/`readarray`/`coproc`, `declare -A`/`-n`, `${var,,}`/`${var^^}`, `&>>`, `|&`, `;;&`) in the script and the test — this is the assertion that fails on `main`;
  - when a real Bash 3 is found (`BASH3_BIN`, `bash3`, Homebrew `bash@3`, or a 3.x `/bin/bash`), the fixtures rerun under it and the transcripts must be byte-identical;
  - a fixture for the duplicate first-tunneled anchor case, which exercises the rewritten loop.

## Verification

Run on Linux with a locally built bash-3.2.57:

- `BASH3_BIN=<bash-3.2.57> bash scripts/docs-check.test.sh` → passes under 5.2.21, reruns under 3.2.57, output identical.
- `<bash-3.2.57> scripts/docs-check.test.sh` → passes.
- `main`'s `docs-check.sh` under 3.2.57 → `line 89: mapfile: command not found` (reproduces the issue); the fixed script passes.
- Test against `main`'s `docs-check.sh` → fails on the construct gate, naming line 89.
- `make docs-check` → passes.
- `grep -nE 'mapfile|readarray|declare -A|\$\{[^}]*(,,|\^\^)' scripts/docs-check.sh` → no output.
- `shellcheck` is not installed on the build host; not run.
