### PR TITLE
fix(scripts): bound doctor launcher probes, verify node-pty binary, raise Node floor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,7 @@ jobs:
           submodules: false
       - run: |
           echo "shell tests: host-specific daemon and pnpm behavior is stubbed"
+          bash scripts/bootstrap-dev-host.test.sh
           bash scripts/dev-ports.test.sh
           bash scripts/dev-sandbox.test.sh
           bash scripts/dev-status.test.sh

--- a/docs/fe/DEVELOPER_GUIDE.md
+++ b/docs/fe/DEVELOPER_GUIDE.md
@@ -6,7 +6,7 @@ This guide reflects the current Intent repository layout and APIs as of package 
 
 ### Prerequisites
 
-- Node.js 18+
+- Node.js 24 (24.15.0+; 22.22.2+ and 26+ also work — node-gyp 13 builds node-pty during install and rejects older releases; `make doctor` checks this)
 - Corepack with the repository-pinned `pnpm` version
 - Git
 - Auggie CLI for the default ACP provider workflow

--- a/scripts/bootstrap-dev-host.sh
+++ b/scripts/bootstrap-dev-host.sh
@@ -4,8 +4,8 @@ set -u
 
 SCRIPT_DIR=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
 ROOT_DIR=$(CDPATH='' cd -- "$SCRIPT_DIR/.." && pwd)
-INTENTD_DIR="$ROOT_DIR/packages/intentd"
-FE_DIR="$ROOT_DIR/packages/cloudlands-fe"
+INTENTD_DIR=${INTENTD_DIR:-"$ROOT_DIR/packages/intentd"}
+FE_DIR=${FE_DIR:-"$ROOT_DIR/packages/cloudlands-fe"}
 TOOLCHAIN_FILE="$INTENTD_DIR/rust-toolchain.toml"
 PACKAGE_FILE="$FE_DIR/package.json"
 CARGO_HOME=${CARGO_HOME:-"$HOME/.cargo"}
@@ -16,6 +16,19 @@ export CARGO_HOME PATH
 # the projectCards API deprecation both need this release or newer.
 GH_MIN_VERSION="2.94.0"
 GH_INSTALL_URL="https://github.com/cli/cli#installation"
+
+# Minimum Node: the frontend install builds node-pty (and cpu-features) with
+# node-gyp 13, whose engines.node is "^22.22.2 || ^24.15.0 || >=26.0.0"; its undici
+# dependency throws on Node 20 (intent-hq/intent#4669). fe CI runs Node 24.
+NODE_REQUIREMENT="22.22.2+, 24.15.0+ (recommended) or 26+"
+NODE_INSTALL_MAJOR=24
+
+# Corepack/pnpm launcher probes run under this bound (seconds) so a launcher that
+# re-invokes itself or stalls fails with a diagnosis instead of hanging the doctor
+# (intent-hq/intent#4635).
+PROBE_TIMEOUT=${BOOTSTRAP_PROBE_TIMEOUT:-20}
+PROBE_OUTPUT=""
+PROBE_ERROR=""
 
 MODE=install
 ASSUME_YES=${BOOTSTRAP_YES:-0}
@@ -92,15 +105,135 @@ active_toolchain_ready() {
   [[ $(rustup show active-toolchain 2>/dev/null) == "$TOOLCHAIN"-* ]]
 }
 
