### PR TITLE
feat: preflight the frontend toolchain in the dev sandbox targets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,9 @@ and health, both component branches (`repos.<name>.gitlinkDirty` flags a submodu
 off its pin), and branch PR checks when `gh` is authenticated.
 Use `make status` for the human-readable form. If `host.doctorOk` is false, run
 `make bootstrap-dev-host`, then `make doctor`; automation can set `BOOTSTRAP_YES=1`, but
-system packages may require privilege. Do not discover prerequisites during a build.
+system packages may require privilege. Do not discover prerequisites during a build: the
+dev and sandbox targets preflight the frontend toolchain and exit naming the missing item
+and `make bootstrap-dev-host`.
 
 ### Act
 

--- a/Makefile
+++ b/Makefile
@@ -176,6 +176,7 @@ GATE_CACHE_DIR ?= $(HOME)/.cache/intent/gate-runs
 FE_BUILD_HEAP_MB ?= 16384
 
 .PHONY: all help doctor bootstrap-dev-host ensure-submodules ensure-intentd-submodule ensure-fe-submodule ensure-ios-submodule \
+	ensure-fe-toolchain \
 	update \
 	build build-intentd build-sidecar gate test test-intentd coverage-e2e coverage-all \
 	fmt clippy check clean clean-dev \
@@ -195,6 +196,17 @@ doctor: ## Report missing intentd + cloudlands-fe development prerequisites
 
 bootstrap-dev-host: ## Install missing development prerequisites (BOOTSTRAP_YES=1 for non-interactive use)
 	@scripts/bootstrap-dev-host.sh $(if $(filter 1 yes true,$(BOOTSTRAP_YES)),--yes,)
+
+# Frontend-toolchain preflight for the targets that shell out to
+# `corepack pnpm`. Fails fast with doctor's [missing] wording plus
+# `run: make bootstrap-dev-host` instead of a mid-run "corepack: command not
+# found". Port-independent like doctor: it must never expand DEV_PORT. It reads
+# the frontend package.json for the pinned pnpm version, so it must not race
+# the submodule checkout under `make -j`: order it after ensure-fe-submodule
+# rather than relying on the sibling prerequisite lists, which make is free to
+# run in parallel.
+ensure-fe-toolchain: ensure-fe-submodule
+	@scripts/bootstrap-dev-host.sh --check-frontend
 
 # The iOS submodule is private and marked `update = none` in .gitmodules, so
 # the generic `git submodule update --init` would silently skip it while
@@ -486,7 +498,7 @@ run-intentd: ## DEPRECATED alias for release-daemon
 	@echo "[run-intentd] DEPRECATED: use 'make release-daemon' (or 'make dev-daemon' for the dev seat)."
 	@$(MAKE) release-daemon
 
