### PR TITLE
feat(bootstrap): require jq in make doctor and install it in bootstrap-dev-host

### DIFF
--- a/scripts/bootstrap-dev-host.sh
+++ b/scripts/bootstrap-dev-host.sh
@@ -327,6 +327,19 @@ gh_ready() {
   [[ "$version" == "$base" || "$base" != "$GH_MIN_VERSION" ]]
 }
 
+jq_version() {
+  command -v jq >/dev/null 2>&1 || return 1
+  local output
+  output=$(jq --version 2>/dev/null) || return 1
+  printf '%s\n' "${output%%$'\n'*}"
+}
+
+# A jq pathname on PATH is not enough: a broken or stale shim passes command -v
+# but cannot run, so require jq --version to succeed.
+jq_ready() {
+  jq_version >/dev/null
+}
+
 installable_gap_exists() {
   required_submodules_ready || return 0
   load_versions
@@ -342,7 +355,7 @@ installable_gap_exists() {
   pnpm_ready || return 0
   frontend_dependencies_ready || return 0
   gh_ready || return 0
-  command -v jq >/dev/null 2>&1 || return 0
+  jq_ready || return 0
   return 1
 }
 
@@ -459,10 +472,12 @@ check_all() {
     fi
   fi
 
-  if command -v jq >/dev/null 2>&1; then
-    ok "jq: $(jq --version 2>/dev/null | head -n 1)"
-  else
+  if ! command -v jq >/dev/null 2>&1; then
     missing "jq: required by the release-notifier test suites (intentd scripts/test-notify-fixed-issues.sh via make test, cloudlands-fe pnpm test:unit); run make bootstrap-dev-host"
+  elif ! jq_ready; then
+    missing "jq: $(command -v jq) is on PATH but jq --version fails; reinstall it (run make bootstrap-dev-host)"
+  else
+    ok "jq: $(jq_version)"
   fi
 
   if command -v sccache >/dev/null 2>&1; then
@@ -690,8 +705,8 @@ install_gh() {
 }
 
 install_jq() {
-  if command -v jq >/dev/null 2>&1; then
-    echo "[skip] jq already installed"
+  if jq_ready; then
+    echo "[skip] jq $(jq_version) already installed"
     return
   fi
 

--- a/scripts/bootstrap-dev-host.sh
+++ b/scripts/bootstrap-dev-host.sh
@@ -17,6 +17,10 @@ export CARGO_HOME PATH
 GH_MIN_VERSION="2.94.0"
 GH_INSTALL_URL="https://github.com/cli/cli#installation"
 
+# jq: the release-notifier test suites parse GitHub API fixtures with it
+# (intentd scripts/test-notify-fixed-issues.sh via make test, cloudlands-fe pnpm test:unit).
+JQ_INSTALL_URL="https://jqlang.github.io/jq/download/"
+
 # Minimum Node: the frontend install builds node-pty (and cpu-features) with
 # node-gyp 13, whose engines.node is "^22.22.2 || ^24.15.0 || >=26.0.0"; its undici
 # dependency throws on Node 20 (intent-hq/intent#4669). fe CI runs Node 24.
@@ -338,6 +342,7 @@ installable_gap_exists() {
   pnpm_ready || return 0
   frontend_dependencies_ready || return 0
   gh_ready || return 0
+  command -v jq >/dev/null 2>&1 || return 0
   return 1
 }
 
@@ -452,6 +457,12 @@ check_all() {
       ok "GitHub CLI: gh $gh_found (>= $GH_MIN_VERSION)"
       optional "GitHub CLI: not authenticated; PR reporting is disabled until gh auth login"
     fi
+  fi
+
+  if command -v jq >/dev/null 2>&1; then
+    ok "jq: $(jq --version 2>/dev/null | head -n 1)"
+  else
+    missing "jq: required by the release-notifier test suites (intentd scripts/test-notify-fixed-issues.sh via make test, cloudlands-fe pnpm test:unit); run make bootstrap-dev-host"
   fi
 
   if command -v sccache >/dev/null 2>&1; then
@@ -678,6 +689,35 @@ install_gh() {
   exit 1
 }
 
+install_jq() {
+  if command -v jq >/dev/null 2>&1; then
+    echo "[skip] jq already installed"
+    return
+  fi
+
+  echo "[install] jq"
+  case "$(uname -s)" in
+    Darwin)
+      command -v brew >/dev/null 2>&1 || { echo "ERROR: Homebrew is required to install jq on macOS; see $JQ_INSTALL_URL" >&2; exit 1; }
+      brew install jq || exit 1
+      ;;
+    Linux)
+      if command -v apt-get >/dev/null 2>&1; then
+        as_root apt-get install -y jq || exit 1
+      elif command -v dnf >/dev/null 2>&1; then
+        as_root dnf install -y jq || exit 1
+      elif command -v yum >/dev/null 2>&1; then
+        as_root yum install -y jq || exit 1
+      else
+        echo "ERROR: unsupported Linux package manager; install jq from $JQ_INSTALL_URL and re-run" >&2
+        exit 1
+      fi
+      ;;
+    *) echo "ERROR: only Linux and macOS are supported; install jq from $JQ_INSTALL_URL" >&2; exit 1 ;;
+  esac
+  hash -r
+}
+
 install_frontend() {
   if ! command -v corepack >/dev/null 2>&1; then
     command -v npm >/dev/null 2>&1 || { echo "ERROR: npm is required to install Corepack" >&2; exit 1; }
@@ -744,6 +784,7 @@ install_rust
 install_node
 install_frontend
 install_gh
+install_jq
 
 echo
 check_all

--- a/scripts/bootstrap-dev-host.test.sh
+++ b/scripts/bootstrap-dev-host.test.sh
@@ -222,4 +222,12 @@ rm -f "$bin_dir/node"
 run_doctor
 expect_line "[missing]  Node: 22.22.2+, 24.15.0+ (recommended) or 26+ is required"
 
+# jq is required; without it the doctor names the suites that need it.
+expect_line "[missing]  jq: required by the release-notifier test suites"
+write_launcher jq '[ "$1" = --version ] && { echo jq-1.7.1; exit 0; }; exit 1'
+run_doctor
+expect_line "[ok]       jq: jq-1.7.1"
+reject_line "[missing]  jq:"
+rm -f "$bin_dir/jq"
+
 echo "bootstrap-dev-host tests passed"

--- a/scripts/bootstrap-dev-host.test.sh
+++ b/scripts/bootstrap-dev-host.test.sh
@@ -228,6 +228,12 @@ write_launcher jq '[ "$1" = --version ] && { echo jq-1.7.1; exit 0; }; exit 1'
 run_doctor
 expect_line "[ok]       jq: jq-1.7.1"
 reject_line "[missing]  jq:"
+
+# A jq on PATH that cannot run is a broken install, not a pass.
+write_launcher jq 'echo "cannot execute" >&2; exit 1'
+run_doctor
+expect_line "[missing]  jq: $bin_dir/jq is on PATH but jq --version fails"
+reject_line "[ok]       jq:"
 rm -f "$bin_dir/jq"
 
 echo "bootstrap-dev-host tests passed"


### PR DESCRIPTION
## Summary

`make doctor` now reports a missing `jq`, and `make bootstrap-dev-host` installs it, so local gates match CI for the release-notifier regression suites.

The notifier suites (intentd `scripts/test-notify-fixed-issues.sh`, run by `make test`; cloudlands-fe `scripts/notify-fixed-issues.test.ts`, run by `pnpm test:unit`) run the scripts' real `gh api graphql --jq` projection through the `jq` CLI since intent-hq/intentd#1812 and intent-hq/cloudlands-fe#2402. `jq` is preinstalled on `ubuntu-latest` but was not a doctor/bootstrap prerequisite, so fresh dev hosts hit a "jq is required" preflight failure unrelated to their change (three ad-hoc user-local installs in one workspace).

## Changes

- `scripts/bootstrap-dev-host.sh`
  - `check_all`: `[ok] jq: <version>` when present; otherwise `[missing] jq: required by the release-notifier test suites (...); run make bootstrap-dev-host`.
  - `installable_gap_exists`: a missing `jq` is an installable gap.
  - `install_jq` (called after `install_gh`): skip when present; `brew install jq` on macOS; `apt-get` / `dnf` / `yum` via `as_root` on Linux; explicit error naming https://jqlang.github.io/jq/download/ otherwise. No version floor.
- `scripts/bootstrap-dev-host.test.sh`: asserts the missing and present doctor lines.

## Verification

- `./scripts/bootstrap-dev-host.test.sh` passes (includes `bash -n` / `bash --posix -n`).
- `make doctor` prints `[ok]       jq: jq-1.7.1` with jq on PATH; with `~/.local/bin` filtered out it prints the `[missing]  jq: ...` line and exits non-zero.
- The install path was verified by review against the existing `install_python` / `install_gh` pattern (not executed; needs sudo).