-node_ready() {
+node_version() {
   command -v node >/dev/null 2>&1 || return 1
-  local major
-  major=$(node -p 'Number(process.versions.node.split(".")[0])' 2>/dev/null) || return 1
-  [[ "$major" =~ ^[0-9]+$ && "$major" -ge 20 ]]
+  local line
+  line=$(node --version 2>/dev/null) || return 1
+  [[ "$line" =~ ^v?([0-9]+\.[0-9]+\.[0-9]+) ]] || return 1
+  printf '%s\n' "${BASH_REMATCH[1]}"
+}
+
+node_version_supported() {
+  case "${1%%.*}" in
+    22) version_ge "$1" "22.22.2" ;;
+    24) version_ge "$1" "24.15.0" ;;
+    *) [[ "${1%%.*}" -ge 26 ]] ;;
+  esac
+}
+
+node_ready() {
+  local version
+  version=$(node_version) || return 1
+  node_version_supported "$version"
 }
 
 python_ready() {
   command -v python3 >/dev/null 2>&1
+}
+
+kill_process_tree() {
+  local pid=$1 child
+  kill -STOP "$pid" 2>/dev/null
+  for child in $(pgrep -P "$pid" 2>/dev/null); do
+    kill_process_tree "$child"
+  done
+  kill -KILL "$pid" 2>/dev/null
+}
+
+# run_bounded <seconds> <dir> <command...>: runs the command in <dir> with stdin
+# closed, leaves its combined output in PROBE_OUTPUT and returns its status, or
+# 124 after killing its whole process tree once <seconds> have elapsed.
+run_bounded() {
+  local seconds=$1 dir=$2 output marker pid watchdog status
+  shift 2
+  output=$(mktemp "${TMPDIR:-/tmp}/bootstrap-probe.XXXXXX") || return 1
+  marker="$output.timeout"
+  (cd "$dir" && exec "$@") </dev/null >"$output" 2>&1 &
+  pid=$!
+  (
+    trap - EXIT
+    sleeper=""
+    trap 'kill "$sleeper" 2>/dev/null; exit 0' TERM
+    sleep "$seconds" &
+    sleeper=$!
+    wait "$sleeper"
+    : >"$marker"
+    kill_process_tree "$pid"
+  ) </dev/null >/dev/null 2>&1 &
+  watchdog=$!
+  wait "$pid" 2>/dev/null
+  status=$?
+  kill -TERM "$watchdog" 2>/dev/null
+  wait "$watchdog" 2>/dev/null
+  PROBE_OUTPUT=$(cat "$output" 2>/dev/null)
+  [[ -e "$marker" ]] && status=124
+  rm -f -- "$output" "$marker"
+  return "$status"
+}
+
+# launcher_probe <dir> <launcher> <args...>: runs a package-manager launcher under
+# PROBE_TIMEOUT. On success PROBE_OUTPUT holds its first output line; otherwise
+# PROBE_ERROR names the launcher path and what went wrong.
+launcher_probe() {
+  local dir=$1 launcher=$2 path status
+  shift 2
+  PROBE_OUTPUT=""
+  PROBE_ERROR=""
+  path=$(command -v "$launcher" 2>/dev/null) || { PROBE_ERROR="$launcher is not on PATH"; return 1; }
+  run_bounded "$PROBE_TIMEOUT" "$dir" "$@"
+  status=$?
+  case "$status" in
+    0)
+      PROBE_OUTPUT=$(printf '%s\n' "$PROBE_OUTPUT" | head -n 1)
+      return 0
+      ;;
+    124)
+      PROBE_ERROR="'$*' did not finish within ${PROBE_TIMEOUT}s: the launcher $path re-invokes itself or stalls. Inspect that file (a valid launcher execs Corepack's dist/corepack.js, never itself), restore it or reinstall Node, then re-run"
+      return 1
+      ;;
+    *)
+      PROBE_ERROR="'$*' failed with exit $status via $path: $(printf '%s\n' "$PROBE_OUTPUT" | head -n 1)"
+      return 1
+      ;;
+  esac
+}
+
+host_platform() {
+  case "$(uname -s)" in
+    Darwin) echo darwin ;;
+    Linux) echo linux ;;
+    *) uname -s | tr '[:upper:]' '[:lower:]' ;;
+  esac
+}
+
+host_arch() {
+  case "$(uname -m)" in
+    x86_64|amd64) echo x64 ;;
+    arm64|aarch64) echo arm64 ;;
+    *) uname -m ;;
+  esac
+}
+
+# node-pty's loader (lib/utils.js) tries build/Release, build/Debug, then the
+# prebuild for this platform and architecture; node-pty is a Node-API addon, so
+# the same binary serves Node and Electron. An interrupted or script-less
+# install leaves node_modules without any of them.
+node_pty_binary() {
+  local dir="$FE_DIR/node_modules/node-pty" candidate
+  for candidate in \
+    "$dir/build/Release/pty.node" \
+    "$dir/build/Debug/pty.node" \
+    "$dir/prebuilds/$(host_platform)-$(host_arch)/pty.node"; do
+    if [[ -f "$candidate" ]]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
+frontend_dependencies_ready() {
+  [[ -d "$FE_DIR/node_modules" ]] && node_pty_binary >/dev/null
 }
 
 corepack_home() {
@@ -126,9 +259,8 @@ pnpm_ready() {
     done
     return 1
   fi
-  local actual
-  actual=$(cd "$FE_DIR" && COREPACK_ENABLE_DOWNLOAD_PROMPT=0 pnpm --version 2>/dev/null) || return 1
-  [[ "$actual" == "$PNPM_VERSION" ]]
+  COREPACK_ENABLE_DOWNLOAD_PROMPT=0 launcher_probe "$FE_DIR" pnpm pnpm --version || return 1
+  [[ "$PROBE_OUTPUT" == "$PNPM_VERSION" ]]
 }
 
 openssl_dev_ready() {
@@ -178,7 +310,7 @@ installable_gap_exists() {
   node_ready || return 0
   command -v corepack >/dev/null 2>&1 || return 0
   pnpm_ready || return 0
-  [[ -d "$FE_DIR/node_modules" ]] || return 0
+  frontend_dependencies_ready || return 0
   gh_ready || return 0
   return 1
 }
@@ -245,16 +377,21 @@ check_all() {
     missing "cargo-nextest: required by make test"
   fi
 
+  local node_found
   if node_ready; then
-    ok "Node: $(node --version) (>= 20)"
+    ok "Node: v$(node_version) (supported: $NODE_REQUIREMENT)"
+  elif node_found=$(node_version); then
+    missing "Node: v$node_found is unsupported; the frontend native build (node-gyp 13) needs Node $NODE_REQUIREMENT"
   else
-    missing "Node: version 20 or newer is required"
+    missing "Node: $NODE_REQUIREMENT is required (node-gyp 13 builds the frontend native modules)"
   fi
 
-  if command -v corepack >/dev/null 2>&1; then
-    ok "Corepack: $(corepack --version 2>/dev/null)"
-  else
+  if ! command -v corepack >/dev/null 2>&1; then
     missing "Corepack: required to select the frontend pnpm version"
+  elif launcher_probe "$ROOT_DIR" corepack corepack --version; then
+    ok "Corepack: $PROBE_OUTPUT"
+  else
+    missing "Corepack: $PROBE_ERROR"
   fi
 
   if [[ -z "$PACKAGE_MANAGER" ]]; then
@@ -265,10 +402,12 @@ check_all() {
     missing "frontend package manager: expected $PACKAGE_MANAGER via Corepack"
   fi
 
-  if [[ -d "$FE_DIR/node_modules" ]]; then
-    ok "frontend dependencies: packages/cloudlands-fe/node_modules present"
+  if [[ ! -d "$FE_DIR/node_modules" ]]; then
+    missing "frontend dependencies: run corepack pnpm install --frozen-lockfile in packages/cloudlands-fe"
+  elif node_pty_binary >/dev/null; then
+    ok "frontend dependencies: packages/cloudlands-fe/node_modules with node-pty built for $(host_platform)-$(host_arch)"
   else
-    missing "frontend dependencies: run corepack pnpm install --frozen-lockfile"
+    missing "frontend dependencies: node-pty has no pty.node for $(host_platform)-$(host_arch) under packages/cloudlands-fe/node_modules (interrupted or script-less install); run corepack pnpm install --frozen-lockfile, then corepack pnpm rebuild node-pty if it is still missing"
   fi
 
   local gh_found
@@ -418,11 +557,11 @@ install_rust() {
 
 install_node() {
   if node_ready; then
-    echo "[skip] Node $(node --version) satisfies >= 20"
+    echo "[skip] Node v$(node_version) is supported ($NODE_REQUIREMENT)"
     return
   fi
 
-  echo "[install] Node >= 20"
+  echo "[install] Node $NODE_INSTALL_MAJOR (supported: $NODE_REQUIREMENT)"
   case "$(uname -s)" in
     Darwin)
       command -v brew >/dev/null 2>&1 || { echo "ERROR: Homebrew is required to install Node on macOS" >&2; exit 1; }
@@ -432,19 +571,19 @@ install_node() {
       command -v curl >/dev/null 2>&1 || { echo "ERROR: curl is required to install Node" >&2; exit 1; }
       TEMP_FILE=$(mktemp "${TMPDIR:-/tmp}/nodesource.XXXXXX") || exit 1
       if command -v apt-get >/dev/null 2>&1; then
-        curl -fsSL https://deb.nodesource.com/setup_20.x -o "$TEMP_FILE" || exit 1
+        curl -fsSL "https://deb.nodesource.com/setup_$NODE_INSTALL_MAJOR.x" -o "$TEMP_FILE" || exit 1
         as_root bash "$TEMP_FILE" || exit 1
         as_root apt-get install -y nodejs || exit 1
       elif command -v dnf >/dev/null 2>&1; then
-        curl -fsSL https://rpm.nodesource.com/setup_20.x -o "$TEMP_FILE" || exit 1
+        curl -fsSL "https://rpm.nodesource.com/setup_$NODE_INSTALL_MAJOR.x" -o "$TEMP_FILE" || exit 1
         as_root bash "$TEMP_FILE" || exit 1
         as_root dnf install -y nodejs || exit 1
       elif command -v yum >/dev/null 2>&1; then
-        curl -fsSL https://rpm.nodesource.com/setup_20.x -o "$TEMP_FILE" || exit 1
+        curl -fsSL "https://rpm.nodesource.com/setup_$NODE_INSTALL_MAJOR.x" -o "$TEMP_FILE" || exit 1
         as_root bash "$TEMP_FILE" || exit 1
         as_root yum install -y nodejs || exit 1
       else
-        echo "ERROR: unsupported Linux package manager; install Node >= 20 and re-run" >&2
+        echo "ERROR: unsupported Linux package manager; install Node $NODE_REQUIREMENT and re-run" >&2
         exit 1
       fi
       rm -f -- "$TEMP_FILE"
@@ -518,6 +657,7 @@ install_frontend() {
     npm install --global corepack || as_root npm install --global corepack || exit 1
     hash -r
   fi
+  launcher_probe "$ROOT_DIR" corepack corepack --version || { echo "ERROR: Corepack: $PROBE_ERROR" >&2; exit 1; }
 
   if pnpm_ready; then
     echo "[skip] $PACKAGE_MANAGER already available via Corepack"
@@ -526,13 +666,18 @@ install_frontend() {
     corepack enable || as_root corepack enable || exit 1
     corepack install --global "$PACKAGE_MANAGER" || exit 1
     hash -r
+    pnpm_ready || { echo "ERROR: frontend package manager: expected $PACKAGE_MANAGER via Corepack${PROBE_ERROR:+; $PROBE_ERROR}" >&2; exit 1; }
   fi
 
-  if [[ -d "$FE_DIR/node_modules" ]]; then
+  if frontend_dependencies_ready; then
     echo "[skip] frontend dependencies already installed"
   else
     echo "[install] frontend dependencies"
     (cd "$FE_DIR" && corepack pnpm install --frozen-lockfile) || exit 1
+    if ! node_pty_binary >/dev/null; then
+      echo "[install] node-pty native module for $(host_platform)-$(host_arch)"
+      (cd "$FE_DIR" && corepack pnpm rebuild node-pty) || exit 1
+    fi
   fi
 }
 

--- a/scripts/bootstrap-dev-host.sh
+++ b/scripts/bootstrap-dev-host.sh
@@ -232,8 +232,34 @@ node_pty_binary() {
   return 1
 }
 
+# node_pty_loadable: the binary node-pty would pick must actually load on this
+# host. build/Release and build/Debug are not platform-specific paths, so a tree
+# copied from another machine (or a truncated build output) passes the file
+# check but fails dlopen at runtime. Loads it with node under PROBE_TIMEOUT;
+# on failure PROBE_ERROR says why.
+node_pty_loadable() {
+  local binary relative status reason
+  PROBE_ERROR=""
+  binary=$(node_pty_binary) || { PROBE_ERROR="node-pty has no pty.node for $(host_platform)-$(host_arch)"; return 1; }
+  relative=${binary#"$FE_DIR/node_modules/"}
+  command -v node >/dev/null 2>&1 || { PROBE_ERROR="node is not on PATH, so $relative cannot be load-tested"; return 1; }
+  run_bounded "$PROBE_TIMEOUT" "$FE_DIR" node -e 'require(process.argv[1])' "$binary"
+  status=$?
+  case "$status" in
+    0) return 0 ;;
+    124) PROBE_ERROR="loading $relative with node did not finish within ${PROBE_TIMEOUT}s" ;;
+    *)
+      reason=$(printf '%s\n' "$PROBE_OUTPUT" | grep '^Error: ' | head -n 1 | sed 's/^Error: //')
+      [[ -n "$reason" ]] || reason=$(printf '%s\n' "$PROBE_OUTPUT" | grep -v '^$' | head -n 1)
+      reason=${reason#"$binary: "}
+      PROBE_ERROR="node cannot load $relative (exit $status${reason:+: $reason})"
+      ;;
+  esac
+  return 1
+}
+
 frontend_dependencies_ready() {
-  [[ -d "$FE_DIR/node_modules" ]] && node_pty_binary >/dev/null
+  [[ -d "$FE_DIR/node_modules" ]] && node_pty_loadable
 }
 
 corepack_home() {
@@ -404,10 +430,12 @@ check_all() {
 
   if [[ ! -d "$FE_DIR/node_modules" ]]; then
     missing "frontend dependencies: run corepack pnpm install --frozen-lockfile in packages/cloudlands-fe"
-  elif node_pty_binary >/dev/null; then
-    ok "frontend dependencies: packages/cloudlands-fe/node_modules with node-pty built for $(host_platform)-$(host_arch)"
-  else
+  elif ! node_pty_binary >/dev/null; then
     missing "frontend dependencies: node-pty has no pty.node for $(host_platform)-$(host_arch) under packages/cloudlands-fe/node_modules (interrupted or script-less install); run corepack pnpm install --frozen-lockfile, then corepack pnpm rebuild node-pty if it is still missing"
+  elif node_pty_loadable; then
+    ok "frontend dependencies: packages/cloudlands-fe/node_modules with node-pty loadable on $(host_platform)-$(host_arch)"
+  else
+    missing "frontend dependencies: $PROBE_ERROR under packages/cloudlands-fe/node_modules (built for another platform or corrupted); run corepack pnpm rebuild node-pty in packages/cloudlands-fe"
   fi
 
   local gh_found
@@ -674,9 +702,10 @@ install_frontend() {
   else
     echo "[install] frontend dependencies"
     (cd "$FE_DIR" && corepack pnpm install --frozen-lockfile) || exit 1
-    if ! node_pty_binary >/dev/null; then
-      echo "[install] node-pty native module for $(host_platform)-$(host_arch)"
+    if ! node_pty_loadable; then
+      echo "[install] node-pty native module for $(host_platform)-$(host_arch): $PROBE_ERROR"
       (cd "$FE_DIR" && corepack pnpm rebuild node-pty) || exit 1
+      node_pty_loadable || { echo "ERROR: frontend dependencies: $PROBE_ERROR after corepack pnpm rebuild node-pty" >&2; exit 1; }
     fi
   fi
 }

--- a/scripts/bootstrap-dev-host.test.sh
+++ b/scripts/bootstrap-dev-host.test.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)
+script="$repo_root/scripts/bootstrap-dev-host.sh"
+temp_dir=$(mktemp -d)
+bin_dir="$temp_dir/bin"
+fixture="$temp_dir/repo"
+intentd_dir="$fixture/packages/intentd"
+fe_dir="$fixture/packages/cloudlands-fe"
+pty_dir="$fe_dir/node_modules/node-pty"
+output="$temp_dir/doctor.out"
+mkdir -p "$bin_dir" "$intentd_dir" "$pty_dir/lib" "$temp_dir/home"
+trap 'rm -rf "$temp_dir"' EXIT
+
+fail() {
+  echo "bootstrap-dev-host test failed: $*" >&2
+  if [[ -f "$output" ]]; then
+    echo "--- doctor output ---" >&2
+    cat "$output" >&2
+  fi
+  exit 1
+}
+
+bash -n "$script" || fail "script does not parse"
+bash --posix -n "$script" || fail "script does not parse under bash --posix"
+
+for command in bash cat cksum date dirname grep head id mktemp pgrep rm sed sleep tr uname; do
+  ln -s "$(command -v "$command")" "$bin_dir/$command"
+done
+
+: >"$intentd_dir/.git"
+: >"$fe_dir/.git"
+printf '{"packageManager": "pnpm@10.30.3"}\n' >"$fe_dir/package.json"
+
+write_launcher() {
+  printf '#!/usr/bin/env bash\n%s\n' "$2" >"$bin_dir/$1"
+  chmod +x "$bin_dir/$1"
+}
+
+set_node_version() {
+  write_launcher node "echo v$1"
+}
+
+host_platform=$(uname -s | tr '[:upper:]' '[:lower:]')
+case "$(uname -m)" in
+  x86_64|amd64) host_arch=x64 ;;
+  arm64|aarch64) host_arch=arm64 ;;
+  *) host_arch=$(uname -m) ;;
+esac
+
+set_pty_binaries() {
+  rm -rf "$pty_dir/build" "$pty_dir/prebuilds"
+  local path
+  for path in "$@"; do
+    mkdir -p "$pty_dir/$(dirname "$path")"
+    : >"$pty_dir/$path"
+  done
+}
+
+now_ms() {
+  python3 -c 'import time; print(time.monotonic_ns() // 1000000)'
+}
+
+run_doctor() {
+  local started finished
+  started=$(now_ms)
+  PATH="$bin_dir" HOME="$temp_dir/home" INTENTD_DIR="$intentd_dir" FE_DIR="$fe_dir" \
+    BOOTSTRAP_PROBE_TIMEOUT=2 bash "$script" --check >"$output" 2>&1 || true
+  finished=$(now_ms)
+  elapsed_ms=$((finished - started))
+}
+
+expect_line() {
+  grep -qF -- "$1" "$output" || fail "expected doctor output to contain: $1"
+}
+
+reject_line() {
+  ! grep -qF -- "$1" "$output" || fail "expected doctor output not to contain: $1"
+}
+
+# Healthy host: supported Node, a launcher that answers, node-pty built for this platform.
+set_node_version 24.19.0
+write_launcher corepack 'echo 0.35.0'
+set_pty_binaries build/Release/pty.node
+run_doctor
+expect_line "[ok]       Node: v24.19.0"
+expect_line "[ok]       Corepack: 0.35.0"
+expect_line "[ok]       frontend dependencies: packages/cloudlands-fe/node_modules with node-pty built for $host_platform-$host_arch"
+[[ "$elapsed_ms" -lt 5000 ]] || fail "healthy doctor took ${elapsed_ms}ms (expected under 5000ms)"
+
+# A Corepack launcher that re-invokes itself fails within the probe timeout and names its path.
+write_launcher corepack 'exec "$0" pnpm "$@"'
+run_doctor
+expect_line "[missing]  Corepack: 'corepack --version' did not finish within 2s: the launcher $bin_dir/corepack re-invokes itself or stalls."
+reject_line "[ok]       Corepack:"
+reject_line "Killed"
+[[ "$elapsed_ms" -lt 10000 ]] || fail "recursive launcher doctor took ${elapsed_ms}ms (expected under 10000ms)"
+! pgrep -f "$bin_dir/corepack" >/dev/null || fail "recursive corepack launcher was left running"
+
+# A stalled launcher is killed together with its children.
+stall_name="stalled-launcher-$(basename "$temp_dir")"
+write_launcher corepack "bash -c 'exec -a $stall_name sleep 6543'; exit 1"
+run_doctor
+expect_line "[missing]  Corepack: 'corepack --version' did not finish within 2s: the launcher $bin_dir/corepack"
+[[ "$elapsed_ms" -lt 10000 ]] || fail "stalled launcher doctor took ${elapsed_ms}ms (expected under 10000ms)"
+sleep 1
+! pgrep -f "$stall_name" >/dev/null || fail "stalled launcher's sleep child was left running"
+
+# A launcher that exits non-zero reports the exit status and its first output line.
+write_launcher corepack 'echo "SyntaxError: bad launcher" >&2; exit 1'
+run_doctor
+expect_line "[missing]  Corepack: 'corepack --version' failed with exit 1 via $bin_dir/corepack: SyntaxError: bad launcher"
+
+# node_modules without a pty.node for this platform is an incomplete install, not a pass.
+write_launcher corepack 'echo 0.35.0'
+set_pty_binaries
+run_doctor
+expect_line "[missing]  frontend dependencies: node-pty has no pty.node for $host_platform-$host_arch under packages/cloudlands-fe/node_modules"
+expect_line "corepack pnpm install --frozen-lockfile, then corepack pnpm rebuild node-pty"
+
+# Prebuilds for other platforms do not count; the host's own prebuild does.
+set_pty_binaries prebuilds/win32-x64/pty.node prebuilds/win32-arm64/pty.node
+run_doctor
+expect_line "[missing]  frontend dependencies: node-pty has no pty.node for $host_platform-$host_arch"
+set_pty_binaries "prebuilds/$host_platform-$host_arch/pty.node"
+run_doctor
+expect_line "[ok]       frontend dependencies: packages/cloudlands-fe/node_modules with node-pty built for $host_platform-$host_arch"
+
+# No node_modules at all keeps the install hint.
+mv "$fe_dir/node_modules" "$temp_dir/node_modules.bak"
+run_doctor
+expect_line "[missing]  frontend dependencies: run corepack pnpm install --frozen-lockfile in packages/cloudlands-fe"
+mv "$temp_dir/node_modules.bak" "$fe_dir/node_modules"
+
+# Node floor follows node-gyp 13's engines: ^22.22.2 || ^24.15.0 || >=26.0.0.
+for version in 20.20.2 22.20.0 24.14.9 25.1.0; do
+  set_node_version "$version"
+  run_doctor
+  expect_line "[missing]  Node: v$version is unsupported; the frontend native build (node-gyp 13) needs Node 22.22.2+, 24.15.0+ (recommended) or 26+"
+done
+for version in 22.22.2 24.15.0 26.0.0; do
+  set_node_version "$version"
+  run_doctor
+  expect_line "[ok]       Node: v$version (supported: 22.22.2+, 24.15.0+ (recommended) or 26+)"
+done
+
+rm -f "$bin_dir/node"
+run_doctor
+expect_line "[missing]  Node: 22.22.2+, 24.15.0+ (recommended) or 26+ is required"
+
+echo "bootstrap-dev-host tests passed"

--- a/scripts/bootstrap-dev-host.test.sh
+++ b/scripts/bootstrap-dev-host.test.sh
@@ -39,8 +39,11 @@ write_launcher() {
   chmod +x "$bin_dir/$1"
 }
 
+# The node shim answers --version with the version under test and hands
+# everything else (the pty.node load probe) to the real node.
+real_node=$(command -v node) || fail "a real node is required to exercise the pty.node load probe"
 set_node_version() {
-  write_launcher node "echo v$1"
+  write_launcher node "[ \"\$1\" = --version ] && { echo v$1; exit 0; }; exec \"$real_node\" \"\$@\""
 }
 
 host_platform=$(uname -s | tr '[:upper:]' '[:lower:]')
@@ -50,12 +53,50 @@ case "$(uname -m)" in
   *) host_arch=$(uname -m) ;;
 esac
 
+# A loadable pty.node cannot be fabricated without a compiler; use the one the
+# repository's frontend checkout built for this host when it exists. Any
+# bundled prebuild for another platform serves as the foreign binary, with a
+# Mach-O header as the stand-in when none is bundled.
+loadable_pty=""
+foreign_pty=""
+for candidate in \
+  "$repo_root/packages/cloudlands-fe/node_modules/node-pty/build/Release/pty.node" \
+  "$repo_root/packages/cloudlands-fe/node_modules/node-pty/prebuilds/$host_platform-$host_arch/pty.node"; do
+  if [[ -z "$loadable_pty" && -f "$candidate" ]]; then
+    loadable_pty=$candidate
+  fi
+done
+for candidate in "$repo_root"/packages/cloudlands-fe/node_modules/node-pty/prebuilds/*/pty.node; do
+  case "$candidate" in
+    */"$host_platform-$host_arch"/*) ;;
+    *)
+      if [[ -z "$foreign_pty" && -f "$candidate" ]]; then
+        foreign_pty=$candidate
+      fi
+      ;;
+  esac
+done
+if [[ -z "$foreign_pty" ]]; then
+  foreign_pty="$temp_dir/foreign-pty.node"
+  printf '\317\372\355\376\007\000\000\001\003\000\000\000' >"$foreign_pty"
+fi
+
+# set_pty_binaries [source=]path...: installs each path under node_modules/node-pty,
+# copied from source when given and empty otherwise.
 set_pty_binaries() {
   rm -rf "$pty_dir/build" "$pty_dir/prebuilds"
-  local path
-  for path in "$@"; do
+  local entry source path
+  for entry in "$@"; do
+    case "$entry" in
+      *=*) source=${entry%%=*}; path=${entry#*=} ;;
+      *) source=""; path=$entry ;;
+    esac
     mkdir -p "$pty_dir/$(dirname "$path")"
-    : >"$pty_dir/$path"
+    if [[ -n "$source" ]]; then
+      cp "$source" "$pty_dir/$path"
+    else
+      : >"$pty_dir/$path"
+    fi
   done
 }
 
@@ -80,14 +121,23 @@ reject_line() {
   ! grep -qF -- "$1" "$output" || fail "expected doctor output not to contain: $1"
 }
 
-# Healthy host: supported Node, a launcher that answers, node-pty built for this platform.
+ok_dependencies="[ok]       frontend dependencies: packages/cloudlands-fe/node_modules with node-pty loadable on $host_platform-$host_arch"
+
+# Healthy host: supported Node, a launcher that answers, node-pty loadable on this platform.
 set_node_version 24.19.0
 write_launcher corepack 'echo 0.35.0'
-set_pty_binaries build/Release/pty.node
+if [[ -n "$loadable_pty" ]]; then
+  set_pty_binaries "$loadable_pty=build/Release/pty.node"
+else
+  echo "bootstrap-dev-host tests: no built pty.node in packages/cloudlands-fe/node_modules; loadable-binary assertions skipped" >&2
+  set_pty_binaries build/Release/pty.node
+fi
 run_doctor
 expect_line "[ok]       Node: v24.19.0"
 expect_line "[ok]       Corepack: 0.35.0"
-expect_line "[ok]       frontend dependencies: packages/cloudlands-fe/node_modules with node-pty built for $host_platform-$host_arch"
+if [[ -n "$loadable_pty" ]]; then
+  expect_line "$ok_dependencies"
+fi
 [[ "$elapsed_ms" -lt 5000 ]] || fail "healthy doctor took ${elapsed_ms}ms (expected under 5000ms)"
 
 # A Corepack launcher that re-invokes itself fails within the probe timeout and names its path.
@@ -124,9 +174,31 @@ expect_line "corepack pnpm install --frozen-lockfile, then corepack pnpm rebuild
 set_pty_binaries prebuilds/win32-x64/pty.node prebuilds/win32-arm64/pty.node
 run_doctor
 expect_line "[missing]  frontend dependencies: node-pty has no pty.node for $host_platform-$host_arch"
-set_pty_binaries "prebuilds/$host_platform-$host_arch/pty.node"
+if [[ -n "$loadable_pty" ]]; then
+  set_pty_binaries "$loadable_pty=prebuilds/$host_platform-$host_arch/pty.node"
+  run_doctor
+  expect_line "$ok_dependencies"
+fi
+
+# A pty.node that exists but cannot be loaded (truncated build output) is a gap, not a pass.
+set_pty_binaries build/Release/pty.node
 run_doctor
-expect_line "[ok]       frontend dependencies: packages/cloudlands-fe/node_modules with node-pty built for $host_platform-$host_arch"
+expect_line "[missing]  frontend dependencies: node cannot load node-pty/build/Release/pty.node (exit 1: "
+expect_line "(built for another platform or corrupted); run corepack pnpm rebuild node-pty in packages/cloudlands-fe"
+reject_line "[ok]       frontend dependencies:"
+
+# A binary built for another platform in the generic build/Release path is a gap too.
+set_pty_binaries "$foreign_pty=build/Release/pty.node"
+run_doctor
+expect_line "[missing]  frontend dependencies: node cannot load node-pty/build/Release/pty.node (exit 1: "
+reject_line "[ok]       frontend dependencies:"
+
+# The load probe is bounded like the launcher probes.
+write_launcher node "[ \"\$1\" = --version ] && { echo v24.19.0; exit 0; }; exec sleep 6543"
+run_doctor
+expect_line "[missing]  frontend dependencies: loading node-pty/build/Release/pty.node with node did not finish within 2s"
+[[ "$elapsed_ms" -lt 10000 ]] || fail "stalled load probe doctor took ${elapsed_ms}ms (expected under 10000ms)"
+set_node_version 24.19.0
 
 # No node_modules at all keeps the install hint.
 mv "$fe_dir/node_modules" "$temp_dir/node_modules.bak"


### PR DESCRIPTION
`make doctor` / `make bootstrap-dev-host` could hang forever on a Corepack launcher that re-invokes itself (#4635) and reported success on a frontend install whose native build had failed, after accepting a Node that node-gyp 13 cannot run on (#4669). Both targets now fail fast and truthfully. Monorepo only: `scripts/bootstrap-dev-host.sh` plus a new hermetic test.

## Changes

**(a) Bounded launcher probes.** `corepack --version` (doctor and the install path, before `corepack enable`/`corepack install`) and `pnpm --version` (install path) run through `run_bounded`, a Bash 3.2-compatible watchdog (no `timeout(1)`, `mapfile` or associative arrays): the probe runs with stdin closed, and after `BOOTSTRAP_PROBE_TIMEOUT` seconds (default 20) its whole process tree is stopped and killed (`kill -STOP` + `pgrep -P` recursion + `kill -KILL`). The doctor line names the launcher path and what to do; the install path exits with the same message instead of proceeding to `corepack install`.

**(b) Real native-module check.** The `node_modules` presence check is replaced by two steps. First, the lookup node-pty's own loader performs (`lib/utils.js`): `build/Release/pty.node`, `build/Debug/pty.node`, or `prebuilds/<platform>-<arch>/pty.node` for *this* host; bundled prebuilds for other platforms (node-pty ships darwin/win32 only) do not count — that is what let `dev-launcher.mjs`'s `hasBinary` miss the gap on Linux. Second, the selected binary is actually loaded — `node -e 'require(<pty.node>)'` under the same watchdog (`node_pty_loadable`) — because `build/Release` / `build/Debug` are not platform-specific paths and a tree copied from another host, or a truncated build output, passes a file check and fails `dlopen` at runtime. node-pty is a Node-API addon, so the same binary serves Node and Electron. An unloadable binary is a gap naming the file and node's reason (`file too short`, `invalid ELF header`, …); `bootstrap-dev-host` repairs a partial tree with `corepack pnpm install --frozen-lockfile`, then `corepack pnpm rebuild node-pty` when the binary is still missing or unloadable, and fails if it still does not load afterwards.

**(c) Node floor.** `node_ready` now requires **`^22.22.2 || ^24.15.0 || >=26.0.0`** — the `engines.node` of `node-gyp@13.0.2`, the version the pinned lockfile resolves for the node-pty / cpu-features install scripts (`node_modules/node-gyp/package.json`); its `undici` dependency is what throws `webidl.util.markAsUncloneable is not a function` on Node 20. Odd majors (23, 25) are outside that range and are rejected too. The NodeSource installer provisions Node 24 to match fe CI (`intent-pr.yml` uses `node-version: '24'`); Homebrew keeps `brew install node` (current, ≥ 26). `docs/fe/DEVELOPER_GUIDE.md`'s "Node.js 18+" prerequisite is updated to match.

Test seams: `INTENTD_DIR` / `FE_DIR` env overrides (same convention as `dev-sandbox.sh`) and `BOOTSTRAP_PROBE_TIMEOUT`.

## Fixture transcripts

1. Deliberately recursive `corepack` on PATH (the #4635 shape), `BOOTSTRAP_PROBE_TIMEOUT=5`:

```
#!/usr/bin/env bash
exec "$0" pnpm "$@"
[missing]  Corepack: 'corepack --version' did not finish within 5s: the launcher /tmp/doctor-fixture.CZy4mc/bin/corepack re-invokes itself or stalls. Inspect that file (a valid launcher execs Corepack's dist/corepack.js, never itself), restore it or reinstall Node, then re-run
Doctor found 1 required gap(s).
exit=1
elapsed: 6s; leftover launcher processes: 0
```

2. `node_modules/node-pty` present without a `pty.node` (interrupted install):

```
[missing]  frontend dependencies: node-pty has no pty.node for linux-x64 under packages/cloudlands-fe/node_modules (interrupted or script-less install); run corepack pnpm install --frozen-lockfile, then corepack pnpm rebuild node-pty if it is still missing
Doctor found 1 required gap(s).
exit=1
```

2b. `build/Release/pty.node` present but unloadable — empty file, then the bundled `darwin-arm64` prebuild copied into the generic path (this host is linux-x64):

```
[missing]  frontend dependencies: node cannot load node-pty/build/Release/pty.node (exit 1: file too short) under packages/cloudlands-fe/node_modules (built for another platform or corrupted); run corepack pnpm rebuild node-pty in packages/cloudlands-fe
Doctor found 1 required gap(s).
exit=1
```

```
[missing]  frontend dependencies: node cannot load node-pty/build/Release/pty.node (exit 1: invalid ELF header) under packages/cloudlands-fe/node_modules (built for another platform or corrupted); run corepack pnpm rebuild node-pty in packages/cloudlands-fe
Doctor found 1 required gap(s).
exit=1
```

3. Node 20 on PATH:

```
[missing]  Node: v20.20.2 is unsupported; the frontend native build (node-gyp 13) needs Node 22.22.2+, 24.15.0+ (recommended) or 26+
Doctor found 1 required gap(s).
exit=1
```

4. Healthy host (real PATH and checkout, Node v24.19.0, Corepack 0.35.0):

```
[ok]       Node: v24.19.0 (supported: 22.22.2+, 24.15.0+ (recommended) or 26+)
[ok]       Corepack: 0.35.0
[ok]       frontend package manager: pnpm@10.30.3 via Corepack
[ok]       frontend dependencies: packages/cloudlands-fe/node_modules with node-pty loadable on linux-x64
Doctor passed: this host is ready for intentd + cloudlands-fe development.
exit=0
```

Note on 4: before this change the same host's checkout had **no** Linux `pty.node` (only the bundled darwin/win32 prebuilds) while the old doctor passed; the new check reported the gap, and the suggested `corepack pnpm rebuild node-pty` fixed it in 2 s — i.e. the false positive from #4669 was live here too.

## Verification

- `bash -n scripts/bootstrap-dev-host.sh` and `bash --posix -n scripts/bootstrap-dev-host.sh` pass.
- `bash scripts/bootstrap-dev-host.test.sh` (new, ~8 s, hermetic PATH; added to the `shell-tests` CI job): healthy host, recursive launcher (fails within the bound, names the path, no leftover process, no bash "Killed" noise), stalled launcher with a child (child killed too), non-zero launcher, missing/foreign-prebuild/host `pty.node`, empty `build/Release/pty.node` (gap), foreign-platform binary in `build/Release` (gap), stalled load probe (bounded), no `node_modules`, Node 20.20.2 / 22.20.0 / 24.14.9 / 25.1.0 rejected, 22.22.2 / 24.15.0 / 26.0.0 accepted, no `node`. The fixture's `node` shim answers `--version` with the version under test and delegates the load probe to the real `node`; the loadable-binary assertions use the checkout's own built `pty.node` and are skipped (with a notice) when the frontend has not been installed, as on the CI runner.
- `bash scripts/dev-status.test.sh` and `bash scripts/docs-check.test.sh` still pass; `dev-status.sh` captures doctor output in ~1.4 s (the watchdog's stdio is detached so no orphaned `sleep` holds the pipe).
- `make doctor` (via `INTENTD_DIR`/`FE_DIR` pointing at the initialized checkout) passes — transcript 4.

Fixes #4669
Fixes #4635

