### PR TITLE
feat(scripts): shipped-in accepts multiple component/sha pairs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -277,18 +277,18 @@ guardrails) lives in [docs/RELEASING.md](./docs/RELEASING.md). The agent-facing 
   is the cloudlands-fe `intentd.version` pin under the emergency-release procedure
   in [docs/RELEASING.md](./docs/RELEASING.md).
 - **Track shipped work**: a workspace that changed intentd and/or cloudlands-fe is NOT
-  done when the PRs merge — monitor until the work ships in a cloudlands-fe alpha,
-  then update the final workspace status message with the carrying version (e.g.
-  "Shipped in cloudlands-fe vX.Y.Z (alpha)."). intentd-only changes ride the chained
-  cloudlands-fe alpha too, so the version to report is always the cloudlands-fe tag.
-  `scripts/shipped-in.sh <intentd|cloudlands-fe> <squash-commit-sha>` (or
-  `make shipped-in COMPONENT=... SHA=...`) is the canonical detector: it prints the
+  done when the PRs merge — monitor until the work ships in a cloudlands-fe alpha, then
+  set the final workspace status message to the carrying version (e.g. "Shipped in
+  cloudlands-fe vX.Y.Z (alpha)."; intentd-only changes ride the chained fe alpha, so the
+  version is always the cloudlands-fe tag). `scripts/shipped-in.sh <component> <sha>...`
+  (one or more pairs; or `make shipped-in COMPONENT=... SHA=...` /
+  `PAIRS="intentd:<sha> cloudlands-fe:<sha>"`) is the canonical detector: it prints the
   first [intent-hq/cloudlands-releases](https://github.com/intent-hq/cloudlands-releases)
-  tag carrying the commit (for intentd, via the `intentdVersion` pin in that tag's
-  `release-manifest.json`), exits 3 while nothing carries it yet, and exits 4 on a
-  transient GitHub failure (rate limit, 5xx, network) that the next poll should
-  simply retry. Never block a turn polling — schedule this hook after replacing
-  the placeholders:
+  tag carrying every listed commit (for intentd, via the `intentdVersion` pin in that
+  tag's `release-manifest.json`), exits 3 while any is still uncarried, and exits 4 on a
+  transient GitHub failure (rate limit, 5xx, network) the next poll should simply retry.
+  Never block a turn polling — schedule this hook after replacing the placeholders
+  (drop the pair for a component you did not change):
 
   ```javascript
   await ws.hook.schedule({
@@ -296,7 +296,7 @@ guardrails) lives in [docs/RELEASING.md](./docs/RELEASING.md). The agent-facing 
     delayMs: 600_000,
     ttlMs: 21_600_000,
     code: `const run = await ws.host.exec({
-    command: "scripts/shipped-in.sh", args: ["<COMPONENT>", "<SHA>"], timeoutMs: 120_000,
+    command: "scripts/shipped-in.sh", args: ["intentd", "<INTENTD_SHA>", "cloudlands-fe", "<FE_SHA>"], timeoutMs: 120_000,
   });
   if (run.exitCode === 0) return { dispatch: true, message: "Shipped in cloudlands-fe " + run.stdout.trim() };
   if (run.exitCode === 3 || run.exitCode === 4) return { dispatch: false };

--- a/Makefile
+++ b/Makefile
@@ -109,14 +109,24 @@ status: ## Show host, ports, sandboxes, and submodule/PR state (STATUS_JSON=1 fo
 docs-check: ## Check documented development targets, knobs, and remote-host guidance
 	@scripts/docs-check.sh
 
-# Release tracking: which cloudlands-releases alpha first carries a merged
-# commit. The script exits 3 for "not shipped yet" and 4 for a transient
-# GitHub failure (rate limit, 5xx, network) worth retrying (make reports them
-# as `Error 3` / `Error 4`); background hooks should invoke
-# scripts/shipped-in.sh directly so they can branch on those codes. `LIMIT=N`
-# widens the scan window past the newest 10 releases.
-shipped-in: ## Print the first cloudlands-releases tag carrying COMPONENT=intentd|cloudlands-fe SHA=<commit> (script exit 3 = not yet, 4 = transient gh failure)
-	@scripts/shipped-in.sh "$(COMPONENT)" "$(SHA)" $(if $(LIMIT),--limit "$(LIMIT)",)
+# Release tracking: which cloudlands-releases alpha first carries one or more
+# merged commits. Pass one pair as COMPONENT=... SHA=..., or several as
+# PAIRS="intentd:<sha> cloudlands-fe:<sha>" (space-separated component:sha
+# tokens, forwarded as positional pairs; the tag must carry every pair). The
+# script exits 3 for "not shipped yet" and 4 for a transient GitHub failure
+# (rate limit, 5xx, network) worth retrying (make reports them as `Error 3` /
+# `Error 4`); background hooks should invoke scripts/shipped-in.sh directly so
+# they can branch on those codes. `LIMIT=N` widens the scan window past the
+# newest 10 releases.
+shipped-in: ## Print the first cloudlands-releases tag carrying COMPONENT=intentd|cloudlands-fe SHA=<commit>, or every pair in PAIRS="intentd:<sha> cloudlands-fe:<sha>" (script exit 3 = not yet, 4 = transient gh failure)
+	@set -- $(if $(COMPONENT)$(SHA),"$(COMPONENT)" "$(SHA)",); \
+	for pair in $(PAIRS); do \
+		case "$$pair" in \
+			*:*) set -- "$$@" "$${pair%%:*}" "$${pair#*:}" ;; \
+			*) echo "shipped-in: PAIRS entries must be <component>:<sha>, got '$$pair'" >&2; exit 2 ;; \
+		esac; \
+	done; \
+	scripts/shipped-in.sh "$$@" $(if $(LIMIT),--limit "$(LIMIT)",)
 
 # Build-artifact GC (cargo-sweep). Rust target/ dirs grow without bound as
 # deps and toolchains churn; `sweep` prunes artifacts older than SWEEP_DAYS

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -175,6 +175,8 @@ cloudlands-fe stable promotion is followed by a website release notes PR on
   [intent-hq/cloudlands-releases](https://github.com/intent-hq/cloudlands-releases)
   distribution repo (same tag) — cloudlands-fe source-repo releases carry no assets.
   `scripts/shipped-in.sh intentd <sha>` (`make shipped-in`) performs this lookup and
-  prints the first cloudlands-releases tag whose pin carries the commit.
+  prints the first cloudlands-releases tag whose pin carries the commit; given several
+  `<component> <sha>` pairs (`make shipped-in PAIRS="intentd:<sha> cloudlands-fe:<sha>"`)
+  it prints the first tag carrying all of them.
 - Commits merged after the release PR was cut ride the next release PR (e.g. intentd#517
   landed via follow-up release PR intentd#520).

--- a/scripts/shipped-in.sh
+++ b/scripts/shipped-in.sh
@@ -1,20 +1,25 @@
 #!/usr/bin/env bash
-# Print the first intent-hq/cloudlands-releases tag that carries a merged commit.
+# Print the first intent-hq/cloudlands-releases tag that carries one or more
+# merged commits.
 #
-#   scripts/shipped-in.sh <intentd|cloudlands-fe> <commit-sha> [--limit N]
+#   scripts/shipped-in.sh <intentd|cloudlands-fe> <commit-sha> \
+#     [<intentd|cloudlands-fe> <commit-sha>]... [--limit N]
 #
-# cloudlands-fe: the tag carries the commit when the GitHub compare
+# Each `<component> <commit-sha>` pair is checked independently; the same
+# component may appear more than once with different SHAs.
+# cloudlands-fe: a tag carries the commit when the GitHub compare
 # `<sha>...<tag>` on intent-hq/cloudlands-fe reports `ahead` or `identical`.
 # intentd: each tag's release-manifest.json names the pinned `intentdVersion`;
 # the tag carries the commit when `<sha>...v<intentdVersion>` on
 # intent-hq/intentd reports `ahead` or `identical`. `behind` and `diverged`
 # never count. The newest N releases are scanned (default 10) and the oldest
-# carrying tag is printed as `<tag> intentdVersion=<version>`.
+# tag carrying EVERY pair is printed as `<tag> intentdVersion=<version>`.
 #
-# Exit codes: 0 = printed a carrying tag; 3 = no scanned release carries the
-# commit yet (stdout empty); 4 = transient GitHub failure (rate limit, 5xx,
-# network) -- retry later; 2 = usage error; 1 = any other gh/API or manifest
-# failure. gh's own error text is appended to the message on 1 and 4.
+# Exit codes: 0 = printed a carrying tag; 3 = no scanned release carries every
+# pair yet (stdout empty; stderr names the pairs the newest scanned release
+# misses); 4 = transient GitHub failure (rate limit, 5xx, network) -- retry
+# later; 2 = usage error; 1 = any other gh/API or manifest failure. gh's own
+# error text is appended to the message on 1 and 4.
 
 set -euo pipefail
 
@@ -23,13 +28,13 @@ fe_repo=intent-hq/cloudlands-fe
 intentd_repo=intent-hq/intentd
 
 usage() {
-  echo "Usage: $0 <intentd|cloudlands-fe> <commit-sha> [--limit N]" >&2
+  echo "Usage: $0 <intentd|cloudlands-fe> <commit-sha> [<intentd|cloudlands-fe> <commit-sha>]... [--limit N]" >&2
   exit 2
 }
 
-component=${1:-}
-sha=${2:-}
-[[ -n "$component" && -n "$sha" ]] || usage
+components=("${1:-}")
+shas=("${2:-}")
+[[ -n "${components[0]}" && -n "${shas[0]}" ]] || usage
 shift 2
 limit=10
 while (($# > 0)); do
@@ -44,16 +49,24 @@ while (($# > 0)); do
       [[ "$limit" =~ ^[1-9][0-9]*$ ]] || usage
       shift
       ;;
-    *) usage ;;
+    -*) usage ;;
+    *)
+      (($# >= 2)) || usage
+      components+=("$1")
+      shas+=("$2")
+      shift 2
+      ;;
   esac
 done
 
-case "$component" in
-  intentd) compare_repo=$intentd_repo ;;
-  cloudlands-fe) compare_repo=$fe_repo ;;
-  *) usage ;;
-esac
-[[ "$sha" =~ ^[0-9a-fA-F]{7,40}$ ]] || usage
+pair_count=${#components[@]}
+for ((i = 0; i < pair_count; i++)); do
+  case "${components[i]}" in
+    intentd | cloudlands-fe) ;;
+    *) usage ;;
+  esac
+  [[ "${shas[i]}" =~ ^[0-9a-fA-F]{7,40}$ ]] || usage
+done
 
 fail() {
   echo "shipped-in: $*" >&2
@@ -79,9 +92,9 @@ gh_fail() {
 }
 
 compare_status() {
-  local head=$1 status
-  status=$(gh api "repos/$compare_repo/compare/$sha...$head" --jq .status 2>"$gh_err") ||
-    gh_fail "gh api compare $sha...$head on $compare_repo failed"
+  local repo=$1 sha=$2 head=$3 status
+  status=$(gh api "repos/$repo/compare/$sha...$head" --jq .status 2>"$gh_err") ||
+    gh_fail "gh api compare $sha...$head on $repo failed"
   printf '%s\n' "$status"
 }
 
@@ -134,23 +147,53 @@ while IFS= read -r tag; do
 done < <(grep -E '^v[0-9]+\.[0-9]+\.[0-9]+' <<<"$release_list" | head -n "$limit" || true)
 ((${#tags[@]} > 0)) || fail "gh release list on $releases_repo returned no vX.Y.Z tags"
 
+# A single pair is reported by its sha alone; several pairs by component + sha.
+describe_pair() {
+  if ((pair_count == 1)); then
+    printf '%s\n' "${shas[$1]}"
+  else
+    printf '%s %s\n' "${components[$1]}" "${shas[$1]}"
+  fi
+}
+
+has_intentd=0
+for ((i = 0; i < pair_count; i++)); do
+  [[ "${components[i]}" != intentd ]] || has_intentd=1
+done
+
+# Several tags pin the same intentd version, so intentd compares are cached
+# per "<sha>:<version>" -- two intentd pairs never share a status.
 intentd_status=""
 first_hit=""
+newest_uncarried=""
 for tag in "${tags[@]}"; do
-  if [[ "$component" == intentd ]]; then
+  version=""
+  if ((has_intentd)); then
     version=$(manifest_version "$tag")
-    if ! status=$(cache_get "$intentd_status" "$version"); then
-      status=$(compare_status "v$version")
-      intentd_status+="$version $status"$'\n'
-    fi
-  else
-    status=$(compare_status "$tag")
   fi
-  carries "$status" && first_hit=$tag
+  uncarried=""
+  for ((i = 0; i < pair_count; i++)); do
+    if [[ "${components[i]}" == intentd ]]; then
+      if ! status=$(cache_get "$intentd_status" "${shas[i]}:$version"); then
+        status=$(compare_status "$intentd_repo" "${shas[i]}" "v$version")
+        intentd_status+="${shas[i]}:$version $status"$'\n'
+      fi
+    else
+      status=$(compare_status "$fe_repo" "${shas[i]}" "$tag")
+    fi
+    carries "$status" || uncarried+="${uncarried:+, }$(describe_pair "$i")"
+  done
+  if [[ -z "$uncarried" ]]; then
+    first_hit=$tag
+  elif [[ "$tag" == "${tags[0]}" ]]; then
+    newest_uncarried=$uncarried
+  fi
 done
 
 if [[ -z "$first_hit" ]]; then
-  echo "shipped-in: $sha is not carried by the newest ${#tags[@]} release(s) on $releases_repo (newest ${tags[0]})" >&2
+  verb=is
+  [[ "$newest_uncarried" != *", "* ]] || verb=are
+  echo "shipped-in: $newest_uncarried $verb not carried by the newest ${#tags[@]} release(s) on $releases_repo (newest ${tags[0]})" >&2
   exit 3
 fi
 

--- a/scripts/shipped-in.test.sh
+++ b/scripts/shipped-in.test.sh
@@ -233,7 +233,98 @@ run_script intentd "$sha"
 [[ "$status" -eq 1 ]] || fail "missing manifest exited $status (expected 1)"
 [[ "$stderr" == *"release download release-manifest.json for v2.2.0 on intent-hq/cloudlands-releases failed: stub: no manifest v2.2.0" ]] || fail "missing manifest hid gh stderr: $stderr"
 
+# Several <component> <sha> pairs: the answer is the oldest tag carrying every
+# pair, so a cross-component workspace can wait on one invocation.
+sha2=d1ec26651cc3f101b740d3f970d7fd54bf4b0268
+set_manifests() {
+  printf '{"version":"2.3.0","intentdVersion":"%s"}\n' "$1" >"$manifest_dir/v2.3.0.json"
+  printf '{"version":"2.2.0","intentdVersion":"%s"}\n' "$2" >"$manifest_dir/v2.2.0.json"
+  printf '{"version":"2.1.0","intentdVersion":"%s"}\n' "$3" >"$manifest_dir/v2.1.0.json"
+}
+
 reset_stub
+set_manifests 0.9.5 0.9.4 0.9.4
+echo ahead >"$fe_compare/$sha...v2.3.0"
+echo identical >"$fe_compare/$sha...v2.2.0"
+echo behind >"$fe_compare/$sha...v2.1.0"
+echo ahead >"$intentd_compare/$sha2...v0.9.5"
+echo behind >"$intentd_compare/$sha2...v0.9.4"
+run_script cloudlands-fe "$sha" intentd "$sha2"
+[[ "$status" -eq 0 ]] || fail "fe+intentd pair exited $status: $stderr"
+[[ "$stdout" == "v2.3.0 intentdVersion=0.9.5" ]] || fail "fe+intentd pair printed '$stdout' (v2.2.0 carries fe but not intentd)"
+grep -q "^api repos/intent-hq/cloudlands-fe/compare/$sha...v2.3.0 " "$temp_dir/gh.log" || fail "fe pair was not compared"
+grep -q "^api repos/intent-hq/intentd/compare/$sha2...v0.9.5 " "$temp_dir/gh.log" || fail "intentd pair was not compared"
+
+reset_stub
+set_manifests 0.9.5 0.9.4 0.9.4
+echo ahead >"$fe_compare/$sha...v2.3.0"
+echo ahead >"$fe_compare/$sha...v2.2.0"
+echo ahead >"$fe_compare/$sha...v2.1.0"
+echo behind >"$intentd_compare/$sha2...v0.9.5"
+echo behind >"$intentd_compare/$sha2...v0.9.4"
+run_script cloudlands-fe "$sha" intentd "$sha2"
+[[ "$status" -eq 3 ]] || fail "uncarried intentd pair exited $status (expected 3): $stderr"
+[[ -z "$stdout" ]] || fail "uncarried intentd pair printed '$stdout'"
+[[ "$stderr" == "shipped-in: intentd $sha2 is not carried by the newest 3 release(s) on intent-hq/cloudlands-releases (newest v2.3.0)" ]] || fail "uncarried intentd pair message: $stderr"
+
+reset_stub
+echo behind >"$fe_compare/$sha...v2.3.0"
+echo behind >"$fe_compare/$sha...v2.2.0"
+echo behind >"$fe_compare/$sha...v2.1.0"
+echo diverged >"$intentd_compare/$sha2...v0.9.0"
+run_script cloudlands-fe "$sha" intentd "$sha2"
+[[ "$status" -eq 3 ]] || fail "two uncarried pairs exited $status (expected 3): $stderr"
+[[ "$stderr" == "shipped-in: cloudlands-fe $sha, intentd $sha2 are not carried by the newest 3 release(s) on intent-hq/cloudlands-releases (newest v2.3.0)" ]] || fail "two uncarried pairs message: $stderr"
+
+# Two intentd SHAs against the same pinned version must not share a cached
+# compare status.
+reset_stub
+set_manifests 0.9.5 0.9.5 0.9.4
+echo ahead >"$intentd_compare/$sha...v0.9.5"
+echo ahead >"$intentd_compare/$sha...v0.9.4"
+echo ahead >"$intentd_compare/$sha2...v0.9.5"
+echo behind >"$intentd_compare/$sha2...v0.9.4"
+run_script intentd "$sha" intentd "$sha2"
+[[ "$status" -eq 0 ]] || fail "two intentd pairs exited $status: $stderr"
+[[ "$stdout" == "v2.2.0 intentdVersion=0.9.5" ]] || fail "two intentd pairs printed '$stdout' (v2.1.0 carries $sha but not $sha2)"
+for range in "$sha...v0.9.5" "$sha...v0.9.4" "$sha2...v0.9.5" "$sha2...v0.9.4"; do
+  [[ "$(grep -c "^api repos/intent-hq/intentd/compare/$range " "$temp_dir/gh.log")" -eq 1 ]] || fail "intentd compare $range was not run exactly once"
+done
+for tag in v2.3.0 v2.1.0; do
+  [[ "$(grep -c "^release download $tag " "$temp_dir/gh.log")" -eq 1 ]] || fail "manifest for $tag was downloaded once per intentd pair instead of once per tag"
+done
+
+reset_stub
+echo ahead >"$fe_compare/$sha...v2.3.0"
+GH_STUB_FAIL=ratelimit GH_STUB_FAIL_ON="api repos/intent-hq/intentd/compare/$sha2...v0.9.0" run_script cloudlands-fe "$sha" intentd "$sha2"
+[[ "$status" -eq 4 ]] || fail "rate-limited second pair exited $status (expected 4): $stderr"
+[[ -z "$stdout" ]] || fail "rate-limited second pair printed '$stdout'"
+[[ "$stderr" == *"compare $sha2...v0.9.0 on intent-hq/intentd failed: gh: API rate limit exceeded"* ]] || fail "rate-limited second pair message: $stderr"
+grep -q "^api repos/intent-hq/cloudlands-fe/compare/$sha...v2.3.0 " "$temp_dir/gh.log" || fail "first pair was not checked before the second pair failed"
+
+reset_stub
+set_manifests 0.9.5 0.9.4 0.9.3
+echo ahead >"$fe_compare/$sha...v2.3.0"
+echo behind >"$fe_compare/$sha...v2.2.0"
+echo identical >"$fe_compare/$sha...v2.1.0"
+echo ahead >"$intentd_compare/$sha2...v0.9.5"
+echo behind >"$intentd_compare/$sha2...v0.9.4"
+echo ahead >"$intentd_compare/$sha2...v0.9.3"
+run_script cloudlands-fe "$sha" intentd "$sha2" --limit 2
+[[ "$status" -eq 0 ]] || fail "multi-pair --limit 2 exited $status: $stderr"
+[[ "$stdout" == "v2.3.0 intentdVersion=0.9.5" ]] || fail "multi-pair --limit 2 printed '$stdout' (v2.1.0 is outside the limit)"
+grep -q -- '^release list --repo intent-hq/cloudlands-releases --limit 12 ' "$temp_dir/gh.log" || fail "multi-pair --limit 2 was not over-fetched as 12"
+! grep -q 'v2.1.0' "$temp_dir/gh.log" || fail "multi-pair --limit 2 inspected v2.1.0"
+run_script cloudlands-fe "$sha" --limit=2 intentd "$sha2"
+[[ "$status" -eq 0 && "$stdout" == "v2.3.0 intentdVersion=0.9.5" ]] || fail "--limit between pairs exited $status with '$stdout': $stderr"
+
+reset_stub
+run_script cloudlands-fe "$sha" intentd
+[[ "$status" -eq 2 ]] || fail "odd positional count exited $status (expected 2)"
+run_script cloudlands-fe "$sha" ios "$sha2"
+[[ "$status" -eq 2 ]] || fail "unknown component in second pair exited $status (expected 2)"
+run_script cloudlands-fe "$sha" intentd main
+[[ "$status" -eq 2 ]] || fail "non-sha ref in second pair exited $status (expected 2)"
 run_script ios "$sha"
 [[ "$status" -eq 2 ]] || fail "unknown component exited $status (expected 2)"
 run_script cloudlands-fe main


### PR DESCRIPTION
## Summary

A workspace that lands both an intentd PR and a cloudlands-fe PR must report the cloudlands-fe alpha that carries **both** squash commits. `scripts/shipped-in.sh` only took one `<component> <sha>` pair and the AGENTS.md "Wait for shipped alpha" hook template was single-component, so agents hand-wrote dual-SHA hooks (and risked reporting a tag that carried only the fe half).

- `scripts/shipped-in.sh` now accepts one or more `<intentd|cloudlands-fe> <sha>` pairs (`--limit` unchanged). A tag carries the request when every pair's compare is `ahead`/`identical`; the oldest scanned tag carrying every pair is printed as `<tag> intentdVersion=<v>`. Exit 3 names the pair(s) the newest tag does not carry; exit 4/1 classification unchanged; usage errors (odd arg count, bad component/sha in any pair) exit 2 without calling `gh`.
- The intentd compare cache is keyed by `<sha>:<version>` so two intentd pairs never share a status; the fe compare takes the sha as a parameter.
- Single-pair behaviour is unchanged (same stdout, stderr, exit codes and `gh` call pattern; only the exit-2 Usage line now advertises the repeated-pair syntax).
- `make shipped-in PAIRS="intentd:<sha> cloudlands-fe:<sha>"` added alongside the unchanged `COMPONENT=/SHA=` form.
- AGENTS.md hook template uses the multi-pair args (bullet length unchanged); `docs/RELEASING.md` gains one clause.

Remains Bash 3.2 compatible (stock macOS).

## Verification

- `bash scripts/shipped-in.test.sh` passes under Bash 5.2 and a real Bash 3.2.57 (`BASH3_BIN=...`); six new fixture groups cover mixed carriage, uncarried-pair diagnostics, two-SHA cache isolation, second-pair transient failure, malformed pairs, and `--limit` after multiple pairs.
- Differential run of all 23 pre-existing fixture invocations: identical status, stdout, operational stderr and `gh` call log.
- `make -n shipped-in` for both forms evaluated under `/bin/sh` produces the exact argv.
- `bash scripts/docs-check.sh`, `bash scripts/docs-check.test.sh`, `node scripts/check-doc-links.mjs` pass.

Monorepo-only change; nothing ships to the alpha channel.