### PR TITLE
ci: run the Bash 3 shell suites on macos-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,23 @@ jobs:
           bash scripts/rust-changed-tests.test.sh
           bash scripts/shipped-in.test.sh
 
+  # Stock macOS /bin/bash is 3.2, and two Bash-3-only regressions shipped
+  # (intent-hq/intent#4706, intent-hq/intent#4759) because the ubuntu leg above
+  # only has Bash 5 and the suites' real Bash 3 rerun is skipped there. Run the
+  # two Bash-3-aware suites on macos-latest with REQUIRE_BASH3 set so a missing
+  # Bash 3 fails instead of skipping. `bash` on PATH may be a Homebrew Bash 5
+  # there; the suites then rerun under /bin/bash 3.2 via find_bash3.
+  shell-tests-bash3:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: false
+      - run: |
+          /bin/bash --version
+          REQUIRE_BASH3=1 bash scripts/docs-check.test.sh
+          REQUIRE_BASH3=1 bash scripts/shipped-in.test.sh
+
   # Agent-facing documentation links and root hygiene are checked without
   # dependencies or initialized submodules, directly on GitHub hosting.
   repo-hygiene:

--- a/scripts/docs-check.test.sh
+++ b/scripts/docs-check.test.sh
@@ -143,7 +143,10 @@ echo "docs-check tests passed under $("$script_bash" -c 'echo "bash $BASH_VERSIO
 # Stock macOS /bin/bash is 3.2 (intent-hq/intent#4759). `bash -n` alone
 # accepts Bash 4+ builtins and expansions, so reject them by pattern too,
 # then rerun the fixtures under a real Bash 3 when one can be found (same
-# lookup as shipped-in.test.sh) and require a byte-identical transcript.
+# lookup as shipped-in.test.sh: BASH3_BIN, bash3, Homebrew bash@3, 3.x
+# /bin/bash) and require a byte-identical transcript. A missing Bash 3 is a
+# skip notice by default; set REQUIRE_BASH3 to a non-empty value (CI) to make
+# it a failure instead.
 bash -n "$script" || fail "docs-check.sh does not parse"
 bash -n "${BASH_SOURCE[0]}" || fail "docs-check.test.sh does not parse"
 bash4_constructs='(^|[^A-Za-z0-9_])(declare|local|typeset)([[:blank:]]+-[A-Za-z]+)*[[:blank:]]+-[A-Za-z]*[An][A-Za-z]*([^A-Za-z]|$)|(^|[^A-Za-z0-9_])(mapfile|readarray|coproc)([^A-Za-z0-9_]|$)|\$\{([A-Za-z_][A-Za-z_0-9]*|[0-9]+|[@*#?!$-])(\[[^]]*\])?(\^\^?|,,?)[^}]*\}|&>>|\|&|;;?&'
@@ -195,6 +198,8 @@ elif bash3=$(find_bash3); then
   cmp -s "$transcript" "$bash3_transcript" ||
     fail "docs-check.sh output differs between bash $BASH_VERSION and $bash3:"$'\n'"$(diff "$transcript" "$bash3_transcript" || true)"
   echo "docs-check.sh output is identical under bash $BASH_VERSION and $bash3"
+elif [[ -n "${REQUIRE_BASH3:-}" ]]; then
+  fail "no Bash 3 interpreter found and REQUIRE_BASH3 is set (point BASH3_BIN at one, or unset REQUIRE_BASH3 to skip the real 3.2 run)"
 else
   echo "docs-check tests: no Bash 3 interpreter found (set BASH3_BIN); real 3.2 run skipped, static gate only"
 fi

--- a/scripts/shipped-in.test.sh
+++ b/scripts/shipped-in.test.sh
@@ -341,7 +341,9 @@ echo "shipped-in tests passed under $("$script_bash" -c 'echo "bash $BASH_VERSIO
 # then rerun the fixtures under a real Bash 3 when one can be found:
 # BASH3_BIN, a bash3 on PATH, Homebrew bash@3, or a 3.x /bin/bash. The
 # pattern gate is a best-effort guard for hosts without a Bash 3; the real
