### PR TITLE
chore(make): run the repo-slug fold lint from make check

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -249,7 +249,7 @@ with no rollback.
 
 - `make gate` runs `make check` and then the full nextest suite. `make test` remains
   the test-only entry point. Resume records apply only to nextest; `make gate` always
-  reruns fmt and clippy.
+  reruns fmt, clippy, and the repo-slug fold lint.
 - After a harness or terminal interruption, rerun `make test RESUME=1`. It skips
   only tests recorded as passed for the identical tracked and untracked worktree,
   submodule pointers, Rust toolchain, lockfile, and nextest configuration. Records

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,9 +78,10 @@ conventional commit before pushing.
 
 Keep the relevant checks green before opening a PR:
 
-- **intentd**: `cargo fmt --check`, `cargo clippy -- -D warnings`, and
-  `cargo build` — the monorepo-root `Makefile` wraps these as `make check`
-  (fmt + clippy) and `make build`; run `make test` for the test suite.
+- **intentd**: `cargo fmt --check`, `cargo clippy -- -D warnings`, the
+  repo-slug fold lint, and `cargo build` — the monorepo-root `Makefile` wraps
+  these as `make check` (fmt + clippy + repo-slug fold lint) and `make build`;
+  run `make test` for the test suite.
 - **cloudlands-fe**: `pnpm run check` and `pnpm vitest run`.
 - **ios**: build + test targets passing.
 

--- a/Makefile
+++ b/Makefile
@@ -160,13 +160,13 @@ BUILD_JOBS ?= -2
 # `make test NEXTEST_SHOW_PROGRESS=bar CARGO_TERM_PROGRESS_WHEN=auto`.
 # CI already sets CI=true, under which both tools are non-interactive anyway.
 gate test test-intentd coverage-e2e coverage-all list-tests: export NEXTEST_SHOW_PROGRESS ?= none
-gate check clippy build-intentd test test-intentd coverage-e2e coverage-all list-tests: export CARGO_TERM_PROGRESS_WHEN ?= never
+gate check clippy lint-repo-slug build-intentd test test-intentd coverage-e2e coverage-all list-tests: export CARGO_TERM_PROGRESS_WHEN ?= never
 # Pagers on the same targets. A saved-script PTY has no keyboard, so any
 # git/gh step that pages to `less` stalls forever waiting for a keypress.
 # nextest ignores PAGER (only --no-pager / user config disable its paging),
 # hence the explicit --no-pager on list-tests.
-gate check clippy build-intentd test test-intentd coverage-e2e coverage-all list-tests: export PAGER ?= cat
-gate check clippy build-intentd test test-intentd coverage-e2e coverage-all list-tests: export GIT_PAGER ?= cat
+gate check clippy lint-repo-slug build-intentd test test-intentd coverage-e2e coverage-all list-tests: export PAGER ?= cat
+gate check clippy lint-repo-slug build-intentd test test-intentd coverage-e2e coverage-all list-tests: export GIT_PAGER ?= cat
 
 # Resumable local test runs are opt-in. Records are keyed by the complete
 # monorepo + intentd worktree state and kept outside the checkout.
@@ -185,7 +185,7 @@ FE_BUILD_HEAP_MB ?= 16384
 	ensure-fe-toolchain \
 	update \
 	build build-intentd build-sidecar gate test test-intentd list-tests coverage-e2e coverage-all \
-	fmt clippy check clean clean-dev \
+	fmt clippy lint-repo-slug check clean clean-dev \
 	sweep sweep-all seed-dev-providers seed-dev-workspaces dev-daemon release-daemon \
 	run-intentd dev-ui dev-sandbox-ui dev-sandbox-app dev-sandbox-stack dev-fe fe-launch \
 	sandbox-status sandbox-stop \
@@ -355,9 +355,15 @@ fmt: ensure-intentd-submodule ## cargo fmt --check
 clippy: ensure-intentd-submodule ## cargo clippy --all-targets -- -D warnings
 	cd $(INTENTD_DIR) && cargo clippy --workspace --all-targets --jobs $(BUILD_JOBS) -- -D warnings
 
-check: fmt clippy ## fmt + clippy
+# Source lint: fails naming file:line wherever repository owner/name identity
+# is case-folded or compared outside intent_core::RepoRef. Mirrors the intentd
+# `check` CI job so local gates match CI.
+lint-repo-slug: ensure-intentd-submodule ## Lint raw repo-slug folding outside RepoRef (intent-core repo_slug_fold_lint)
+	cd $(INTENTD_DIR) && cargo test -p intent-core --test repo_slug_fold_lint --jobs $(BUILD_JOBS)
 
-gate: check ## Run all local Rust gates (fmt, clippy, then nextest)
+check: fmt clippy lint-repo-slug ## fmt + clippy + repo-slug fold lint
+
+gate: check ## Run all local Rust gates (fmt, clippy, repo-slug lint, then nextest)
 	@$(MAKE) --no-print-directory test
 
 test: test-intentd ## Run Rust tests; after interruption use RESUME=1 (GATE_FORCE=1 runs all)

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ git clone --recurse-submodules https://github.com/intent-hq/intent.git
 cd intent
 
 make doctor  # report missing development prerequisites; use BOOTSTRAP_YES=1 make bootstrap-dev-host to install them
-make check   # cargo fmt --check + cargo clippy -- -D warnings
+make check   # cargo fmt --check + cargo clippy -- -D warnings + repo-slug fold lint
 make test    # cargo nextest run --workspace (needs cargo-nextest: cargo install cargo-nextest --locked)
 make build   # cargo build --workspace
 ```


### PR DESCRIPTION
## Why

intent-hq/intentd#1821 added a source-scanning lint test (crates/intent-core/tests/repo_slug_fold_lint.rs) that fails, naming file:line, wherever repository owner/name identity is case-folded outside intent_core::RepoRef. It runs in the intentd "check" CI job. This wires the same test into the monorepo's local gates so "make check" matches CI before a PR is opened.

## What

- New "lint-repo-slug" target: cargo test -p intent-core --test repo_slug_fold_lint in packages/intentd.
- "check" now runs fmt, clippy, lint-repo-slug; "gate" inherits it.
- lint-repo-slug is added to the existing CARGO_TERM_PROGRESS_WHEN / PAGER / GIT_PAGER export lists and .PHONY. Makefile only; no submodule gitlink moves.

The pinned packages/intentd (af13a495) already carries the lint, so "make check" passes on main.

## Verification

- CARGO_TERM_PROGRESS_WHEN=never make lint-repo-slug against the pinned af13a495: 19 tests pass.
- make -n check chains fmt, clippy, then the lint test.
