### PR TITLE
docs(releasing): notifier requires a closed issue with a delivered closing PR

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -135,19 +135,21 @@ cloudlands-fe).
   pre-filter that nominates candidates; the gate decides. A comment is posted only
   when **both** hold: (1) at least one PR linked to the issue via a GitHub closing
   keyword (`Fixes intent-hq/intent#N` — what `closedByPullRequestsReferences`
-  reports) is merged and contained in the release, with every other in-scope linked
-  fix PR also merged and contained; and (2) the issue is closed at release time. A
-  PR or commit that merely *mentions* the issue is not evidence of a fix — the
-  notifier stays silent on mention-only references, and an open issue never gets a
-  comment even when a linked PR is delivered. The gates differ in scope: intentd's
-  gate is component-scoped — it checks only intentd-linked fix PRs against the
-  released intentd tag (an intentd release still comments while an fe-side fix PR is
-  open); cloudlands-fe's gate is cross-repo — fe PRs must be contained in the fe tag
-  AND intentd PRs in the bundled intentd tag, making the fe comment the user-facing
-  availability signal. Any in-scope open or not-yet-contained linked fix PR → skip; a
-  later release whose scan re-references the issue picks it up. When completeness
-  cannot be determined (API error, token cannot see a repo), the notifier skips with
-  a warning rather than post a possibly-false claim.
+  reports) is merged and contained in the release, no in-scope linked fix PR is
+  still open, and every merged in-scope linked fix PR is contained (linked PRs that
+  were closed without merging are abandoned and ignored); and (2) the issue is
+  closed at release time. A PR or commit that merely *mentions* the issue is not
+  evidence of a fix — the notifier stays silent on mention-only references, and an
+  open issue never gets a comment even when a linked PR is delivered. The gates
+  differ in scope: intentd's gate is component-scoped — it checks only
+  intentd-linked fix PRs against the released intentd tag (an intentd release still
+  comments while an fe-side fix PR is open); cloudlands-fe's gate is cross-repo — fe
+  PRs must be contained in the fe tag AND intentd PRs in the bundled intentd tag,
+  making the fe comment the user-facing availability signal. Any in-scope open or
+  not-yet-contained linked fix PR → skip; a later release whose scan re-references
+  the issue picks it up. When completeness cannot be determined (API error, token
+  cannot see a repo), the notifier skips with a warning rather than post a
+  possibly-false claim.
 - Comments embed a hidden per-component/version marker, so tag rebuilds and workflow
   re-runs never double-post. `--dry-run` prints intended comments without posting.
 - Posting uses the `MONOREPO_ISSUES_TOKEN` secret (issues:write on

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -131,18 +131,23 @@ cloudlands-fe).
 - Comments never name a channel and there are no beta/stable promotion comments.
   intentd posts "This fix is included in intentd vX.Y.Z."; cloudlands-fe posts
   "This fix is included in cloudlands-fe vX.Y.Z (bundles intentd vA.B.C)."
-- Completeness gate ("stay silent until complete"): a comment is posted only when
-  every linked fix PR the gate considers is merged and contained. The gates differ
-  in scope: intentd's gate is component-scoped — it checks only intentd-linked fix
-  PRs against the released intentd tag (an intentd release still comments while an
-  fe-side fix PR is open); cloudlands-fe's gate is cross-repo — fe PRs must be
-  contained in the fe tag AND intentd PRs in the bundled intentd tag, making the fe
-  comment the user-facing availability signal. Any in-scope open or
-  not-yet-contained linked fix PR → skip; a later release whose scan re-references
-  the issue picks it up. When completeness cannot be determined (API error, token
-  cannot see a repo), the notifier skips with a warning rather than post a
-  possibly-false claim. Issues with no linked fix PRs at all fall back to the
-  range-scan evidence (best effort).
+- Completeness gate ("stay silent until complete"): the range scan is only a cheap
+  pre-filter that nominates candidates; the gate decides. A comment is posted only
+  when **both** hold: (1) at least one PR linked to the issue via a GitHub closing
+  keyword (`Fixes intent-hq/intent#N` — what `closedByPullRequestsReferences`
+  reports) is merged and contained in the release, with every other in-scope linked
+  fix PR also merged and contained; and (2) the issue is closed at release time. A
+  PR or commit that merely *mentions* the issue is not evidence of a fix — the
+  notifier stays silent on mention-only references, and an open issue never gets a
+  comment even when a linked PR is delivered. The gates differ in scope: intentd's
+  gate is component-scoped — it checks only intentd-linked fix PRs against the
+  released intentd tag (an intentd release still comments while an fe-side fix PR is
+  open); cloudlands-fe's gate is cross-repo — fe PRs must be contained in the fe tag
+  AND intentd PRs in the bundled intentd tag, making the fe comment the user-facing
+  availability signal. Any in-scope open or not-yet-contained linked fix PR → skip; a
+  later release whose scan re-references the issue picks it up. When completeness
+  cannot be determined (API error, token cannot see a repo), the notifier skips with
+  a warning rather than post a possibly-false claim.
 - Comments embed a hidden per-component/version marker, so tag rebuilds and workflow
   re-runs never double-post. `--dry-run` prints intended comments without posting.
 - Posting uses the `MONOREPO_ISSUES_TOKEN` secret (issues:write on


### PR DESCRIPTION
Docs-only. Updates `docs/RELEASING.md` so the release-notifier description matches the tightened completeness gate: a "This fix is included in …" comment requires the `intent-hq/intent` issue to be **closed** and to have at least one **merged, tag-contained closing-linked PR** in the gated repo(s). Mention-only references and open issues never post; abandoned (closed-unmerged) closing PRs are ignored.

The behavioural change lands in the two submodule PRs:

- intent-hq/intentd#1806
- intent-hq/cloudlands-fe#2394

No `packages/*` gitlink moves are included in this branch.
