### PR TITLE
chore(make): add pager-safe list-tests target and export PAGER=cat on Rust gates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -257,9 +257,10 @@ with no rollback.
 - Run long gates as saved command-mode `ws.script` entries (`ws.script.start`, a
   self-checking `ws.hook.schedule` on `ws.script.status`, then `ws.script.output`);
   `ws.script.run` rejects `timeoutSeconds` above budget − 5s (25s default). Saved scripts
-  are PTY-backed, so use the `make` targets — they set `NEXTEST_SHOW_PROGRESS=none` and
-  `CARGO_TERM_PROGRESS_WHEN=never`; a raw `cargo nextest run` / `cargo build` must pass
-  the same or its progress-bar redraws flood the output buffer.
+  are PTY-backed with no keyboard, so use the `make` targets — they disable progress bars
+  and pagers (`make list-tests` for nextest discovery, which ignores `PAGER`); a raw
+  `cargo nextest` / `cargo build` / `git` / `gh` must pass `--no-pager` / the same env or
+  it floods the buffer or stalls on `less`.
 
 ## Release Process
 

--- a/Makefile
+++ b/Makefile
@@ -149,8 +149,14 @@ BUILD_JOBS ?= -2
 # human at a terminal can restore the bars with
 # `make test NEXTEST_SHOW_PROGRESS=bar CARGO_TERM_PROGRESS_WHEN=auto`.
 # CI already sets CI=true, under which both tools are non-interactive anyway.
-gate test test-intentd coverage-e2e coverage-all: export NEXTEST_SHOW_PROGRESS ?= none
-gate check clippy build-intentd test test-intentd coverage-e2e coverage-all: export CARGO_TERM_PROGRESS_WHEN ?= never
+gate test test-intentd coverage-e2e coverage-all list-tests: export NEXTEST_SHOW_PROGRESS ?= none
+gate check clippy build-intentd test test-intentd coverage-e2e coverage-all list-tests: export CARGO_TERM_PROGRESS_WHEN ?= never
+# Pagers on the same targets. A saved-script PTY has no keyboard, so any
+# git/gh step that pages to `less` stalls forever waiting for a keypress.
+# nextest ignores PAGER (only --no-pager / user config disable its paging),
+# hence the explicit --no-pager on list-tests.
+gate check clippy build-intentd test test-intentd coverage-e2e coverage-all list-tests: export PAGER ?= cat
+gate check clippy build-intentd test test-intentd coverage-e2e coverage-all list-tests: export GIT_PAGER ?= cat
 
 # Resumable local test runs are opt-in. Records are keyed by the complete
 # monorepo + intentd worktree state and kept outside the checkout.
@@ -167,7 +173,7 @@ FE_BUILD_HEAP_MB ?= 16384
 
 .PHONY: all help doctor bootstrap-dev-host ensure-submodules ensure-intentd-submodule ensure-fe-submodule ensure-ios-submodule \
 	update \
-	build build-intentd build-sidecar gate test test-intentd coverage-e2e coverage-all \
+	build build-intentd build-sidecar gate test test-intentd list-tests coverage-e2e coverage-all \
 	fmt clippy check clean clean-dev \
 	sweep sweep-all seed-dev-providers seed-dev-workspaces dev-daemon release-daemon \
 	run-intentd dev-ui dev-sandbox-ui dev-sandbox-app dev-sandbox-stack dev-fe fe-launch \
@@ -356,6 +362,15 @@ test-intentd: ensure-intentd-submodule
 		--force "$(GATE_FORCE)" \
 		--build-jobs "$(BUILD_JOBS)" \
 		--test-threads "$(TEST_THREADS)"
+
+# nextest ignores PAGER, so --no-pager is passed explicitly (see the pager
+# export above). ARGS passes through, e.g. `make list-tests ARGS="-p intentd"`.
+list-tests: ensure-intentd-submodule ## List nextest tests without a pager (ARGS="-p <crate>" to narrow)
+	@cargo nextest --version >/dev/null 2>&1 || { \
+		echo "[list-tests] ERROR: cargo-nextest is not installed — run 'cargo install cargo-nextest --locked'"; \
+		exit 1; \
+	}
+	cd $(INTENTD_DIR) && cargo nextest list --no-pager $(ARGS)
 
 # Local reproduction of the CI coverage jobs (packages/intentd
 # .github/workflows/ci.yml: coverage-e2e / coverage-all), wrapping the same


### PR DESCRIPTION
## Summary

Saved command-mode `ws.script` entries are PTY-backed with no keyboard, so any step that pages to `less` stalls forever waiting for a keypress. `cargo nextest list` is the recorded offender (script `aa8ba81c`, workspace runs-test), and nextest ignores `PAGER` — only `--no-pager`, user config, or a non-TTY stdout disable its paging.

- **Makefile**: new `list-tests` target (`cargo nextest list --no-pager $(ARGS)` in `$(INTENTD_DIR)`, same nextest preflight as `test-intentd`, `ARGS` pass-through e.g. `make list-tests ARGS="-p intentd"`), added to `.PHONY` and the existing progress-rendering exports.
- **Makefile**: `PAGER ?= cat` / `GIT_PAGER ?= cat` target-specific exports on the Rust gate targets (`gate check clippy build-intentd test test-intentd coverage-e2e coverage-all list-tests`), so a gate composed of `git`/`gh` steps is safe even on a daemon that predates the companion intentd change. `?=` keeps an explicitly set value.
- **AGENTS.md**: the "Resuming local Rust gates" bullet now points at `make list-tests` and covers pagers as well as progress bars.

No `packages/*` gitlink moves.

## Verification

| Claim | Command | Result |
|---|---|---|
| help lists target | `make help \| grep list-tests` | `list-tests  List nextest tests without a pager (ARGS="-p <crate>" to narrow)` |
| dry run | `make -n list-tests ARGS="-p intent-services"` | ends with `cd packages/intentd && cargo nextest list --no-pager -p intent-services` |
| env reaches recipe | `make -s list-tests ARGS='--help >/dev/null; env \| grep ...'` | `PAGER=cat GIT_PAGER=cat NEXTEST_SHOW_PROGRESS=none CARGO_TERM_PROGRESS_WHEN=never` |
| explicit override kept | `PAGER=less make -s list-tests ARGS=...` | `PAGER=less` |
| saved-script run | ws.script `list-tests-intent-services` running `make list-tests ARGS="-p intent-services"` | see PR comment / task note for exit code and output |