-dev-ui: ensure-fe-submodule ## Run the fast browser-only frontend UI preview
+dev-ui: ensure-fe-submodule ensure-fe-toolchain ## Run the fast browser-only frontend UI preview
 	@$(FE_DEPS_FRESH) || (echo "[dev-ui] $(FE_DEPS_INSTALL_MSG)" && cd $(FE_DIR) && corepack pnpm install --frozen-lockfile)
 	@script=$$(node -e 'const scripts = JSON.parse(require("fs").readFileSync(process.argv[1], "utf8")).scripts || {}; if (scripts["dev:ui"]) process.stdout.write("dev:ui"); else if (scripts["dev:web"]) process.stdout.write("dev:web"); else process.exit(1)' "$(FE_DIR)/package.json") || { \
 		echo "[dev-ui] ERROR: frontend package.json defines neither dev:ui nor dev:web"; \
@@ -499,20 +511,20 @@ dev-ui: ensure-fe-submodule ## Run the fast browser-only frontend UI preview
 	fi; \
 	cd $(FE_DIR) && DEV_PORT="$(DEV_PORT)" corepack pnpm run "$$script"
 
-dev-sandbox-ui: ensure-fe-submodule ## UI preview sandbox on this worktree's derived DEV_PORT
+dev-sandbox-ui: ensure-fe-submodule ensure-fe-toolchain ## UI preview sandbox on this worktree's derived DEV_PORT
 	@$(FE_DEPS_FRESH) || (echo "[dev-sandbox-ui] $(FE_DEPS_INSTALL_MSG)" && cd $(FE_DIR) && corepack pnpm install --frozen-lockfile)
 	@DEV_PORT="$(DEV_PORT)" DEV_TCP_PORT="$(DEV_TCP_PORT)" SANDBOX_READY_TIMEOUT="$(SANDBOX_READY_TIMEOUT)" \
 		DEV_PORT_ORIGIN="$(origin DEV_PORT)" DEV_TCP_PORT_ORIGIN="$(origin DEV_TCP_PORT)" \
 		FE_DIR="$(CURDIR)/$(FE_DIR)" exec scripts/dev-sandbox.sh ui
 
-dev-sandbox-app: ensure-fe-submodule ## Web renderer sandbox connected to the installed intentd
+dev-sandbox-app: ensure-fe-submodule ensure-fe-toolchain ## Web renderer sandbox connected to the installed intentd
 	@$(FE_DEPS_FRESH) || (echo "[dev-sandbox-app] $(FE_DEPS_INSTALL_MSG)" && cd $(FE_DIR) && corepack pnpm install --frozen-lockfile)
 	@DEV_PORT="$(DEV_PORT)" DEV_TCP_PORT="$(DEV_TCP_PORT)" SANDBOX_READY_TIMEOUT="$(SANDBOX_READY_TIMEOUT)" \
 		DEV_PORT_ORIGIN="$(origin DEV_PORT)" DEV_TCP_PORT_ORIGIN="$(origin DEV_TCP_PORT)" \
 		SANDBOX_WARM_TIMEOUT="$(SANDBOX_WARM_TIMEOUT)" \
 		FE_DIR="$(CURDIR)/$(FE_DIR)" exec scripts/dev-sandbox.sh app
 
-dev-sandbox-stack: ensure-intentd-submodule ensure-fe-submodule ## Dev-profile intentd + renderer (INTENTD_PROFILE=release or INTENTD_BIN=/path)
+dev-sandbox-stack: ensure-intentd-submodule ensure-fe-submodule ensure-fe-toolchain ## Dev-profile intentd + renderer (INTENTD_PROFILE=release or INTENTD_BIN=/path)
 	@$(FE_DEPS_FRESH) || (echo "[dev-sandbox-stack] $(FE_DEPS_INSTALL_MSG)" && cd $(FE_DIR) && corepack pnpm install --frozen-lockfile)
 	@DEV_PORT="$(DEV_PORT)" DEV_TCP_PORT="$(DEV_TCP_PORT)" DEV_DATA_DIR="$(DEV_DATA_DIR)" \
 		DEV_PORT_ORIGIN="$(origin DEV_PORT)" DEV_TCP_PORT_ORIGIN="$(origin DEV_TCP_PORT)" \

--- a/scripts/bootstrap-dev-host.sh
+++ b/scripts/bootstrap-dev-host.sh
@@ -46,14 +46,17 @@ cleanup() {
 trap cleanup EXIT
 
 usage() {
-  echo "Usage: $0 [--check] [--yes]"
-  echo "  --check  Report missing requirements without changing the host"
-  echo "  --yes    Install without prompting"
+  echo "Usage: $0 [--check] [--check-frontend] [--yes]"
+  echo "  --check            Report missing requirements without changing the host"
+  echo "  --check-frontend   Report only the frontend toolchain gaps (Corepack + pinned pnpm)"
+  echo "                     that block the dev/sandbox targets; exit 0 silently when ready"
+  echo "  --yes              Install without prompting"
 }
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --check) MODE=check ;;
+    --check-frontend) MODE=check-frontend ;;
     --yes) ASSUME_YES=1 ;;
     -h|--help) usage; exit 0 ;;
     *) echo "ERROR: unknown option: $1" >&2; usage >&2; exit 2 ;;
