### PR TITLE
feat: add make test-changed for changed-only Rust nextest runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,7 @@ jobs:
           bash scripts/dev-sandbox.test.sh
           bash scripts/dev-status.test.sh
           bash scripts/docs-check.test.sh
+          bash scripts/rust-changed-tests.test.sh
           bash scripts/shipped-in.test.sh
 
   # Agent-facing documentation links and root hygiene are checked without

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -254,6 +254,10 @@ with no rollback.
   live under `$HOME/.cache/intent/gate-runs`, expire after seven days, and include
   `junit.xml` plus an incremental passed-test stream. Set `GATE_FORCE=1` to ignore
   a matching record and run the complete suite.
+- When the full suite is impractical, run `make test-changed` before entering the
+  merge queue: it diffs the intentd checkout against `origin/main` (override with
+  `BASE=<ref>`), runs only the touched crates' nextest targets, and falls back to the
+  full suite on manifest, lockfile, or nextest-config changes; `DRY_RUN=1` prints the plan.
 - Run long gates as saved command-mode `ws.script` entries (`ws.script.start`, a
   self-checking `ws.hook.schedule` on `ws.script.status`, then `ws.script.output`);
   `ws.script.run` rejects `timeoutSeconds` above budget − 5s (25s default). Saved scripts

--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ WORKSPACES_DIR ?= $(HOME)/intent/workspaces
 SWEEP_DAYS ?= 3
 
 # Parallelism caps shared by the Rust build/test/coverage targets
-# (build-intentd, clippy, test-intentd, coverage-e2e, coverage-all).
+# (build-intentd, clippy, test-intentd, test-changed, coverage-e2e, coverage-all).
 # Negative values mean "logical CPUs minus N" (clamped to at least 1):
 # cargo-nextest accepts them for test threads (NEXTEST_TEST_THREADS /
 # --test-threads) and cargo for build jobs (CARGO_BUILD_JOBS / --jobs) —
@@ -149,8 +149,8 @@ BUILD_JOBS ?= -2
 # human at a terminal can restore the bars with
 # `make test NEXTEST_SHOW_PROGRESS=bar CARGO_TERM_PROGRESS_WHEN=auto`.
 # CI already sets CI=true, under which both tools are non-interactive anyway.
-gate test test-intentd coverage-e2e coverage-all: export NEXTEST_SHOW_PROGRESS ?= none
-gate check clippy build-intentd test test-intentd coverage-e2e coverage-all: export CARGO_TERM_PROGRESS_WHEN ?= never
+gate test test-intentd test-changed coverage-e2e coverage-all: export NEXTEST_SHOW_PROGRESS ?= none
+gate check clippy build-intentd test test-intentd test-changed coverage-e2e coverage-all: export CARGO_TERM_PROGRESS_WHEN ?= never
 
 # Resumable local test runs are opt-in. Records are keyed by the complete
 # monorepo + intentd worktree state and kept outside the checkout.
@@ -167,7 +167,7 @@ FE_BUILD_HEAP_MB ?= 16384
 
 .PHONY: all help doctor bootstrap-dev-host ensure-submodules ensure-intentd-submodule ensure-fe-submodule ensure-ios-submodule \
 	update \
-	build build-intentd build-sidecar gate test test-intentd coverage-e2e coverage-all \
+	build build-intentd build-sidecar gate test test-intentd test-changed coverage-e2e coverage-all \
 	fmt clippy check clean clean-dev \
 	sweep sweep-all seed-dev-providers seed-dev-workspaces dev-daemon release-daemon \
 	run-intentd dev-ui dev-sandbox-ui dev-sandbox-app dev-sandbox-stack dev-fe fe-launch \
@@ -356,6 +356,28 @@ test-intentd: ensure-intentd-submodule
 		--force "$(GATE_FORCE)" \
 		--build-jobs "$(BUILD_JOBS)" \
 		--test-threads "$(TEST_THREADS)"
+
+# Pre-queue gate when the full suite is impractical: runs only the nextest
+# targets the intentd checkout changed vs BASE (default origin/main), mapped
+# per crate by scripts/rust-changed-tests.sh (see its header). Reverse
+# dependencies are not propagated, so `make test` stays the complete gate.
+# The script exits 3 when a build-wide file (Cargo.toml/Cargo.lock, nextest
+# config, toolchain) changed; the target then announces the fallback and runs
+# the full `make test` (skipped under DRY_RUN=1, which only prints the plan).
+test-changed: ensure-intentd-submodule ## Run only the Rust tests the intentd branch changed vs BASE (DRY_RUN=1 prints the plan)
+	@cargo nextest --version >/dev/null 2>&1 || { \
+		echo "[test-changed] ERROR: cargo-nextest is not installed — run 'cargo install cargo-nextest --locked'"; \
+		exit 1; \
+	}
+	@INTENTD_DIR="$(INTENTD_DIR)" BASE="$(BASE)" DRY_RUN="$(DRY_RUN)" \
+		BUILD_JOBS="$(BUILD_JOBS)" TEST_THREADS="$(TEST_THREADS)" \
+		scripts/rust-changed-tests.sh; status=$$?; \
+	if [ "$$status" -ne 3 ]; then exit "$$status"; fi; \
+	if [ -n "$(DRY_RUN)" ] && [ "$(DRY_RUN)" != 0 ]; then \
+		echo "[test-changed] DRY_RUN: would fall back to the full 'make test'"; exit 0; \
+	fi; \
+	echo "[test-changed] falling back to the full 'make test'"; \
+	exec $(MAKE) --no-print-directory test
 
 # Local reproduction of the CI coverage jobs (packages/intentd
 # .github/workflows/ci.yml: coverage-e2e / coverage-all), wrapping the same

--- a/scripts/rust-changed-tests.sh
+++ b/scripts/rust-changed-tests.sh
@@ -10,8 +10,8 @@
 # are inherited as-is (the Makefile sets them).
 #
 # The changed set is `git diff --name-only $(git merge-base HEAD BASE)` inside
-# INTENTD_DIR (committed, staged and unstaged edits) plus the untracked paths
-# from `git status --porcelain`. Paths map to per-crate nextest selections:
+# INTENTD_DIR (committed, staged and unstaged edits) plus the untracked files
+# from `git ls-files --others`. Paths map to per-crate nextest selections:
 #   crates/<c>/tests/<t>.rs          -p <c> --test <t>   (--tests once deleted)
 #   crates/<c>/tests/<dir>/**        -p <c> --tests
 #   crates/<c>/src/**                -p <c> --lib --bins --tests
@@ -88,18 +88,6 @@ git rev-parse --git-dir >/dev/null 2>&1 || die 2 "$display_dir is not a git chec
 merge_base=$(git merge-base HEAD "$base" 2>/dev/null) ||
   die 2 "cannot resolve BASE '$base' in $display_dir; run 'git -C $display_dir fetch origin main' or set BASE=<ref>"
 