-# Bash 3 fixture run is the authoritative check.
+# Bash 3 fixture run is the authoritative check. A missing Bash 3 is a skip
+# notice by default; set REQUIRE_BASH3 to a non-empty value (CI) to make it
+# a failure instead.
 bash -n "$script" || fail "shipped-in.sh does not parse"
 bash -n "${BASH_SOURCE[0]}" || fail "shipped-in.test.sh does not parse"
 bash4_constructs='(^|[^A-Za-z0-9_])(declare|local|typeset)([[:blank:]]+-[A-Za-z]+)*[[:blank:]]+-[A-Za-z]*[An][A-Za-z]*([^A-Za-z]|$)|(^|[^A-Za-z0-9_])(mapfile|readarray|coproc)([^A-Za-z0-9_]|$)|\$\{([A-Za-z_][A-Za-z_0-9]*|[0-9]+|[@*#?!$-])(\[[^]]*\])?(\^\^?|,,?)[^}]*\}|&>>|\|&|;;?&'
@@ -418,6 +420,8 @@ if [[ "${BASH_VERSINFO[0]}" -eq 3 ]]; then
   : # the fixtures above already ran under Bash 3
 elif bash3=$(find_bash3); then
   SHIPPED_IN_TEST_BASH="$bash3" "$bash3" "${BASH_SOURCE[0]}"
+elif [[ -n "${REQUIRE_BASH3:-}" ]]; then
+  fail "no Bash 3 interpreter found and REQUIRE_BASH3 is set (point BASH3_BIN at one, or unset REQUIRE_BASH3 to skip the real 3.2 run)"
 else
   echo "shipped-in tests: no Bash 3 interpreter found (set BASH3_BIN); real 3.2 run skipped, static gate only"
 fi


### PR DESCRIPTION
## Summary

The `shell-tests` job runs on `ubuntu-latest` (Bash 5 only), so the authoritative Bash 3 rerun built into `scripts/docs-check.test.sh` and `scripts/shipped-in.test.sh` always printed "real 3.2 run skipped, static gate only" in CI. Stock macOS `/bin/bash` is 3.2.57, and two Bash-3-only regressions shipped anyway: intent-hq/intent#4706 (release detector) and intent-hq/intent#4759 (docs gate). In intent-hq/intent#4910 the final commit never executed under Bash 3 before merge.

This PR makes a Bash 3.2 regression in those two scripts fail the PR check:

- `scripts/docs-check.test.sh`, `scripts/shipped-in.test.sh`: add a `REQUIRE_BASH3` switch. When set and `find_bash3` finds no Bash 3 interpreter, the suite fails and names `BASH3_BIN` instead of printing the skip notice. Default behavior (switch unset) is unchanged.
- `.github/workflows/ci.yml`: add a `shell-tests-bash3` job on `macos-latest` that prints `/bin/bash --version` and runs the two suites with `REQUIRE_BASH3=1`. `bash` on PATH there may be a Homebrew Bash 5; the suites then rerun under `/bin/bash` 3.2 via `find_bash3` (docs-check also compares transcripts). Either way a Bash 3 execution is guaranteed or the job fails.

The existing ubuntu `shell-tests` job is untouched; it still covers the other five suites and the Bash 5 path (and still prints the skip notice there, which is expected). The other five suites are not added to the macOS leg because they do not claim Bash 3 compatibility.

The repository is public, so `macos-latest` minutes are free; the job is expected to take about 1-2 minutes.

## Verification

- Local: `bash scripts/shipped-in.test.sh` and `bash scripts/docs-check.test.sh` exit 0 with the skip notice; `REQUIRE_BASH3=1 bash scripts/<suite>.test.sh` exits non-zero naming `BASH3_BIN` on a host without Bash 3.
- CI: the `shell-tests-bash3` job log on this PR shows the `/bin/bash --version` 3.2.57 line and the suites' Bash 3 pass lines, without "real 3.2 run skipped".

Motivation: intent-hq/intent#4706, intent-hq/intent#4759, intent-hq/intent#4910.