@@ -277,8 +280,15 @@ corepack_home() {
 pnpm_ready() {
   [[ -n "$PNPM_VERSION" ]] || return 1
   command -v corepack >/dev/null 2>&1 || return 1
-  command -v pnpm >/dev/null 2>&1 || return 1
-  if [[ "$MODE" == check ]]; then
+  # The `pnpm` shim is required everywhere except check-frontend mode: the
+  # targets that mode guards run `corepack pnpm`, which resolves the pinned
+  # version straight from the Corepack cache, so a host with Corepack installed
+  # but never `corepack enable`d runs them fine. Doctor keeps requiring the shim
+  # for the bare-`pnpm` targets (fe-launch, dev, run-fe-local).
+  if [[ "$MODE" != check-frontend ]]; then
+    command -v pnpm >/dev/null 2>&1 || return 1
+  fi
+  if [[ "$MODE" == check || "$MODE" == check-frontend ]]; then
     local metadata
     for metadata in "$(corepack_home)"/v*/pnpm/"$PNPM_VERSION"/.corepack; do
       [[ -f "$metadata" ]] && return 0
@@ -338,6 +348,47 @@ installable_gap_exists() {
   pnpm_ready || return 0
   frontend_dependencies_ready || return 0
   gh_ready || return 0
+  return 1
+}
+
+# Reports the Corepack and frontend-package-manager state shared by check_all
+# (doctor) and check_frontend (the dev/sandbox preflight), so the two modes have
+# a single wording source; scripts/dev-sandbox.test.sh guards them against
+# drift. With a non-empty $1 the [ok] lines are suppressed: the preflight is
+# silent when the toolchain is ready.
+report_frontend_toolchain() {
+  local quiet=${1:-}
+
+  if ! command -v corepack >/dev/null 2>&1; then
+    missing "Corepack: required to select the frontend pnpm version"
+  elif launcher_probe "$ROOT_DIR" corepack corepack --version; then
+    [[ -n "$quiet" ]] || ok "Corepack: $PROBE_OUTPUT"
+  else
+    missing "Corepack: $PROBE_ERROR"
+  fi
+
+  if [[ -z "$PACKAGE_MANAGER" ]]; then
+    missing "frontend packageManager: cannot read packages/cloudlands-fe/package.json"
+  elif pnpm_ready; then
+    [[ -n "$quiet" ]] || ok "frontend package manager: $PACKAGE_MANAGER via Corepack"
+  else
+    missing "frontend package manager: expected $PACKAGE_MANAGER via Corepack"
+  fi
+}
+
+# Preflight for the targets that shell out to `corepack pnpm` (dev-ui,
+# dev-sandbox-ui|app|stack). It reports the same lines check_all prints for
+# Corepack and the pinned package manager, never invokes the pnpm shim, and
+# never populates the Corepack cache. node_modules is deliberately not checked:
+# the targets install it themselves.
+check_frontend() {
+  FAILURES=0
+  load_versions
+
+  report_frontend_toolchain quiet
+
+  [[ "$FAILURES" -eq 0 ]] && return 0
+  echo "run: make bootstrap-dev-host"
   return 1
 }
 
@@ -412,21 +463,7 @@ check_all() {
     missing "Node: $NODE_REQUIREMENT is required (node-gyp 13 builds the frontend native modules)"
   fi
 
-  if ! command -v corepack >/dev/null 2>&1; then
-    missing "Corepack: required to select the frontend pnpm version"
-  elif launcher_probe "$ROOT_DIR" corepack corepack --version; then
-    ok "Corepack: $PROBE_OUTPUT"
-  else
-    missing "Corepack: $PROBE_ERROR"
-  fi
-
-  if [[ -z "$PACKAGE_MANAGER" ]]; then
-    missing "frontend packageManager: cannot read packages/cloudlands-fe/package.json"
-  elif pnpm_ready; then
-    ok "frontend package manager: $PACKAGE_MANAGER via Corepack"
-  else
-    missing "frontend package manager: expected $PACKAGE_MANAGER via Corepack"
-  fi
+  report_frontend_toolchain
 
   if [[ ! -d "$FE_DIR/node_modules" ]]; then
     missing "frontend dependencies: run corepack pnpm install --frozen-lockfile in packages/cloudlands-fe"
@@ -709,6 +746,11 @@ install_frontend() {
     fi
   fi
 }
+
+if [[ "$MODE" == check-frontend ]]; then
+  check_frontend
+  exit $?
+fi
 
 if [[ "$MODE" == check ]]; then
   check_all

--- a/scripts/dev-sandbox.sh
+++ b/scripts/dev-sandbox.sh
@@ -148,6 +148,13 @@ if [[ "$mode" == ui || "$mode" == app || "$mode" == stack ]]; then
     describe_busy_port "$dev_tcp_port"
     exit 1
   fi
+  # Every mode runs the frontend through `corepack pnpm`. The Makefile targets
+  # preflight the full toolchain via `make ensure-fe-toolchain`; this covers
+  # direct callers of this script.
+  if ! command -v corepack >/dev/null 2>&1; then
+    echo "[dev-sandbox-$mode] ERROR: corepack is required to run the frontend; run 'make bootstrap-dev-host'." >&2
+    exit 1
+  fi
 fi
 
 children_of() {

--- a/scripts/dev-sandbox.test.sh
+++ b/scripts/dev-sandbox.test.sh
@@ -826,4 +826,176 @@ grep -q "^ERROR: gh 2\.45\.0 ($bootstrap_bin/gh) is still below 2\.94\.0 after i
 grep -q 'shadows the new one.*https://github.com/cli/cli#installation' "$temp_dir/install-gh.out" \
   || fail "shadowed gh error did not explain PATH shadowing with the install URL"
 
+# Frontend-toolchain preflight (bootstrap-dev-host.sh --check-frontend and the
+# dev-sandbox.sh guard). The fixtures are self-contained under $temp_dir and run
+# on a sanitized PATH so the host's real corepack/pnpm — present or absent —
+# cannot decide the outcome.
+fe_root="$temp_dir/fe-preflight-root"
+fe_stub_bin="$temp_dir/fe-preflight-bin"
+sanitized_bin="$temp_dir/fe-preflight-sanitized-bin"
+fe_cargo_home="$temp_dir/fe-preflight-cargo-home"
+fe_bootstrap="$fe_root/scripts/bootstrap-dev-host.sh"
+mkdir -p "$fe_root/scripts" "$fe_root/packages/intentd" "$fe_root/packages/cloudlands-fe" \
+  "$fe_stub_bin" "$sanitized_bin"
+cp "$repo_root/scripts/bootstrap-dev-host.sh" "$fe_bootstrap"
+touch "$fe_root/packages/intentd/.git" "$fe_root/packages/cloudlands-fe/.git"
+printf 'channel = "1.96.0"\n' >"$fe_root/packages/intentd/rust-toolchain.toml"
+printf '{"packageManager":"pnpm@10.30.3"}\n' >"$fe_root/packages/cloudlands-fe/package.json"
+for tool in bash sh env sed head grep find cat rm mkdir mktemp touch dirname date sleep tr uname ps pgrep python3; do
+  tool_path=$(command -v "$tool" 2>/dev/null) || continue
+  [[ "$tool_path" == /* ]] || continue
+  ln -sf "$tool_path" "$sanitized_bin/$tool"
+done
+if (PATH="$sanitized_bin"; command -v corepack >/dev/null 2>&1); then
+  fail "sanitized PATH still resolves corepack; the absent-corepack fixtures would be meaningless"
+fi
+cat >"$fe_stub_bin/corepack" <<'SH'
+#!/usr/bin/env bash
+printf '0.35.0\n'
+SH
+cat >"$fe_stub_bin/pnpm" <<'SH'
+#!/usr/bin/env bash
+mkdir -p "$COREPACK_HOME/v1/pnpm/10.30.3"
+touch "$COREPACK_HOME/v1/pnpm/10.30.3/downloaded"
+printf '10.30.3\n'
+SH
+chmod +x "$fe_stub_bin/corepack" "$fe_stub_bin/pnpm"
+
+ready_cache="$temp_dir/fe-preflight-cache-ready"
+mkdir -p "$ready_cache/v1/pnpm/10.30.3"
+touch "$ready_cache/v1/pnpm/10.30.3/.corepack"
+set +e
+PATH="$fe_stub_bin:$sanitized_bin" COREPACK_HOME="$ready_cache" CARGO_HOME="$fe_cargo_home" \
+  bash "$fe_bootstrap" --check-frontend >"$temp_dir/fe-ready.out" 2>&1
+status=$?
+set -e
+[[ "$status" -eq 0 ]] || fail "--check-frontend returned $status on a ready frontend toolchain"
+[[ ! -s "$temp_dir/fe-ready.out" ]] || fail "--check-frontend was not silent on a ready frontend toolchain"
+[[ ! -e "$ready_cache/v1/pnpm/10.30.3/downloaded" ]] \
+  || fail "--check-frontend invoked the Corepack pnpm shim instead of reading its cache metadata"
+
+no_corepack_cache="$temp_dir/fe-preflight-cache-no-corepack"
+mkdir -p "$no_corepack_cache"
+set +e
+PATH="$sanitized_bin" COREPACK_HOME="$no_corepack_cache" CARGO_HOME="$fe_cargo_home" \
+  bash "$fe_bootstrap" --check-frontend >"$temp_dir/fe-no-corepack.out" 2>&1
+status=$?
+set -e
+[[ "$status" -eq 1 ]] || fail "--check-frontend returned $status instead of 1 without corepack"
+grep -qx '\[missing\]  Corepack: required to select the frontend pnpm version' "$temp_dir/fe-no-corepack.out" \
+  || fail "--check-frontend did not report the missing Corepack in doctor's wording"
+grep -qx 'run: make bootstrap-dev-host' "$temp_dir/fe-no-corepack.out" \
+  || fail "--check-frontend did not name the fix (make bootstrap-dev-host)"
+
+unpinned_cache="$temp_dir/fe-preflight-cache-unpinned"
+mkdir -p "$unpinned_cache"
+set +e
+PATH="$fe_stub_bin:$sanitized_bin" COREPACK_HOME="$unpinned_cache" CARGO_HOME="$fe_cargo_home" \
+  bash "$fe_bootstrap" --check-frontend >"$temp_dir/fe-unpinned.out" 2>&1
+status=$?
+set -e
+[[ "$status" -eq 1 ]] || fail "--check-frontend returned $status instead of 1 without the pinned pnpm"
+grep -q 'frontend package manager: expected pnpm@10.30.3 via Corepack' "$temp_dir/fe-unpinned.out" \
+  || fail "--check-frontend did not report the unpinned frontend package manager"
+! grep -q 'Corepack: required to select' "$temp_dir/fe-unpinned.out" \
+  || fail "--check-frontend reported Corepack missing while it was on PATH"
+[[ -z $(find "$unpinned_cache" -mindepth 1 -print -quit) ]] \
+  || fail "--check-frontend populated the Corepack cache while reporting the pinned pnpm gap"
+
+# Drift guard: doctor and the preflight must print the same [missing] lines for
+# the two frontend items, byte for byte, on the same fixture.
+set +e
+PATH="$sanitized_bin" COREPACK_HOME="$no_corepack_cache" CARGO_HOME="$fe_cargo_home" \
+  bash "$fe_bootstrap" --check >"$temp_dir/fe-doctor.out" 2>&1
+status=$?
+set -e
+[[ "$status" -eq 1 ]] || fail "fixture doctor returned $status instead of reporting the frontend gaps"
+fe_missing_pattern='^\[missing\]  (Corepack|frontend package manager|frontend packageManager):'
+grep -E "$fe_missing_pattern" "$temp_dir/fe-doctor.out" >"$temp_dir/fe-doctor.lines" \
+  || fail "fixture doctor printed no frontend [missing] lines"
+grep -E "$fe_missing_pattern" "$temp_dir/fe-no-corepack.out" >"$temp_dir/fe-preflight.lines" \
+  || fail "--check-frontend printed no frontend [missing] lines"
+[[ $(wc -l <"$temp_dir/fe-doctor.lines") -eq 2 ]] \
+  || fail "fixture doctor did not report both frontend items as missing"
+cmp -s "$temp_dir/fe-doctor.lines" "$temp_dir/fe-preflight.lines" \
+  || fail "doctor and --check-frontend disagree on the frontend [missing] wording"
+
+# A Corepack that is on PATH but fails its bounded launcher probe
+# (intent-hq/intent#4635) is a third outcome: both modes must report the probe
+# error itself, in the same words, rather than claiming Corepack is absent.
+broken_stub_bin="$temp_dir/fe-preflight-broken-bin"
+mkdir -p "$broken_stub_bin"
+cat >"$broken_stub_bin/corepack" <<'SH'
+#!/usr/bin/env bash
+echo "corepack: cannot find dist/corepack.js" >&2
+exit 1
+SH
+chmod +x "$broken_stub_bin/corepack"
+broken_cache="$temp_dir/fe-preflight-cache-broken"
+mkdir -p "$broken_cache"
+set +e
+PATH="$broken_stub_bin:$sanitized_bin" COREPACK_HOME="$broken_cache" CARGO_HOME="$fe_cargo_home" \
+  bash "$fe_bootstrap" --check-frontend >"$temp_dir/fe-broken.out" 2>&1
+status=$?
+set -e
+[[ "$status" -eq 1 ]] || fail "--check-frontend returned $status instead of 1 on a failing Corepack probe"
+grep -q "\[missing\]  Corepack: 'corepack --version' failed with exit 1 via $broken_stub_bin/corepack" \
+  "$temp_dir/fe-broken.out" || fail "--check-frontend did not report the Corepack probe error"
+! grep -q 'Corepack: required to select' "$temp_dir/fe-broken.out" \
+  || fail "--check-frontend claimed Corepack was absent while it was on PATH but broken"
+set +e
+PATH="$broken_stub_bin:$sanitized_bin" COREPACK_HOME="$broken_cache" CARGO_HOME="$fe_cargo_home" \
+  bash "$fe_bootstrap" --check >"$temp_dir/fe-broken-doctor.out" 2>&1
+set -e
+grep -E "$fe_missing_pattern" "$temp_dir/fe-broken-doctor.out" >"$temp_dir/fe-broken-doctor.lines" \
+  || fail "fixture doctor printed no frontend [missing] lines on a failing Corepack probe"
+grep -E "$fe_missing_pattern" "$temp_dir/fe-broken.out" >"$temp_dir/fe-broken-preflight.lines" \
+  || fail "--check-frontend printed no frontend [missing] lines on a failing Corepack probe"
+cmp -s "$temp_dir/fe-broken-doctor.lines" "$temp_dir/fe-broken-preflight.lines" \
+  || fail "doctor and --check-frontend disagree on the Corepack probe-error wording"
+
+# Corepack installed but never `corepack enable`d: no pnpm shim on PATH, yet the
+# pinned version sits in the Corepack cache, so `corepack pnpm run ...` — the
+# command the guarded targets actually run — works. The preflight must not be
+# stricter than the command it guards, while doctor keeps requiring the shim for
+# the bare-pnpm targets (fe-launch, dev, run-fe-local).
+corepack_only_bin="$temp_dir/fe-preflight-corepack-only-bin"
+mkdir -p "$corepack_only_bin"
+cp "$fe_stub_bin/corepack" "$corepack_only_bin/corepack"
+chmod +x "$corepack_only_bin/corepack"
+if (PATH="$corepack_only_bin:$sanitized_bin"; command -v pnpm >/dev/null 2>&1); then
+  fail "the shim-less fixture still resolves a pnpm shim"
+fi
+shimless_cache="$temp_dir/fe-preflight-cache-shimless"
+mkdir -p "$shimless_cache/v1/pnpm/10.30.3"
+touch "$shimless_cache/v1/pnpm/10.30.3/.corepack"
+set +e
+PATH="$corepack_only_bin:$sanitized_bin" COREPACK_HOME="$shimless_cache" CARGO_HOME="$fe_cargo_home" \
+  bash "$fe_bootstrap" --check-frontend >"$temp_dir/fe-shimless.out" 2>&1
+status=$?
+set -e
+[[ "$status" -eq 0 ]] || fail "--check-frontend returned $status without a pnpm shim that corepack pnpm does not need"
+[[ ! -s "$temp_dir/fe-shimless.out" ]] || fail "--check-frontend was not silent without a pnpm shim"
+set +e
+PATH="$corepack_only_bin:$sanitized_bin" COREPACK_HOME="$shimless_cache" CARGO_HOME="$fe_cargo_home" \
+  bash "$fe_bootstrap" --check >"$temp_dir/fe-shimless-doctor.out" 2>&1
+status=$?
+set -e
+[[ "$status" -eq 1 ]] || fail "fixture doctor returned $status instead of flagging the absent pnpm shim"
+grep -qx '\[missing\]  frontend package manager: expected pnpm@10.30.3 via Corepack' \
+  "$temp_dir/fe-shimless-doctor.out" \
+  || fail "doctor stopped requiring the pnpm shim its bare-pnpm targets need"
+
+no_corepack_state="$temp_dir/no-corepack-state"
+set +e
+PATH="$sanitized_bin" FE_DIR="$temp_dir/fe" DEV_PORT="$(free_port)" \
+  SANDBOX_STATE_DIR="$no_corepack_state" SANDBOX_READY_TIMEOUT=5 \
+  bash "$script" ui >"$temp_dir/no-corepack-ui.out" 2>&1
+status=$?
+set -e
+[[ "$status" -eq 1 ]] || fail "UI sandbox returned $status instead of 1 without corepack"
+grep -q "\[dev-sandbox-ui\] ERROR: corepack is required to run the frontend; run 'make bootstrap-dev-host'." \
+  "$temp_dir/no-corepack-ui.out" || fail "missing corepack message did not name the fix"
+[[ ! -e "$no_corepack_state" ]] || fail "UI sandbox wrote state before failing the corepack preflight"
+
 echo "dev-sandbox tests passed (daemon, cargo, and pnpm behavior stubbed)"


### PR DESCRIPTION
## Summary
- `make dev-ui` and `make dev-sandbox-ui|app|stack` now fail fast when Corepack or the pinned pnpm is missing, printing `make doctor`'s exact `[missing]` lines plus `run: make bootstrap-dev-host` — instead of dying mid-run with an opaque `corepack: command not found` (Homebrew Node ≥ 25 no longer bundles corepack).
- New `scripts/bootstrap-dev-host.sh --check-frontend` reuses doctor's `pnpm_ready` in check-mode (never invokes the pnpm shim, never writes `COREPACK_HOME`); wired in as the port-independent `ensure-fe-toolchain` prerequisite. `scripts/dev-sandbox.sh` gets a cheap `command -v corepack` guard for direct callers.
- `scripts/dev-sandbox.test.sh` covers ready / corepack-absent / unpinned-pnpm / direct-script paths, plus a drift guard asserting `--check` and `--check-frontend` print byte-identical wording.
- AGENTS.md § Situate: the existing "Do not discover prerequisites during a build" sentence is extended in place (no new prose).

Mechanizes an existing AGENTS.md prose rule (retrospective finding from the cloudlands-fe #2245 workspace, where an agent hand-rolled a private corepack prefix to get past this).

## Verification
On a real no-corepack host (Node v26.5.0 via Homebrew): all four targets exit non-zero in ~40 ms with the two `[missing]` lines + the bootstrap pointer, no `.dev/sandbox/*.json`, no `pnpm install` attempted. Ready-path fixture: exit 0, silent, cache untouched. `shellcheck` clean. Full `dev-sandbox.test.sh` relies on CI (macOS lacks `setsid`, pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)