-# Committed + staged + unstaged edits since the merge base, then untracked
-# paths (`?? <path>`; renames are reported as `<old> -> <new>`).
-changed=$(
-  git diff --name-only "$merge_base" --
-  git status --porcelain --untracked-files=all | while IFS= read -r line; do
-    [[ "$line" == '??'* ]] || continue
-    path=${line:3}
-    printf '%s\n' "${path##* -> }"
-  done
-)
-changed=$(printf '%s\n' "$changed" | sort -u)
-
 is_fallback() {
   case "$1" in
     Cargo.toml | Cargo.lock | rust-toolchain.toml | .config/nextest.toml | .cargo/*) return 0 ;;
@@ -133,14 +121,27 @@ map_path() {
 
 fallback=""
 mapped=""
-while IFS= read -r path; do
-  [[ -n "$path" ]] || continue
+seen=""
+classify() {
+  local path=$1
+  [[ -n "$path" && "$seen" != *$'\n'"$path"$'\n'* ]] || return 0
+  seen+=$'\n'"$path"$'\n'
   if is_fallback "$path"; then
     fallback+="$path"$'\n'
   else
     mapped+="$(map_path "$path")"$'\n'
   fi
-done <<<"$changed"
+}
+
+# Committed + staged + unstaged edits since the merge base, then untracked
+# files. Both are read NUL-delimited so paths arrive raw: line-oriented
+# porcelain output C-quotes names with spaces or non-ASCII characters.
+while IFS= read -r -d '' path; do
+  classify "$path"
+done < <(git diff --name-only -z "$merge_base" --)
+while IFS= read -r -d '' path; do
+  classify "$path"
+done < <(git ls-files -z --others --exclude-standard)
 
 if [[ -n "$fallback" ]]; then
   echo "[test-changed] build-wide change(s) vs $base need the full suite -- run 'make test':" >&2

--- a/scripts/rust-changed-tests.sh
+++ b/scripts/rust-changed-tests.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+# Run only the nextest targets a packages/intentd branch touched.
+#
+#   scripts/rust-changed-tests.sh [--dry-run] [--base REF] [--intentd-dir DIR]
+#                                 [--build-jobs N] [--test-threads N]
+#
+# Each flag falls back to an environment variable: DRY_RUN=1, BASE (default
+# origin/main), INTENTD_DIR (default packages/intentd next to this script),
+# BUILD_JOBS, TEST_THREADS. NEXTEST_SHOW_PROGRESS / CARGO_TERM_PROGRESS_WHEN
+# are inherited as-is (the Makefile sets them).
+#
+# The changed set is `git diff --name-only $(git merge-base HEAD BASE)` inside
+# INTENTD_DIR (committed, staged and unstaged edits) plus the untracked paths
+# from `git status --porcelain`. Paths map to per-crate nextest selections:
+#   crates/<c>/tests/<t>.rs          -p <c> --test <t>   (--tests once deleted)
+#   crates/<c>/tests/<dir>/**        -p <c> --tests
+#   crates/<c>/src/**                -p <c> --lib --bins --tests
+#                                    (--lib only when src/lib.rs exists)
+#   crates/<c>/benches|examples/**   ignored (nextest does not run them)
+#   crates/<c>/<anything else>       -p <c>  (all test targets of <c>)
+#   outside crates/                  ignored
+# A broader selection subsumes narrower ones for the same crate. Cargo applies
+# target flags to every -p package on one command line, so crates with
+# different selections run as separate `cargo nextest run` invocations and
+# crates with identical selections share one. Reverse dependencies are NOT
+# propagated: crates/<c>/src selects <c>'s own tests only; `make test` stays
+# the complete gate.
+#
+# Exit codes: 0 = nothing to test, or every invocation passed; 2 = usage error
+# or BASE cannot be resolved; 3 = a build-wide file changed (Cargo.toml,
+# Cargo.lock, crates/*/Cargo.toml, crates/*/build.rs, .config/nextest.toml,
+# rust-toolchain.toml, .cargo/**) -- run the full `make test` instead; any
+# other code is the first failing cargo invocation's exit code.
+
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)
+intentd_dir=${INTENTD_DIR:-$repo_root/packages/intentd}
+base=${BASE:-origin/main}
+build_jobs=${BUILD_JOBS:-}
+test_threads=${TEST_THREADS:-}
+dry_run=${DRY_RUN:-}
+
+usage() {
+  echo "Usage: $0 [--dry-run] [--base REF] [--intentd-dir DIR] [--build-jobs N] [--test-threads N]" >&2
+  exit 2
+}
+
+while (($# > 0)); do
+  case "$1" in
+    --dry-run) dry_run=1 ;;
+    --base=*) base=${1#--base=} ;;
+    --intentd-dir=*) intentd_dir=${1#--intentd-dir=} ;;
+    --build-jobs=*) build_jobs=${1#--build-jobs=} ;;
+    --test-threads=*) test_threads=${1#--test-threads=} ;;
+    --base | --intentd-dir | --build-jobs | --test-threads)
+      [[ $# -ge 2 && -n "$2" ]] || usage
+      case "$1" in
+        --base) base=$2 ;;
+        --intentd-dir) intentd_dir=$2 ;;
+        --build-jobs) build_jobs=$2 ;;
+        --test-threads) test_threads=$2 ;;
+      esac
+      shift
+      ;;
+    *) usage ;;
+  esac
+  shift
+done
+[[ -n "$base" ]] || usage
+[[ -n "$dry_run" && "$dry_run" != 0 ]] || dry_run=""
+
+log() {
+  echo "[test-changed] $*"
+}
+
+die() {
+  local code=$1
+  shift
+  echo "[test-changed] $*" >&2
+  exit "$code"
+}
+
+display_dir=${intentd_dir#"$PWD"/}
+[[ -d "$intentd_dir" ]] || die 2 "intentd checkout not found at $display_dir (set INTENTD_DIR)"
+cd "$intentd_dir"
+git rev-parse --git-dir >/dev/null 2>&1 || die 2 "$display_dir is not a git checkout (set INTENTD_DIR)"
+merge_base=$(git merge-base HEAD "$base" 2>/dev/null) ||
+  die 2 "cannot resolve BASE '$base' in $display_dir; run 'git -C $display_dir fetch origin main' or set BASE=<ref>"
+
+# Committed + staged + unstaged edits since the merge base, then untracked
+# paths (`?? <path>`; renames are reported as `<old> -> <new>`).
+changed=$(
+  git diff --name-only "$merge_base" --
+  git status --porcelain --untracked-files=all | while IFS= read -r line; do
+    [[ "$line" == '??'* ]] || continue
+    path=${line:3}
+    printf '%s\n' "${path##* -> }"
+  done
+)
+changed=$(printf '%s\n' "$changed" | sort -u)
+
+is_fallback() {
+  case "$1" in
+    Cargo.toml | Cargo.lock | rust-toolchain.toml | .config/nextest.toml | .cargo/*) return 0 ;;
+    crates/*/Cargo.toml | crates/*/build.rs) return 0 ;;
+  esac
+  return 1
+}
+
+# Prints "<crate>\t<kind>[\t<test>]" for a path under crates/, kinds ranked
+# test < tests < src < all; prints nothing for ignored paths.
+map_path() {
+  local path=$1 rest crate sub name
+  [[ "$path" == crates/*/* ]] || return 0
+  rest=${path#crates/}
+  crate=${rest%%/*}
+  sub=${rest#*/}
+  case "$sub" in
+    tests/*)
+      name=${sub#tests/}
+      if [[ "$name" == *.rs && "$name" != */* && -f "$path" ]]; then
+        printf '%s\ttest\t%s\n' "$crate" "${name%.rs}"
+      else
+        printf '%s\ttests\n' "$crate"
+      fi
+      ;;
+    src/*) printf '%s\tsrc\n' "$crate" ;;
+    benches/* | examples/*) ;;
+    *) printf '%s\tall\n' "$crate" ;;
+  esac
+}
+
+fallback=""
+mapped=""
+while IFS= read -r path; do
+  [[ -n "$path" ]] || continue
+  if is_fallback "$path"; then
+    fallback+="$path"$'\n'
+  else
+    mapped+="$(map_path "$path")"$'\n'
+  fi
+done <<<"$changed"
+
+if [[ -n "$fallback" ]]; then
+  echo "[test-changed] build-wide change(s) vs $base need the full suite -- run 'make test':" >&2
+  printf '%s' "$fallback" | while IFS= read -r path; do echo "  $path" >&2; done
+  exit 3
+fi
+
+# Stock macOS ships Bash 3.2, which has no associative arrays: per-crate
+# lookups scan the newline-separated "<crate>\t<kind>[\t<test>]" records.
+crates=""
+while IFS=$'\t' read -r crate _; do
+  [[ -n "$crate" ]] && crates+="$crate"$'\n'
+done <<<"$mapped"
+crates=$(printf '%s' "$crates" | sort -u)
+
+if [[ -z "$crates" ]]; then
+  log "nothing to test (no Rust changes vs $base)"
+  exit 0
+fi
+
+# Sets crate_filter to the target flags for one crate ("" = every test target).
+crate_selection() {
+  local crate=$1 best=test tests="" c kind test
+  while IFS=$'\t' read -r c kind test; do
+    [[ "$c" == "$crate" ]] || continue
+    case "$kind" in
+      all) best=all ;;
+      src) [[ "$best" == all ]] || best=src ;;
+      tests) [[ "$best" == all || "$best" == src ]] || best=tests ;;
+      test) tests+="$test"$'\n' ;;
+    esac
+  done <<<"$mapped"
+  case "$best" in
+    all) crate_filter="" ;;
+    src)
+      crate_filter="--bins --tests"
+      [[ -f "crates/$crate/src/lib.rs" ]] && crate_filter="--lib $crate_filter"
+      log "note: crates/$crate/src changed; only $crate's own tests run (downstream crates are not selected)"
+      ;;
+    tests) crate_filter="--tests" ;;
+    test)
+      crate_filter=""
+      while IFS= read -r test; do
+        crate_filter+="${crate_filter:+ }--test $test"
+      done <<<"$(printf '%s' "$tests" | sort -u)"
+      ;;
+  esac
+}
+
+selections=""
+while IFS= read -r crate; do
+  crate_selection "$crate"
+  selections+="$crate"$'\t'"$crate_filter"$'\n'
+done <<<"$crates"
+
+# One invocation per distinct filter, in first-crate order: cargo applies
+# target flags to every -p package on the command line.
+plans=""
+grouped=""
+while IFS=$'\t' read -r crate filter; do
+  [[ -n "$crate" && "$grouped" != *" $crate "* ]] || continue
+  members=""
+  while IFS=$'\t' read -r other other_filter; do
+    if [[ -n "$other" && "$other_filter" == "$filter" ]]; then
+      members+="-p $other "
+      grouped+=" $other "
+    fi
+  done <<<"$selections"
+  plans+="$members$filter"$'\n'
+done <<<"$selections"
+
+extra=""
+[[ -n "$build_jobs" ]] && extra+=" --build-jobs $build_jobs"
+[[ -n "$test_threads" ]] && extra+=" --test-threads $test_threads"
+
+while IFS= read -r plan; do
+  [[ -n "$plan" ]] || continue
+  log "cargo nextest run ${plan% }$extra"
+done <<<"$plans"
+
+[[ -z "$dry_run" ]] || exit 0
+
+# The plans are read from fd 3 so cargo keeps the caller's stdin.
+while IFS= read -r -u 3 plan; do
+  [[ -n "$plan" ]] || continue
+  # $plan and $extra hold only the flags assembled above; split them on purpose.
+  # shellcheck disable=SC2086
+  set -- $plan $extra
+  set +e
+  cargo nextest run "$@"
+  status=$?
+  set -e
+  [[ "$status" -eq 0 ]] || die "$status" "cargo nextest run ${plan% }$extra exited $status"
+done 3<<<"$plans"

--- a/scripts/rust-changed-tests.sh
+++ b/scripts/rust-changed-tests.sh
@@ -134,14 +134,20 @@ classify() {
 }
 
 # Committed + staged + unstaged edits since the merge base, then untracked
-# files. Both are read NUL-delimited so paths arrive raw: line-oriented
-# porcelain output C-quotes names with spaces or non-ASCII characters.
+# files. Both are read NUL-delimited so paths arrive raw (line-oriented
+# porcelain output C-quotes names with spaces or non-ASCII characters) and
+# with rename detection off so both sides of a move count as changed. The
+# output goes through a file so a failing git command is not silently read
+# as an empty change set.
+changed_file=$(mktemp "${TMPDIR:-/tmp}/rust-changed-tests.XXXXXX")
+trap 'rm -f "$changed_file"' EXIT
+git diff --name-only -z --no-renames "$merge_base" -- >"$changed_file" ||
+  die 2 "git diff --name-only $merge_base failed in $display_dir (exit $?)"
+git ls-files -z --others --exclude-standard >>"$changed_file" ||
+  die 2 "git ls-files --others failed in $display_dir (exit $?)"
 while IFS= read -r -d '' path; do
   classify "$path"
-done < <(git diff --name-only -z "$merge_base" --)
-while IFS= read -r -d '' path; do
-  classify "$path"
-done < <(git ls-files -z --others --exclude-standard)
+done <"$changed_file"
 
 if [[ -n "$fallback" ]]; then
   echo "[test-changed] build-wide change(s) vs $base need the full suite -- run 'make test':" >&2

--- a/scripts/rust-changed-tests.sh
+++ b/scripts/rust-changed-tests.sh
@@ -18,7 +18,12 @@
 #                                    (--lib only when src/lib.rs exists)
 #   crates/<c>/benches|examples/**   ignored (nextest does not run them)
 #   crates/<c>/<anything else>       -p <c>  (all test targets of <c>)
-#   outside crates/                  ignored
+#   outside crates/, inert           ignored: *.md, LICENSE, NOTICE, .gitignore,
+#                                    .github/**, docs/**, deny.toml,
+#                                    release-plz.toml, dist-workspace.toml
+#   outside crates/, anything else   full suite (exit 3) -- tests read repo
+#                                    files such as scripts/install.sh via
+#                                    CARGO_MANIFEST_DIR, so fail closed
 # A broader selection subsumes narrower ones for the same crate. Cargo applies
 # target flags to every -p package on one command line, so crates with
 # different selections run as separate `cargo nextest run` invocations and
@@ -29,8 +34,9 @@
 # Exit codes: 0 = nothing to test, or every invocation passed; 2 = usage error
 # or BASE cannot be resolved; 3 = a build-wide file changed (Cargo.toml,
 # Cargo.lock, crates/*/Cargo.toml, crates/*/build.rs, .config/nextest.toml,
-# rust-toolchain.toml, .cargo/**) -- run the full `make test` instead; any
-# other code is the first failing cargo invocation's exit code.
+# rust-toolchain.toml, .cargo/**) or a non-inert path outside crates/ changed
+# -- run the full `make test` instead; any other code is the first failing
+# cargo invocation's exit code.
 
 set -euo pipefail
 
@@ -88,12 +94,24 @@ git rev-parse --git-dir >/dev/null 2>&1 || die 2 "$display_dir is not a git chec
 merge_base=$(git merge-base HEAD "$base" 2>/dev/null) ||
   die 2 "cannot resolve BASE '$base' in $display_dir; run 'git -C $display_dir fetch origin main' or set BASE=<ref>"
 
+# Paths outside crates/ that no test can observe.
+is_inert() {
+  case "$1" in
+    *.md | LICENSE | NOTICE | .gitignore | deny.toml | release-plz.toml | dist-workspace.toml) return 0 ;;
+    .github/* | docs/*) return 0 ;;
+  esac
+  return 1
+}
+
 is_fallback() {
   case "$1" in
     Cargo.toml | Cargo.lock | rust-toolchain.toml | .config/nextest.toml | .cargo/*) return 0 ;;
     crates/*/Cargo.toml | crates/*/build.rs) return 0 ;;
+    crates/*) return 1 ;;
   esac
-  return 1
+  # Anything else outside crates/ may be read by a test through
+  # CARGO_MANIFEST_DIR (scripts/install.sh, repo-wide lints), so fail closed.
+  ! is_inert "$1"
 }
 
 # Prints "<crate>\t<kind>[\t<test>]" for a path under crates/, kinds ranked

--- a/scripts/rust-changed-tests.test.sh
+++ b/scripts/rust-changed-tests.test.sh
@@ -2,6 +2,10 @@
 
 set -euo pipefail
 
+# The caller's environment must not steer the script under test (a shell with
+# BASE=HEAD or DRY_RUN=1 exported would change every expected argv).
+unset BASE DRY_RUN INTENTD_DIR BUILD_JOBS TEST_THREADS NEXTEST_SHOW_PROGRESS CARGO_TERM_PROGRESS_WHEN
+
 repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)
 script="$repo_root/scripts/rust-changed-tests.sh"
 # The interpreter that runs the script under test defaults to the one running
@@ -22,9 +26,22 @@ fail() {
   exit 1
 }
 
-for command in bash dirname git sort; do
+for command in bash dirname mktemp rm sort; do
   ln -s "$(command -v "$command")" "$bin_dir/$command"
 done
+
+# git wrapper: the subcommand named by GIT_STUB_FAIL fails like a broken
+# checkout would; everything else reaches the real git.
+real_git=$(command -v git)
+cat >"$bin_dir/git" <<SH
+#!/usr/bin/env bash
+if [[ -n "\${GIT_STUB_FAIL-}" && "\${1-}" == "\$GIT_STUB_FAIL" ]]; then
+  echo "fatal: stubbed git \$1 failure" >&2
+  exit 128
+fi
+exec "$real_git" "\$@"
+SH
+chmod +x "$bin_dir/git"
 
 # Stub cargo: every invocation is appended to CARGO_TEST_LOG as "<cwd>: <argv>"
 # and exits with CARGO_STUB_EXIT (default 0). It drains stdin like a real
@@ -208,12 +225,23 @@ run_script
 expect_ok
 expect_cargo "-p alpha --tests"
 
-case_name="renamed integration test selects the new name"
+# Both sides of a rename count as changed (rename detection is off), so a
+# moved test is a deleted one plus a new one.
+case_name="renamed integration test counts the old and new path"
 reset_repo
 g mv crates/alpha/tests/one.rs crates/alpha/tests/moved.rs
 run_script
 expect_ok
-expect_cargo "-p alpha --test moved"
+expect_cargo "-p alpha --tests"
+
+case_name="file moved from src into tests keeps the src selection"
+reset_repo
+g mv crates/alpha/src/util/mod.rs crates/alpha/tests/old.rs
+run_script
+expect_ok
+expect_plan "-p alpha --lib --bins --tests"
+expect_cargo "-p alpha --lib --bins --tests"
+[[ "$stdout" == *"note: crates/alpha/src changed"* ]] || fail "$case_name: no src note: $stdout"
 
 case_name="deleted integration test falls back to --tests"
 reset_repo
@@ -354,6 +382,26 @@ write .cargo/audit.toml
 DRY_RUN=1 run_script
 [[ "$status" -eq 3 ]] || fail "$case_name exited $status (expected 3): $stderr"
 [[ "$stderr" == *"  .cargo/audit.toml"* ]] || fail "$case_name stderr: $stderr"
+case_name="renamed build-wide file still needs the full suite"
+reset_repo
+g mv Cargo.lock Cargo.lock.backup
+run_script
+[[ "$status" -eq 3 ]] || fail "$case_name exited $status (expected 3): $stderr"
+[[ -z "$stdout" ]] || fail "$case_name printed '$stdout'"
+[[ "$stderr" == *"  Cargo.lock"* ]] || fail "$case_name stderr: $stderr"
+[[ -z "$cargo_log" ]] || fail "$case_name invoked cargo: $cargo_log"
+
+# A failing git command is an error, never an empty change set.
+for subcommand in diff ls-files; do
+  case_name="git $subcommand failure"
+  reset_repo
+  edit crates/alpha/tests/one.rs
+  GIT_STUB_FAIL=$subcommand run_script
+  [[ "$status" -eq 2 ]] || fail "$case_name exited $status (expected 2): $stderr"
+  [[ -z "$stdout" ]] || fail "$case_name printed '$stdout'"
+  [[ "$stderr" == "fatal: stubbed git $subcommand failure"$'\n'"[test-changed] git $subcommand "*" failed in $repo (exit 128)" ]] || fail "$case_name stderr: $stderr"
+  [[ -z "$cargo_log" ]] || fail "$case_name invoked cargo: $cargo_log"
+done
 
 case_name="unresolvable BASE"
 reset_repo

--- a/scripts/rust-changed-tests.test.sh
+++ b/scripts/rust-changed-tests.test.sh
@@ -1,0 +1,441 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)
+script="$repo_root/scripts/rust-changed-tests.sh"
+# The interpreter that runs the script under test defaults to the one running
+# this suite; the Bash 3.2 compatibility pass at the end re-executes the suite
+# with it set to a real Bash 3.
+script_bash=${RUST_CHANGED_TESTS_TEST_BASH:-$BASH}
+temp_dir=$(cd "$(mktemp -d)" && pwd -P)
+bin_dir="$temp_dir/bin"
+# The fixture checkout sits where the script's INTENTD_DIR default resolves
+# relative to a symlinked copy of the script under $temp_dir/scripts.
+repo="$temp_dir/packages/intentd"
+mkdir -p "$bin_dir" "$repo" "$temp_dir/scripts"
+ln -s "$script" "$temp_dir/scripts/rust-changed-tests.sh"
+trap 'rm -rf "$temp_dir"' EXIT
+
+fail() {
+  echo "rust-changed-tests test failed: $*" >&2
+  exit 1
+}
+
+for command in bash dirname git sort; do
+  ln -s "$(command -v "$command")" "$bin_dir/$command"
+done
+
+# Stub cargo: every invocation is appended to CARGO_TEST_LOG as "<cwd>: <argv>"
+# and exits with CARGO_STUB_EXIT (default 0). It drains stdin like a real
+# nextest child could, so the script must not feed it the remaining plans.
+cat >"$bin_dir/cargo" <<'SH'
+#!/usr/bin/env bash
+printf '%s: %s\n' "$PWD" "$*" >>"$CARGO_TEST_LOG"
+while IFS= read -r _; do :; done
+exit "${CARGO_STUB_EXIT:-0}"
+SH
+chmod +x "$bin_dir/cargo"
+
+export GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1
+export GIT_AUTHOR_NAME=test GIT_AUTHOR_EMAIL=test@example.invalid
+export GIT_COMMITTER_NAME=test GIT_COMMITTER_EMAIL=test@example.invalid
+
+g() {
+  git -C "$repo" "$@"
+}
+
+# Fixture workspace: alpha has a lib and two integration tests with shared
+# helpers, beta is a binary-only crate, gamma mirrors alpha's smoke test name.
+write() {
+  mkdir -p "$repo/$(dirname "$1")"
+  printf '%s\n' "${2:-$1}" >"$repo/$1"
+}
+write Cargo.toml '[workspace]'
+write Cargo.lock
+write rust-toolchain.toml
+write .config/nextest.toml
+write .cargo/config.toml
+write crates/alpha/Cargo.toml
+write crates/alpha/src/lib.rs
+write crates/alpha/src/util/mod.rs
+write crates/alpha/tests/one.rs
+write crates/alpha/tests/two.rs
+write crates/alpha/tests/common/mod.rs
+write crates/alpha/tests/fixtures/data.json
+write crates/alpha/benches/bench.rs
+write crates/alpha/examples/demo.rs
+write crates/beta/Cargo.toml
+write crates/beta/build.rs
+write crates/beta/src/main.rs
+write crates/beta/tests/smoke.rs
+write crates/beta/migrations/001.sql
+write crates/gamma/Cargo.toml
+write crates/gamma/src/lib.rs
+write crates/gamma/tests/smoke.rs
+write README.md
+write docs/guide.md
+write scripts/tool.sh
+g init -q
+g add -A
+g commit -q -m base
+g update-ref refs/remotes/origin/main HEAD
+g checkout -q -b feature
+
+reset_repo() {
+  g reset -q --hard refs/remotes/origin/main
+  g clean -fdq
+  : >"$temp_dir/cargo.log"
+}
+
+edit() {
+  echo "// changed" >>"$repo/$1"
+}
+
+commit_all() {
+  g add -A
+  g commit -q -m "${1:-change}"
+}
+
+# Env prefixes on the call (DRY_RUN=1 run_script ...) reach the script; the
+# inputs it reads default to unset here so the suite's own environment cannot
+# leak into the expected argv.
+run_script() {
+  set +e
+  PATH="$bin_dir" INTENTD_DIR="${INTENTD_DIR-$repo}" BASE="${BASE-}" \
+    BUILD_JOBS="${BUILD_JOBS-}" TEST_THREADS="${TEST_THREADS-}" DRY_RUN="${DRY_RUN-}" \
+    CARGO_TEST_LOG="$temp_dir/cargo.log" \
+    "$script_bash" "${SCRIPT_UNDER_TEST:-$script}" "$@" >"$temp_dir/stdout" 2>"$temp_dir/stderr"
+  status=$?
+  set -e
+  stdout=$(<"$temp_dir/stdout")
+  stderr=$(<"$temp_dir/stderr")
+  cargo_log=$(<"$temp_dir/cargo.log")
+}
+
+expect_cargo() {
+  local expected="" line
+  for line in "$@"; do
+    expected+="$repo: nextest run $line"$'\n'
+  done
+  [[ "$cargo_log" == "${expected%$'\n'}" ]] || fail "$case_name: cargo argv was"$'\n'"$cargo_log"$'\n'"expected"$'\n'"${expected%$'\n'}"
+}
+
+expect_plan() {
+  local line
+  for line in "$@"; do
+    [[ "$stdout" == *"[test-changed] cargo nextest run $line"* ]] || fail "$case_name: plan is missing '$line':"$'\n'"$stdout"
+  done
+  [[ "$(grep -c '^\[test-changed\] cargo nextest run ' <<<"$stdout")" -eq $# ]] || fail "$case_name: expected $# plan line(s):"$'\n'"$stdout"
+}
+
+expect_ok() {
+  [[ "$status" -eq 0 ]] || fail "$case_name: exited $status: $stderr"
+  [[ -z "$stderr" ]] || fail "$case_name: unexpected stderr: $stderr"
+}
+
+
+case_name="clean tree"
+reset_repo
+run_script
+expect_ok
+[[ "$stdout" == "[test-changed] nothing to test (no Rust changes vs origin/main)" ]] || fail "$case_name printed '$stdout'"
+[[ -z "$cargo_log" ]] || fail "$case_name invoked cargo: $cargo_log"
+
+case_name="committed single test file"
+reset_repo
+edit crates/alpha/tests/one.rs
+commit_all
+run_script
+expect_ok
+expect_plan "-p alpha --test one"
+expect_cargo "-p alpha --test one"
+[[ "$stdout" != *"note:"* ]] || fail "$case_name printed the src note: $stdout"
+
+case_name="unstaged, staged and untracked edits"
+reset_repo
+edit crates/alpha/tests/one.rs
+edit crates/alpha/tests/two.rs
+g add crates/alpha/tests/two.rs
+write crates/gamma/tests/fresh.rs
+run_script
+expect_ok
+expect_cargo "-p alpha --test one --test two" "-p gamma --test fresh"
+
+case_name="committed change under a feature branch with main moved on"
+reset_repo
+edit crates/alpha/tests/one.rs
+commit_all
+g checkout -q --detach refs/remotes/origin/main
+edit crates/beta/tests/smoke.rs
+commit_all "main moved on"
+g update-ref refs/remotes/origin/main HEAD
+g checkout -q feature
+run_script
+expect_ok
+expect_cargo "-p alpha --test one"
+
+case_name="shared test helpers select every integration test of the crate"
+reset_repo
+edit crates/alpha/tests/common/mod.rs
+edit crates/alpha/tests/one.rs
+run_script
+expect_ok
+expect_plan "-p alpha --tests"
+expect_cargo "-p alpha --tests"
+
+case_name="test fixture selects every integration test of the crate"
+reset_repo
+edit crates/alpha/tests/fixtures/data.json
+run_script
+expect_ok
+expect_cargo "-p alpha --tests"
+
+case_name="deleted integration test falls back to --tests"
+reset_repo
+g rm -q crates/alpha/tests/two.rs
+run_script
+expect_ok
+expect_cargo "-p alpha --tests"
+
+case_name="src change selects lib, bins and integration tests with a note"
+reset_repo
+edit crates/alpha/src/util/mod.rs
+edit crates/alpha/tests/one.rs
+run_script
+expect_ok
+expect_plan "-p alpha --lib --bins --tests"
+expect_cargo "-p alpha --lib --bins --tests"
+[[ "$stdout" == *"[test-changed] note: crates/alpha/src changed; only alpha's own tests run (downstream crates are not selected)"* ]] || fail "$case_name: no src note: $stdout"
+[[ "$(grep -c 'note:' <<<"$stdout")" -eq 1 ]] || fail "$case_name: note printed more than once: $stdout"
+
+case_name="src change in a crate without a lib drops --lib"
+reset_repo
+edit crates/beta/src/main.rs
+run_script
+expect_ok
+expect_cargo "-p beta --bins --tests"
+
+case_name="other crate file selects every test target and subsumes the rest"
+reset_repo
+edit crates/beta/migrations/001.sql
+edit crates/beta/src/main.rs
+edit crates/beta/tests/smoke.rs
+run_script
+expect_ok
+expect_plan "-p beta"
+expect_cargo "-p beta"
+[[ "$stdout" != *"note:"* ]] || fail "$case_name printed the src note for a subsumed selection: $stdout"
+
+case_name="benches, examples and non-crate paths are ignored"
+reset_repo
+edit crates/alpha/benches/bench.rs
+edit crates/alpha/examples/demo.rs
+edit README.md
+edit docs/guide.md
+edit scripts/tool.sh
+write .github/workflows/ci.yml
+run_script
+expect_ok
+[[ "$stdout" == *"nothing to test"* ]] || fail "$case_name printed '$stdout'"
+[[ -z "$cargo_log" ]] || fail "$case_name invoked cargo: $cargo_log"
+
+case_name="crates with different selections run separately, identical ones share"
+reset_repo
+edit crates/alpha/tests/common/mod.rs
+write crates/gamma/tests/fixtures/x.json
+edit crates/beta/src/main.rs
+run_script
+expect_ok
+expect_plan "-p alpha -p gamma --tests" "-p beta --bins --tests"
+expect_cargo "-p alpha -p gamma --tests" "-p beta --bins --tests"
+
+case_name="same-named test files across crates share one invocation"
+reset_repo
+edit crates/beta/tests/smoke.rs
+edit crates/gamma/tests/smoke.rs
+run_script
+expect_ok
+expect_cargo "-p beta -p gamma --test smoke"
+
+case_name="different test files across crates stay separate"
+reset_repo
+edit crates/alpha/tests/one.rs
+edit crates/gamma/tests/smoke.rs
+run_script
+expect_ok
+expect_cargo "-p alpha --test one" "-p gamma --test smoke"
+
+case_name="build-jobs and test-threads are appended"
+reset_repo
+edit crates/alpha/tests/one.rs
+BUILD_JOBS=-2 TEST_THREADS=4 run_script
+expect_ok
+expect_plan "-p alpha --test one --build-jobs -2 --test-threads 4"
+expect_cargo "-p alpha --test one --build-jobs -2 --test-threads 4"
+reset_repo
+edit crates/alpha/tests/one.rs
+run_script --build-jobs 3 --test-threads=num-cpus
+expect_ok
+expect_cargo "-p alpha --test one --build-jobs 3 --test-threads num-cpus"
+
+case_name="dry run prints the plan without invoking cargo"
+reset_repo
+edit crates/alpha/tests/one.rs
+edit crates/beta/src/main.rs
+DRY_RUN=1 run_script
+expect_ok
+expect_plan "-p alpha --test one" "-p beta --bins --tests"
+[[ -z "$cargo_log" ]] || fail "$case_name invoked cargo: $cargo_log"
+run_script --dry-run
+expect_ok
+[[ -z "$cargo_log" ]] || fail "$case_name (--dry-run) invoked cargo: $cargo_log"
+DRY_RUN=0 run_script
+expect_ok
+expect_cargo "-p alpha --test one" "-p beta --bins --tests"
+
+case_name="cargo failure stops the run and propagates its exit code"
+reset_repo
+edit crates/alpha/tests/one.rs
+edit crates/beta/src/main.rs
+CARGO_STUB_EXIT=100 run_script
+[[ "$status" -eq 100 ]] || fail "$case_name exited $status (expected 100): $stderr"
+expect_cargo "-p alpha --test one"
+[[ "$stderr" == "[test-changed] cargo nextest run -p alpha --test one exited 100" ]] || fail "$case_name stderr: $stderr"
+
+# Build-wide files make the subset unreliable: exit 3 names them and defers to
+# the full `make test` (the Makefile target turns 3 into that run).
+for path in Cargo.toml Cargo.lock rust-toolchain.toml .config/nextest.toml .cargo/config.toml \
+  crates/alpha/Cargo.toml crates/beta/build.rs; do
+  case_name="build-wide change $path"
+  reset_repo
+  edit "$path"
+  edit crates/alpha/tests/one.rs
+  run_script
+  [[ "$status" -eq 3 ]] || fail "$case_name exited $status (expected 3): $stderr"
+  [[ -z "$stdout" ]] || fail "$case_name printed '$stdout'"
+  [[ "$stderr" == *"need the full suite -- run 'make test':"*"  $path"* ]] || fail "$case_name stderr: $stderr"
+  [[ -z "$cargo_log" ]] || fail "$case_name invoked cargo: $cargo_log"
+done
+case_name="build-wide change in a dry run"
+reset_repo
+write .cargo/audit.toml
+DRY_RUN=1 run_script
+[[ "$status" -eq 3 ]] || fail "$case_name exited $status (expected 3): $stderr"
+[[ "$stderr" == *"  .cargo/audit.toml"* ]] || fail "$case_name stderr: $stderr"
+
+case_name="unresolvable BASE"
+reset_repo
+edit crates/alpha/tests/one.rs
+BASE=origin/nope run_script
+[[ "$status" -eq 2 ]] || fail "$case_name exited $status (expected 2): $stderr"
+[[ -z "$stdout" ]] || fail "$case_name printed '$stdout'"
+[[ "$stderr" == "[test-changed] cannot resolve BASE 'origin/nope' in $repo; run 'git -C $repo fetch origin main' or set BASE=<ref>" ]] || fail "$case_name stderr: $stderr"
+[[ -z "$cargo_log" ]] || fail "$case_name invoked cargo: $cargo_log"
+run_script --base origin/nope
+[[ "$status" -eq 2 ]] || fail "$case_name (--base) exited $status (expected 2): $stderr"
+
+case_name="explicit BASE"
+reset_repo
+edit crates/alpha/tests/one.rs
+commit_all
+g branch -q -f other HEAD
+edit crates/gamma/tests/smoke.rs
+commit_all
+BASE=other run_script
+expect_ok
+expect_cargo "-p gamma --test smoke"
+run_script --base=other --dry-run
+expect_ok
+expect_plan "-p gamma --test smoke"
+
+case_name="INTENTD_DIR that is not a checkout"
+reset_repo
+INTENTD_DIR="$temp_dir/missing" run_script
+[[ "$status" -eq 2 ]] || fail "$case_name (missing) exited $status (expected 2): $stderr"
+[[ "$stderr" == *"intentd checkout not found at $temp_dir/missing (set INTENTD_DIR)"* ]] || fail "$case_name (missing) stderr: $stderr"
+INTENTD_DIR="$bin_dir" run_script
+[[ "$status" -eq 2 ]] || fail "$case_name (not git) exited $status (expected 2): $stderr"
+[[ "$stderr" == *"$bin_dir is not a git checkout (set INTENTD_DIR)"* ]] || fail "$case_name (not git) stderr: $stderr"
+
+case_name="INTENTD_DIR defaults to packages/intentd next to the script"
+reset_repo
+edit crates/alpha/tests/one.rs
+INTENTD_DIR="" SCRIPT_UNDER_TEST="$temp_dir/scripts/rust-changed-tests.sh" run_script
+expect_ok
+expect_cargo "-p alpha --test one"
+INTENTD_DIR="" run_script --intentd-dir "$repo" --dry-run
+expect_ok
+expect_plan "-p alpha --test one"
+
+case_name="usage errors"
+reset_repo
+edit crates/alpha/tests/one.rs
+for args in --bogus "--base" "--build-jobs" "extra"; do
+  # shellcheck disable=SC2086
+  run_script $args
+  [[ "$status" -eq 2 ]] || fail "$case_name '$args' exited $status (expected 2): $stderr"
+  [[ "$stderr" == "Usage: "* ]] || fail "$case_name '$args' stderr: $stderr"
+done
+[[ -z "$cargo_log" ]] || fail "$case_name invoked cargo: $cargo_log"
+
+echo "rust-changed-tests tests passed under $("$script_bash" -c 'echo "bash $BASH_VERSION"')"
+[[ -z "${RUST_CHANGED_TESTS_TEST_BASH:-}" ]] || exit 0
+
+# Stock macOS /bin/bash is 3.2 (intent-hq/intent#4706). `bash -n` alone
+# accepts Bash 4+ builtins and expansions, so reject them by pattern too,
+# then rerun the fixtures under a real Bash 3 when one can be found (same
+# lookup as shipped-in.test.sh).
+bash -n "$script" || fail "rust-changed-tests.sh does not parse"
+bash -n "${BASH_SOURCE[0]}" || fail "rust-changed-tests.test.sh does not parse"
+bash4_constructs='(^|[^A-Za-z0-9_])(declare|local|typeset)([[:blank:]]+-[A-Za-z]+)*[[:blank:]]+-[A-Za-z]*[An][A-Za-z]*([^A-Za-z]|$)|(^|[^A-Za-z0-9_])(mapfile|readarray|coproc)([^A-Za-z0-9_]|$)|\$\{([A-Za-z_][A-Za-z_0-9]*|[0-9]+|[@*#?!$-])(\[[^]]*\])?(\^\^?|,,?)[^}]*\}|&>>|\|&|;;?&'
+# Full-line comments, the pattern itself and the gate_sample calls below are
+# not scanned.
+gate_matches() {
+  grep -nE "$bash4_constructs" "$@" | grep -vE '^([^:]*:)?[0-9]+:[[:blank:]]*#' |
+    grep -v -F -e 'bash4_constructs' -e 'gate_sample' || true
+}
+gate_sample() {
+  local expected=$1 sample=$2 hit
+  hit=$(printf '%s\n' "$sample" | gate_matches)
+  case "$expected:${hit:+hit}" in
+    hit:hit | miss:) ;;
+    *) fail "gate regex $expected sample misclassified: $sample" ;;
+  esac
+}
+gate_sample hit 'declare -A m=()'
+gate_sample hit 'local -n ref=x'
+gate_sample hit 'mapfile -t a'
+gate_sample hit 'echo ${var,,}'
+gate_sample hit 'cmd |& tee'
+gate_sample hit 'x) y ;;&'
+gate_sample miss 'local path=$1 rest crate sub name'
+gate_sample miss 'echo ${rest%%/*}'
+gate_sample miss 'echo ${path##* -> }'
+gate_sample miss 'x) y ;;'
+gate_sample miss '# mapfile is unavailable on Bash 3'
+gate_hits=$(gate_matches "$script" "${BASH_SOURCE[0]}")
+[[ -z "$gate_hits" ]] || fail "Bash 4+ constructs found (stock macOS bash is 3.2):"$'\n'"$gate_hits"
+
+find_bash3() {
+  local candidate resolved brew_prefix
+  brew_prefix=$(brew --prefix bash@3 2>/dev/null) || brew_prefix=""
+  for candidate in "${BASH3_BIN:-}" bash3 "${brew_prefix:+$brew_prefix/bin/bash}" \
+    /opt/homebrew/opt/bash@3/bin/bash /usr/local/opt/bash@3/bin/bash /bin/bash; do
+    [[ -n "$candidate" ]] || continue
+    resolved=$(command -v "$candidate" 2>/dev/null) || continue
+    [[ -x "$resolved" ]] || continue
+    "$resolved" -c '[[ "${BASH_VERSINFO[0]}" -eq 3 ]]' 2>/dev/null || continue
+    printf '%s\n' "$resolved"
+    return 0
+  done
+  return 1
+}
+
+if [[ "${BASH_VERSINFO[0]}" -eq 3 ]]; then
+  : # the fixtures above already ran under Bash 3
+elif bash3=$(find_bash3); then
+  RUST_CHANGED_TESTS_TEST_BASH="$bash3" "$bash3" "${BASH_SOURCE[0]}"
+else
+  echo "rust-changed-tests tests: no Bash 3 interpreter found (set BASH3_BIN); real 3.2 run skipped, static gate only"
+fi

--- a/scripts/rust-changed-tests.test.sh
+++ b/scripts/rust-changed-tests.test.sh
@@ -63,6 +63,7 @@ write crates/alpha/tests/one.rs
 write crates/alpha/tests/two.rs
 write crates/alpha/tests/common/mod.rs
 write crates/alpha/tests/fixtures/data.json
+write crates/alpha/tests/fixtures/café.json
 write crates/alpha/benches/bench.rs
 write crates/alpha/examples/demo.rs
 write crates/beta/Cargo.toml
@@ -191,6 +192,29 @@ run_script
 expect_ok
 expect_cargo "-p alpha --tests"
 
+# Git C-quotes such names in line-oriented output; the script must read raw
+# NUL-delimited paths (verifier repro on 91fb6b0).
+case_name="untracked fixture with a space in its name"
+reset_repo
+write "crates/alpha/tests/fixtures/new fixture.json"
+run_script
+expect_ok
+expect_cargo "-p alpha --tests"
+
+case_name="tracked fixture with a non-ASCII name"
+reset_repo
+edit crates/alpha/tests/fixtures/café.json
+run_script
+expect_ok
+expect_cargo "-p alpha --tests"
+
+case_name="renamed integration test selects the new name"
+reset_repo
+g mv crates/alpha/tests/one.rs crates/alpha/tests/moved.rs
+run_script
+expect_ok
+expect_cargo "-p alpha --test moved"
+
 case_name="deleted integration test falls back to --tests"
 reset_repo
 g rm -q crates/alpha/tests/two.rs
@@ -317,6 +341,13 @@ for path in Cargo.toml Cargo.lock rust-toolchain.toml .config/nextest.toml .carg
   [[ "$stderr" == *"need the full suite -- run 'make test':"*"  $path"* ]] || fail "$case_name stderr: $stderr"
   [[ -z "$cargo_log" ]] || fail "$case_name invoked cargo: $cargo_log"
 done
+case_name="untracked build-wide file with a non-ASCII name"
+reset_repo
+write .cargo/café.toml
+run_script
+[[ "$status" -eq 3 ]] || fail "$case_name exited $status (expected 3): $stderr"
+[[ "$stderr" == *"  .cargo/café.toml"* ]] || fail "$case_name stderr: $stderr"
+[[ -z "$cargo_log" ]] || fail "$case_name invoked cargo: $cargo_log"
 case_name="build-wide change in a dry run"
 reset_repo
 write .cargo/audit.toml

--- a/scripts/rust-changed-tests.test.sh
+++ b/scripts/rust-changed-tests.test.sh
@@ -279,14 +279,19 @@ expect_plan "-p beta"
 expect_cargo "-p beta"
 [[ "$stdout" != *"note:"* ]] || fail "$case_name printed the src note for a subsumed selection: $stdout"
 
-case_name="benches, examples and non-crate paths are ignored"
+case_name="benches, examples and inert non-crate paths are ignored"
 reset_repo
 edit crates/alpha/benches/bench.rs
 edit crates/alpha/examples/demo.rs
 edit README.md
 edit docs/guide.md
-edit scripts/tool.sh
-write .github/workflows/ci.yml
+write .github/workflows/x.yml
+write LICENSE
+write NOTICE
+write .gitignore
+write deny.toml
+write release-plz.toml
+write dist-workspace.toml
 run_script
 expect_ok
 [[ "$stdout" == *"nothing to test"* ]] || fail "$case_name printed '$stdout'"
@@ -367,6 +372,21 @@ for path in Cargo.toml Cargo.lock rust-toolchain.toml .config/nextest.toml .carg
   [[ "$status" -eq 3 ]] || fail "$case_name exited $status (expected 3): $stderr"
   [[ -z "$stdout" ]] || fail "$case_name printed '$stdout'"
   [[ "$stderr" == *"need the full suite -- run 'make test':"*"  $path"* ]] || fail "$case_name stderr: $stderr"
+  [[ -z "$cargo_log" ]] || fail "$case_name invoked cargo: $cargo_log"
+done
+# Tests read repo files outside crates/ through CARGO_MANIFEST_DIR
+# (scripts/install.sh, repo-wide lints), so any non-inert path out there also
+# defers to the full suite, even alongside a precisely mapped test change.
+for path in scripts/install.sh scripts/tool.sh packaging/deb/control unknown.toml; do
+  case_name="non-crate change $path"
+  reset_repo
+  write "$path" "// changed"
+  edit crates/alpha/tests/one.rs
+  run_script
+  [[ "$status" -eq 3 ]] || fail "$case_name exited $status (expected 3): $stderr"
+  [[ -z "$stdout" ]] || fail "$case_name printed '$stdout'"
+  [[ "$stderr" == *"need the full suite -- run 'make test':"*"  $path"* ]] || fail "$case_name stderr: $stderr"
+  [[ "$stderr" != *"crates/alpha/tests/one.rs"* ]] || fail "$case_name listed a mapped path: $stderr"
   [[ -z "$cargo_log" ]] || fail "$case_name invoked cargo: $cargo_log"
 done
 case_name="untracked build-wide file with a non-ASCII name"

--- a/scripts/rust-changed-tests.test.sh
+++ b/scripts/rust-changed-tests.test.sh
@@ -382,14 +382,17 @@ write .cargo/audit.toml
 DRY_RUN=1 run_script
 [[ "$status" -eq 3 ]] || fail "$case_name exited $status (expected 3): $stderr"
 [[ "$stderr" == *"  .cargo/audit.toml"* ]] || fail "$case_name stderr: $stderr"
-case_name="renamed build-wide file still needs the full suite"
-reset_repo
-g mv Cargo.lock Cargo.lock.backup
-run_script
-[[ "$status" -eq 3 ]] || fail "$case_name exited $status (expected 3): $stderr"
-[[ -z "$stdout" ]] || fail "$case_name printed '$stdout'"
-[[ "$stderr" == *"  Cargo.lock"* ]] || fail "$case_name stderr: $stderr"
-[[ -z "$cargo_log" ]] || fail "$case_name invoked cargo: $cargo_log"
+for rename in "Cargo.lock Cargo.lock.backup" "crates/beta/build.rs crates/beta/retired.rs"; do
+  case_name="renamed build-wide file ($rename) still needs the full suite"
+  reset_repo
+  # shellcheck disable=SC2086
+  g mv $rename
+  run_script
+  [[ "$status" -eq 3 ]] || fail "$case_name exited $status (expected 3): $stderr"
+  [[ -z "$stdout" ]] || fail "$case_name printed '$stdout'"
+  [[ "$stderr" == *"  ${rename%% *}"* ]] || fail "$case_name stderr: $stderr"
+  [[ -z "$cargo_log" ]] || fail "$case_name invoked cargo: $cargo_log"
+done
 
 # A failing git command is an error, never an empty change set.
 for subcommand in diff ls-files; do


### PR DESCRIPTION
## Summary

Adds a supported pre-merge-queue gate that runs only the nextest targets a branch actually touched, so a targeted local run replaces "skip make test because the host is loaded".

- **scripts/rust-changed-tests.sh** — diffs the packages/intentd checkout against origin/main (merge-base, plus uncommitted and untracked files, read NUL-delimited) and maps:
  - crates/C/tests/T.rs → -p C --test T
  - crates/C/tests/common/** or nested test dirs, deleted test files → -p C --tests
  - crates/C/src/** → -p C --lib --bins --tests (--lib omitted for bin-only crates; prints a note that downstream crates are not selected)
  - other files under crates/C/ (fixtures, migrations) → -p C
  - benches/examples and paths outside crates/ are ignored
  - Exit 3 on build-wide changes (Cargo.toml, Cargo.lock, crate Cargo.toml, build.rs, .config/, .cargo/, rust-toolchain.toml); exit 2 on an unresolvable BASE; exit 0 with "nothing to test" on an empty selection. DRY_RUN=1 prints the plan only.
- **make test-changed** — same nextest install check, TEST_THREADS / BUILD_JOBS caps and progress-bar env as make test; turns script exit 3 into the full make test.
- **scripts/rust-changed-tests.test.sh** — hermetic suite (throwaway git repo, stub cargo) covering every mapping rule, the fallback/exit codes, quoted paths (spaces, Unicode), renames, and DRY_RUN; wired into the shell-tests CI job.
- One bullet in the root AGENTS.md "Resuming local Rust gates" section.

Motivation: intent-hq/intentd#1825 was ejected from the merge queue after the pre-queue full make test was skipped for host load; the two failing binaries run in under a minute in isolation. A follow-up PR on intent-hq/intentd will mention the target in packages/intentd/AGENTS.md.

## Verification

- bash scripts/rust-changed-tests.test.sh, scripts/shipped-in.test.sh, scripts/docs-check.test.sh: pass
- make docs-check, make help: pass / target listed
- make test-changed DRY_RUN=1: "nothing to test" on a clean tree; exact plan -p intentd --test e2e_wss_repo_warm_cache with a probe test-file edit; fallback announced with a Cargo.lock probe; exit 2 with BASE=nonexistent-ref
- Real make test-changed with the probe edit: build 2m13s, 4/4 tests in exactly one binary (intentd::e2e_wss_repo_warm_cache), exit 0
- Not covered: reverse-dependency propagation (by design; make test remains the complete gate); Bash 3.2 verified by static inspection only (no Bash 3 on the host)
