### PR TITLE
fix(ci): make docs-check ignore prose make mentions

### DIFF
--- a/scripts/docs-check.sh
+++ b/scripts/docs-check.sh
@@ -22,7 +22,8 @@ fail() {
 
 # Emit `file:line:make <target>` for every mention that appears in code: lines
 # inside fenced code blocks and the contents of inline backtick spans. Prose
-# mentions such as "can make an export" are ignored.
+# mentions such as "can make an export" are ignored. An inline span may wrap
+# onto following lines within the same paragraph; a blank line ends it.
 code_make_mentions() {
   awk '
     function emit(text,   rest) {
@@ -40,7 +41,7 @@ code_make_mentions() {
       }
       return ""
     }
-    FNR == 1 { in_fence = 0 }
+    FNR == 1 { in_fence = 0; open_tick = "" }
     {
       run = fence_run($0)
       if (in_fence) {
@@ -52,13 +53,21 @@ code_make_mentions() {
         emit($0)
         next
       }
-      if (run != "") { in_fence = 1; fence = run; next }
+      if (run != "") { in_fence = 1; fence = run; open_tick = ""; next }
+      if ($0 ~ /^[ \t]*$/) open_tick = ""
       rest = $0
+      if (open_tick != "") {
+        close_pos = index(rest, open_tick)
+        if (close_pos == 0) { emit(rest); next }
+        emit(substr(rest, 1, close_pos - 1))
+        rest = substr(rest, close_pos + length(open_tick))
+        open_tick = ""
+      }
       while (match(rest, /`+/)) {
         tick = substr(rest, RSTART, RLENGTH)
         rest = substr(rest, RSTART + RLENGTH)
         close_pos = index(rest, tick)
-        if (close_pos == 0) break
+        if (close_pos == 0) { open_tick = tick; emit(rest); break }
         emit(substr(rest, 1, close_pos - 1))
         rest = substr(rest, close_pos + length(tick))
       }

--- a/scripts/docs-check.sh
+++ b/scripts/docs-check.sh
@@ -20,12 +20,58 @@ fail() {
   failures=$((failures + 1))
 }
 
+# Emit `file:line:make <target>` for every mention that appears in code: lines
+# inside fenced code blocks and the contents of inline backtick spans. Prose
+# mentions such as "can make an export" are ignored.
+code_make_mentions() {
+  awk '
+    function emit(text,   rest) {
+      rest = text
+      while (match(rest, /make[[:space:]]+[A-Za-z0-9_-]+/)) {
+        print FILENAME ":" FNR ":" substr(rest, RSTART, RLENGTH)
+        rest = substr(rest, RSTART + RLENGTH)
+      }
+    }
+    function fence_run(line,   run) {
+      if (match(line, /^[ \t]*(```+|~~~+)/)) {
+        run = substr(line, RSTART, RLENGTH)
+        sub(/^[ \t]+/, "", run)
+        return run
+      }
+      return ""
+    }
+    FNR == 1 { in_fence = 0 }
+    {
+      run = fence_run($0)
+      if (in_fence) {
+        if (run != "" && substr(run, 1, 1) == substr(fence, 1, 1) &&
+            length(run) >= length(fence) && $0 ~ /^[ \t]*(`+|~+)[ \t]*$/) {
+          in_fence = 0
+          next
+        }
+        emit($0)
+        next
+      }
+      if (run != "") { in_fence = 1; fence = run; next }
+      rest = $0
+      while (match(rest, /`+/)) {
+        tick = substr(rest, RSTART, RLENGTH)
+        rest = substr(rest, RSTART + RLENGTH)
+        close_pos = index(rest, tick)
+        if (close_pos == 0) break
+        emit(substr(rest, 1, close_pos - 1))
+        rest = substr(rest, close_pos + length(tick))
+      }
+    }
+  ' "${docs[@]}"
+}
+
 while IFS=: read -r file line mention; do
   read -r _ target <<<"$mention"
   if ! grep -Eq "^${target}[[:space:]]*:" Makefile; then
     fail "$file" "$line" "documented make target '$target' does not exist"
   fi
-done < <(grep -nHEo 'make[[:space:]]+[A-Za-z0-9_-]+' "${docs[@]}" || true)
+done < <(code_make_mentions)
 
 section_lines() {
   local file=$1 start=$2 stop=$3

--- a/scripts/docs-check.test.sh
+++ b/scripts/docs-check.test.sh
@@ -121,6 +121,20 @@ fi
 grep -q "README.md:2: error: documented make target 'missing-fenced' does not exist" <<<"$check_output" ||
   fail "fenced missing make target failure did not name the target: $check_output"
 
+cat >"$temp_dir/README.md" <<'EOF'
+Run `npm run lint &&
+make missing-multiline` and then you can make an export.
+
+This paragraph can make an export too.
+EOF
+if run_check; then
+  fail "missing make target in a wrapped inline code span was accepted"
+fi
+grep -q "README.md:2: error: documented make target 'missing-multiline' does not exist" <<<"$check_output" ||
+  fail "wrapped inline span failure did not name the target: $check_output"
+grep -q "documented make target 'an'" <<<"$check_output" &&
+  fail "prose after a wrapped inline span was treated as code: $check_output"
+
 : >"$temp_dir/README.md"
 
 echo "docs-check tests passed under $("$script_bash" -c 'echo "bash $BASH_VERSION"')"

--- a/scripts/docs-check.test.sh
+++ b/scripts/docs-check.test.sh
@@ -28,7 +28,8 @@ run_check() {
 
 mkdir -p "$temp_dir/scripts" "$temp_dir/docs/fe" "$temp_dir/packages/cloudlands-fe"
 cp "$script" "$temp_dir/scripts/docs-check.sh"
-touch "$temp_dir/Makefile" "$temp_dir/README.md"
+touch "$temp_dir/README.md"
+printf 'real-target:\n\ttrue\n' >"$temp_dir/Makefile"
 
 cat >"$temp_dir/AGENTS.md" <<'EOF'
 ## Developing on a remote host
@@ -90,6 +91,37 @@ EOF
 if ! run_check; then
   fail "restored hydration expectation was rejected: $check_output"
 fi
+
+cat >"$temp_dir/README.md" <<'EOF'
+Dropping an import in one file can make an export in another unused.
+Run `make real-target` first.
+```bash
+make real-target
+```
+EOF
+if ! run_check; then
+  fail "prose make mention or valid code make target was rejected: $check_output"
+fi
+
+printf '%s\n' 'Then run `make missing-inline`.' >>"$temp_dir/README.md"
+if run_check; then
+  fail "backticked missing make target was accepted"
+fi
+grep -q "README.md:6: error: documented make target 'missing-inline' does not exist" <<<"$check_output" ||
+  fail "backticked missing make target failure did not name the target: $check_output"
+
+cat >"$temp_dir/README.md" <<'EOF'
+~~~
+make missing-fenced
+~~~
+EOF
+if run_check; then
+  fail "fenced missing make target was accepted"
+fi
+grep -q "README.md:2: error: documented make target 'missing-fenced' does not exist" <<<"$check_output" ||
+  fail "fenced missing make target failure did not name the target: $check_output"
+
+: >"$temp_dir/README.md"
 
 echo "docs-check tests passed under $("$script_bash" -c 'echo "bash $BASH_VERSION"')"
 [[ -z "${DOCS_CHECK_TEST_BASH:-}" ]] || exit 0


### PR DESCRIPTION
## Summary

`scripts/docs-check.sh` validated every `make <word>` substring in the checked docs against the Makefile, including prose. The monorepo `docs-check` job started failing after intent-hq/cloudlands-fe#2368 merged (and the pin advanced in #4791) because `packages/cloudlands-fe/AGENTS.md:322` contains the sentence "dropping an import in one file can make an export in another unused":

- Failing run: https://github.com/intent-hq/intent/actions/runs/34669104807
  `packages/cloudlands-fe/AGENTS.md:322: error: documented make target 'an' does not exist`

This change collects make-target mentions only from code: lines inside fenced code blocks (``` or ~~~ fences, tracked per file) and the contents of inline backtick spans. Prose mentions are ignored.

At cloudlands-fe `35d1f30f` (current main pin) all 56 real mentions across the four checked docs are in one of those two forms; the only prose hit is the false positive, so detection coverage is unchanged.

## Tests

`scripts/docs-check.test.sh` gains cases for:
- a prose `make an export` line plus a valid backticked and fenced `make real-target` → passes
- a backticked missing target (`make missing-inline`) → fails, naming the target and line
- a `~~~`-fenced missing target (`make missing-fenced`) → fails, naming the target and line

## Verification

- `bash scripts/docs-check.test.sh` → `docs-check tests passed`
- `make docs-check` with `packages/cloudlands-fe` at `35d1f30f` → `checked 4 docs; all invariants passed` (previously failed on line 322)
- `make docs-check` with `packages/cloudlands-fe` at `75a641d9` (the #2375 branch head) → passes
- Verified with mawk 1.3.4 (the `ubuntu-latest` default awk)

No submodule pointer change.
